### PR TITLE
[codex] Harden Bases upserts and note update cache refresh

### DIFF
--- a/plugins/obsidian-bases-bridge/src/main.ts
+++ b/plugins/obsidian-bases-bridge/src/main.ts
@@ -11,6 +11,7 @@ import {
 type EngineRow = Record<string, any>;
 type EngineSnap = { ts: number; rows: EngineRow[]; total: number };
 const ENGINE_CACHE = new Map<string, EngineSnap>();
+const ENGINE_CACHE_TTL_MS = 15_000;
 
 interface BridgeSettings {
   engineEnabled: boolean;
@@ -276,6 +277,33 @@ export default class BasesBridgePlugin extends Plugin {
     if (this.settings.engineEnabled) {
       this.maybeRegisterHeadlessView();
     }
+
+    const onVaultMutation = (path: string) => {
+      if (!path) return;
+      if (path.endsWith(".base")) {
+        this.invalidateEngineCache(path);
+        return;
+      }
+      if (path.endsWith(".md")) {
+        this.invalidateEngineCache();
+      }
+    };
+    this.registerEvent(
+      this.app.vault.on("modify", (file: any) => onVaultMutation(String(file?.path ?? "")))
+    );
+    this.registerEvent(
+      this.app.vault.on("create", (file: any) => onVaultMutation(String(file?.path ?? "")))
+    );
+    this.registerEvent(
+      this.app.vault.on("delete", (file: any) => onVaultMutation(String(file?.path ?? "")))
+    );
+    this.registerEvent(
+      this.app.vault.on("rename", (file: any, oldPath: string) => {
+        onVaultMutation(String(oldPath ?? ""));
+        onVaultMutation(String(file?.path ?? ""));
+      })
+    );
+
     this.registerRestExtension().catch((error) => {
       console.error("[bases-bridge] Unable to register REST extension:", error);
     });
@@ -378,9 +406,19 @@ export default class BasesBridgePlugin extends Plugin {
   private async ensureEngineForBase(baseId: string): Promise<void> {
     if (!this.settings.engineEnabled) return;
     const key = ensureBaseExt(baseId);
-    if (ENGINE_CACHE.has(key)) return;
+    const snap = ENGINE_CACHE.get(key);
+    if (snap && Date.now() - snap.ts <= ENGINE_CACHE_TTL_MS) return;
+    if (snap) ENGINE_CACHE.delete(key);
 
     this.maybeRegisterHeadlessView();
+  }
+
+  private invalidateEngineCache(baseId?: string): void {
+    if (baseId) {
+      ENGINE_CACHE.delete(ensureBaseExt(baseId));
+      return;
+    }
+    ENGINE_CACHE.clear();
   }
 
   private async readBaseConfig(baseId: string): Promise<{ id: string; file: TFile; yaml: string; json: Record<string, any> }> {
@@ -560,6 +598,26 @@ export default class BasesBridgePlugin extends Plugin {
     return this.evalFormulaExpression(file, expr, schema);
   }
 
+  private isTruthyValue(value: any): boolean {
+    return (
+      value === true ||
+      (typeof value === "string" && value.trim().length > 0) ||
+      (typeof value === "number" && Number.isFinite(value)) ||
+      (Array.isArray(value) && value.length > 0) ||
+      (!!value && typeof value === "object" && Object.keys(value).length > 0)
+    );
+  }
+
+  private getEngineRowPath(row: any): string | undefined {
+    const candidates = [row?.file?.path, row?.path, row?.filePath];
+    for (const candidate of candidates) {
+      if (typeof candidate === "string" && candidate.trim().length > 0) {
+        return candidate.replace(/\\/g, "/");
+      }
+    }
+    return undefined;
+  }
+
   /**
    * Évalue un sous-ensemble “safe” de formules Bases.
    * Objectif : améliorer le mode fallback quand l’engine est désactivé.
@@ -570,6 +628,7 @@ export default class BasesBridgePlugin extends Plugin {
 
     // Literals
     if (raw === "null") return null;
+    if (/^(true|false)$/i.test(raw)) return /^true$/i.test(raw);
     if (/^-?\d+(?:\.\d+)?$/.test(raw)) return Number(raw);
     if ((raw.startsWith("\"") && raw.endsWith("\"")) || (raw.startsWith("'") && raw.endsWith("'"))) {
       return stripQuotes(raw);
@@ -606,20 +665,18 @@ export default class BasesBridgePlugin extends Plugin {
     if (ifMatch) {
       const args = splitTopLevelCommas(String(ifMatch[1] ?? "")).map((x) => x.trim());
       if (args.length >= 3) {
-        const condRef = args[0]!;
-        const thenRef = args[1]!;
+        const condExpr = args[0]!;
+        const thenExpr = args[1]!;
         const elseExpr = args.slice(2).join(",").trim();
 
-        const condVal = this.getValueForRef(file, condRef, schema);
-        const condOk =
-          condVal === true ||
-          (typeof condVal === "string" && condVal.trim().length > 0) ||
-          (typeof condVal === "number" && Number.isFinite(condVal)) ||
-          (Array.isArray(condVal) && condVal.length > 0) ||
-          (condVal && typeof condVal === "object" && Object.keys(condVal).length > 0);
+        let condVal = this.evalFormulaExpression(file, condExpr, schema);
+        if (condVal === undefined) {
+          const condRes = this.evaluateStatement(file, condExpr, schema);
+          condVal = condRes.ok;
+        }
 
-        return condOk
-          ? this.getValueForRef(file, thenRef, schema)
+        return this.isTruthyValue(condVal)
+          ? this.evalFormulaExpression(file, thenExpr, schema)
           : this.evalFormulaExpression(file, elseExpr, schema);
       }
     }
@@ -809,6 +866,10 @@ export default class BasesBridgePlugin extends Plugin {
       const leftNum = typeof left === "number" ? left : Number(left);
       const rightNum = typeof right === "number" ? right : Number(right);
       const bothNumeric = Number.isFinite(leftNum) && Number.isFinite(rightNum);
+      const numericOp = op === ">" || op === "<" || op === ">=" || op === "<=";
+      if (numericOp && typeof right === "number" && !Number.isFinite(leftNum)) {
+        return { ok: false, warnings };
+      }
 
       switch (op) {
         case "==":
@@ -1172,11 +1233,47 @@ export default class BasesBridgePlugin extends Plugin {
           }
           const warnings = Array.from(warningsSet).sort((a, b) => a.localeCompare(b));
           if (warningsTruncated) warnings.push("Warnings tronqués (max 200).");
-          if (evaluate && snap) {
+
+          if (evaluate && shouldEngine && snap) {
+            const cachedRowsByPath = new Map<string, any>();
+            for (const rawRow of snap.rows ?? []) {
+              const rowPath = this.getEngineRowPath(rawRow);
+              if (!rowPath || cachedRowsByPath.has(rowPath)) continue;
+              cachedRowsByPath.set(rowPath, rawRow);
+            }
+
+            const alignedRows: BaseQueryRow[] = matches.map((file) => {
+              const cached = cachedRowsByPath.get(file.path);
+              if (cached && cached.file && cached.props) return cached as BaseQueryRow;
+              if (cached) {
+                const inferredPath = this.getEngineRowPath(cached) ?? file.path;
+                const inferredName =
+                  typeof cached?.file?.name === "string" && cached.file.name.trim().length > 0
+                    ? cached.file.name
+                    : file.basename;
+                return {
+                  file: { path: inferredPath, name: inferredName },
+                  props:
+                    cached?.props && typeof cached.props === "object"
+                      ? cached.props
+                      : this.buildRowProps(file, schema),
+                  computed:
+                    cached?.computed && typeof cached.computed === "object"
+                      ? cached.computed
+                      : this.buildComputed(file, schema),
+                };
+              }
+              return {
+                file: { path: file.path, name: file.basename },
+                props: this.buildRowProps(file, schema),
+                computed: this.buildComputed(file, schema),
+              };
+            });
+
             const startEngine = (page - 1) * limit;
-            const engineRows = snap.rows.slice(startEngine, startEngine + limit);
+            const engineRows = alignedRows.slice(startEngine, startEngine + limit);
             const response: BaseQueryResponse = {
-              total: snap.total,
+              total: alignedRows.length,
               page,
               rows: engineRows as any,
               evaluate,
@@ -1265,7 +1362,10 @@ export default class BasesBridgePlugin extends Plugin {
               results.push({
                 file: filePath,
                 mtime: abstract.stat.mtime,
-                error: { code: "write_error", message: String(e?.message ?? e) },
+                error: {
+                  code: "write_error",
+                  message: String(e?.message ?? e),
+                },
               });
               if (!continueOnError) break;
             }

--- a/src/mcp-server/tools/basesUpsertRowsTool/logic.ts
+++ b/src/mcp-server/tools/basesUpsertRowsTool/logic.ts
@@ -5,14 +5,28 @@
 import { z } from "zod";
 import { ObsidianRestApiService } from "../../../services/obsidianRestAPI/index.js";
 import {
-  BaseUpsertRequest,
+  BaseUpsertOperation,
   BaseUpsertResponse,
+  BaseUpsertResult,
 } from "../../../services/obsidianRestAPI/types.js";
 import {
   logger,
   RequestContext,
   requestContextService,
 } from "../../../utils/index.js";
+
+const UPSERT_CHUNK_SIZE = 25;
+
+function chunkOperations(
+  operations: BaseUpsertOperation[],
+  chunkSize: number,
+): BaseUpsertOperation[][] {
+  const chunks: BaseUpsertOperation[][] = [];
+  for (let i = 0; i < operations.length; i += chunkSize) {
+    chunks.push(operations.slice(i, i + chunkSize));
+  }
+  return chunks;
+}
 
 const OperationSchema = z
   .object({
@@ -65,16 +79,6 @@ export async function processBasesUpsertRows(
   parentContext: RequestContext,
   obsidianService: ObsidianRestApiService,
 ): Promise<BaseUpsertResponse> {
-  const payload: BaseUpsertRequest = {
-    operations: params.operations.map((operation) => ({
-      file: operation.file,
-      set: operation.set,
-      unset: operation.unset,
-      expected_mtime: operation.expected_mtime,
-    })),
-    continueOnError: params.continueOnError,
-  };
-
   const context = requestContextService.createRequestContext({
     parentContext,
     operation: "BasesUpsertRows",
@@ -85,6 +89,69 @@ export async function processBasesUpsertRows(
     },
   });
 
-  logger.debug("Upserting rows via REST bridge", context);
-  return obsidianService.upsertBaseRows(params.base_id, payload, context);
+  const operations: BaseUpsertOperation[] = params.operations.map((operation) => ({
+    file: operation.file,
+    set: operation.set,
+    unset: operation.unset,
+    expected_mtime: operation.expected_mtime,
+  }));
+  const operationChunks = chunkOperations(operations, UPSERT_CHUNK_SIZE);
+  const allResults: BaseUpsertResult[] = [];
+
+  logger.debug("Upserting rows via REST bridge (chunked)", {
+    ...context,
+    chunkSize: UPSERT_CHUNK_SIZE,
+    chunkCount: operationChunks.length,
+  });
+
+  for (let index = 0; index < operationChunks.length; index++) {
+    const chunk = operationChunks[index]!;
+    const chunkContext = requestContextService.createRequestContext({
+      parentContext: context,
+      operation: "BasesUpsertRowsChunk",
+      params: {
+        base_id: params.base_id,
+        chunkIndex: index + 1,
+        chunkCount: operationChunks.length,
+        operationsInChunk: chunk.length,
+      },
+    });
+
+    try {
+      const response = await obsidianService.upsertBaseRows(
+        params.base_id,
+        { operations: chunk, continueOnError: params.continueOnError },
+        chunkContext,
+      );
+
+      allResults.push(...response.results);
+      if (!params.continueOnError && !response.ok) {
+        break;
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error("bases_upsert_rows chunk failed after retries", {
+        ...chunkContext,
+        error: message,
+      });
+      allResults.push(
+        ...chunk.map((operation) => ({
+          file: operation.file,
+          mtime: 0,
+          error: {
+            code: "request_failed_outcome_unknown",
+            message: `Chunk request failed; individual write outcomes are unknown. ${message}`,
+          },
+        })),
+      );
+      if (!params.continueOnError) {
+        break;
+      }
+    }
+  }
+
+  return {
+    ok: allResults.every((result) => !result.error),
+    results: allResults,
+  };
 }

--- a/src/mcp-server/tools/obsidianUpdateNoteTool/logic.ts
+++ b/src/mcp-server/tools/obsidianUpdateNoteTool/logic.ts
@@ -263,14 +263,12 @@ export interface ObsidianUpdateNoteResponse {
 /**
  * Attempts to retrieve the final state (content and stats) of the target note after an update operation.
  * Uses the appropriate Obsidian API method based on the target type.
- * Logs a warning and returns null if fetching the final state fails, to avoid failing the entire update operation.
- *
  * @param {z.infer<typeof TargetTypeSchema>} targetType - The type of the target note.
  * @param {string | undefined} targetIdentifier - The identifier (path or period) if applicable.
  * @param {z.infer<typeof PeriodicNotePeriodSchema> | undefined} period - The parsed period if targetType is 'periodicNote'.
  * @param {ObsidianRestApiService} obsidianService - The Obsidian API service instance.
  * @param {RequestContext} context - The request context for logging and correlation.
- * @returns {Promise<NoteJson | null>} A promise resolving to the NoteJson object or null if retrieval fails.
+ * @returns {Promise<NoteJson | null>} A promise resolving to the NoteJson object or null if no target could be resolved.
  */
 async function getFinalState(
   targetType: z.infer<typeof TargetTypeSchema>,
@@ -284,40 +282,50 @@ async function getFinalState(
     `Attempting to retrieve final state for target: ${targetType} ${targetIdentifier ?? "(active)"}`,
     { ...context, operation },
   );
+  let noteJson: NoteJson | null = null;
+  // Call the appropriate API method based on target type
+  if (targetType === "filePath" && targetIdentifier) {
+    noteJson = (await obsidianService.getFileContent(
+      targetIdentifier,
+      "json",
+      context,
+    )) as NoteJson;
+  } else if (targetType === "activeFile") {
+    noteJson = (await obsidianService.getActiveFile(
+      "json",
+      context,
+    )) as NoteJson;
+  } else if (targetType === "periodicNote" && period) {
+    noteJson = (await obsidianService.getPeriodicNote(
+      period,
+      "json",
+      context,
+    )) as NoteJson;
+  }
+  logger.debug(`Successfully retrieved final state`, {
+    ...context,
+    operation,
+  });
+  return noteJson;
+}
+
+async function refreshFileCacheBestEffort(
+  vaultCacheService: VaultCacheService | null | undefined,
+  filePath: string | undefined,
+  context: RequestContext,
+): Promise<void> {
+  if (!vaultCacheService || !filePath) {
+    return;
+  }
+
   try {
-    let noteJson: NoteJson | null = null;
-    // Call the appropriate API method based on target type
-    if (targetType === "filePath" && targetIdentifier) {
-      noteJson = (await obsidianService.getFileContent(
-        targetIdentifier,
-        "json",
-        context,
-      )) as NoteJson;
-    } else if (targetType === "activeFile") {
-      noteJson = (await obsidianService.getActiveFile(
-        "json",
-        context,
-      )) as NoteJson;
-    } else if (targetType === "periodicNote" && period) {
-      noteJson = (await obsidianService.getPeriodicNote(
-        period,
-        "json",
-        context,
-      )) as NoteJson;
-    }
-    logger.debug(`Successfully retrieved final state`, {
-      ...context,
-      operation,
-    });
-    return noteJson;
+    await vaultCacheService.updateCacheForFile(filePath, context);
   } catch (error) {
-    // Log the error but don't let it fail the main update operation.
     const errorMsg = error instanceof Error ? error.message : String(error);
     logger.warning(
-      `Could not retrieve final state after update for target: ${targetType} ${targetIdentifier ?? "(active)"}. Error: ${errorMsg}`,
-      { ...context, operation, error: errorMsg },
+      `Background cache refresh failed for '${filePath}': ${errorMsg}`,
+      { ...context, operation: "backgroundCacheRefresh", filePath },
     );
-    return null; // Return null to indicate failure without throwing
   }
 }
 
@@ -353,6 +361,7 @@ export const processObsidianUpdateNote = async (
   const mode = params.wholeFileMode;
   let wasCreated = false; // Flag to track if the file was newly created by the operation
   let targetPeriod: z.infer<typeof PeriodicNotePeriodSchema> | undefined;
+  let writtenContentForStats = contentString;
 
   // Parse the period if the target is a periodic note
   if (params.targetType === "periodicNote" && targetId) {
@@ -562,6 +571,7 @@ export const processObsidianUpdateNote = async (
         mode === "prepend"
           ? contentString + existingContent
           : existingContent + contentString;
+      writtenContentForStats = newContent;
       logger.debug(
         `Combined content length for ${mode}: ${newContent.length}`,
         updateContext,
@@ -589,8 +599,8 @@ export const processObsidianUpdateNote = async (
         `Successfully wrote combined content for ${mode}`,
         writeContext,
       );
-      if (params.targetType === "filePath" && targetId && vaultCacheService) {
-        await vaultCacheService.updateCacheForFile(targetId, writeContext);
+      if (params.targetType === "filePath") {
+        await refreshFileCacheBestEffort(vaultCacheService, targetId, writeContext);
       }
     } else {
       // Handle 'overwrite' mode directly.
@@ -619,75 +629,154 @@ export const processObsidianUpdateNote = async (
         `Successfully performed overwrite on target: ${params.targetType} ${targetId ?? "(active)"}`,
         updateContext,
       );
-      if (params.targetType === "filePath" && targetId && vaultCacheService) {
-        await vaultCacheService.updateCacheForFile(targetId, updateContext);
+      if (params.targetType === "filePath") {
+        await refreshFileCacheBestEffort(vaultCacheService, targetId, updateContext);
       }
     }
 
-    // --- Step 4: Get Final State (Stat and Optional Content) ---
-    // Add a small delay before attempting to get the final state, to allow Obsidian API to stabilize after write.
-    const POST_UPDATE_DELAY_MS = 250;
-    logger.debug(
-      `Waiting ${POST_UPDATE_DELAY_MS}ms before retrieving final state...`,
-      { ...context, operation: "postUpdateDelay" },
-    );
-    await new Promise((resolve) => setTimeout(resolve, POST_UPDATE_DELAY_MS));
-
-    // Attempt to retrieve the file's state *after* the modification.
     let finalState: NoteJson | null = null; // Initialize to null
-    try {
-      finalState = await retryWithDelay(
-        async () =>
-          getFinalState(
-            params.targetType,
-            targetId,
-            targetPeriod,
-            obsidianService,
-            context,
-          ),
-        {
-          operationName: "getFinalStateAfterUpdate",
-          context: { ...context, operation: "getFinalStateAfterUpdateAttempt" }, // Use a distinct context for retry logs
-          maxRetries: 3, // Total attempts: 1 initial + 2 retries
-          delayMs: 250, // Shorter delay
-          shouldRetry: (error: unknown) => {
-            // Retry on common transient issues or if the file might not be immediately available
-            const should =
-              error instanceof McpError &&
-              (error.code === BaseErrorCode.NOT_FOUND || // File might not be indexed immediately
-                error.code === BaseErrorCode.SERVICE_UNAVAILABLE || // API temporarily busy
-                error.code === BaseErrorCode.TIMEOUT); // API call timed out
-            if (should) {
-              logger.debug(
-                `getFinalStateAfterUpdate: shouldRetry=true for error code ${(error as McpError).code}`,
+    let formattedStat: FormattedStat | undefined;
+    let finalStateWarning = false;
+    if (params.returnContent) {
+      // Only pay the post-write read-back cost when the caller explicitly asked for it.
+      const POST_UPDATE_DELAY_MS = 250;
+      logger.debug(
+        `Waiting ${POST_UPDATE_DELAY_MS}ms before retrieving final state...`,
+        { ...context, operation: "postUpdateDelay" },
+      );
+      await new Promise((resolve) => setTimeout(resolve, POST_UPDATE_DELAY_MS));
+
+      try {
+        finalState = await retryWithDelay(
+          async () =>
+            getFinalState(
+              params.targetType,
+              targetId,
+              targetPeriod,
+              obsidianService,
+              context,
+            ),
+          {
+            operationName: "getFinalStateAfterUpdate",
+            context: { ...context, operation: "getFinalStateAfterUpdateAttempt" },
+            maxRetries: 3,
+            delayMs: 250,
+            shouldRetry: (error: unknown) => {
+              const should =
+                error instanceof McpError &&
+                (error.code === BaseErrorCode.NOT_FOUND ||
+                  error.code === BaseErrorCode.SERVICE_UNAVAILABLE ||
+                  error.code === BaseErrorCode.TIMEOUT);
+              if (should) {
+                logger.debug(
+                  `getFinalStateAfterUpdate: shouldRetry=true for error code ${(error as McpError).code}`,
+                  context,
+                );
+              }
+              return should;
+            },
+            onRetry: (attempt, error) => {
+              const errorMsg =
+                error instanceof Error ? error.message : String(error);
+              logger.warning(
+                `getFinalState (attempt ${attempt}) failed. Error: ${errorMsg}. Retrying...`,
+                { ...context, operation: "getFinalStateRetry" },
+              );
+            },
+          },
+        );
+        if (finalState === null) {
+          finalStateWarning = true;
+        }
+      } catch (error) {
+        finalState = null;
+        finalStateWarning = true;
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        logger.error(
+          `Failed to retrieve final state for target '${params.targetType} ${targetId ?? ""}' even after retries. Error: ${errorMsg}`,
+          error instanceof Error ? error : undefined,
+          context,
+        );
+      }
+    } else if (params.targetType === "filePath" && targetId) {
+      try {
+        const stat = await retryWithDelay(
+          async () => {
+            const metadata = await obsidianService.getFileMetadata(targetId, context);
+            if (!metadata) {
+              throw new McpError(
+                BaseErrorCode.SERVICE_UNAVAILABLE,
+                `Could not retrieve final metadata for '${targetId}' after update.`,
                 context,
               );
             }
-            return should;
+            return metadata;
           },
-          onRetry: (attempt, error) => {
-            const errorMsg =
-              error instanceof Error ? error.message : String(error);
-            logger.warning(
-              `getFinalState (attempt ${attempt}) failed. Error: ${errorMsg}. Retrying...`,
-              { ...context, operation: "getFinalStateRetry" },
-            );
+          {
+            operationName: "getFileMetadataAfterUpdate",
+            context: { ...context, operation: "getFileMetadataAfterUpdateAttempt" },
+            maxRetries: 3,
+            delayMs: 250,
+            shouldRetry: (error: unknown) =>
+              error instanceof McpError &&
+              (error.code === BaseErrorCode.NOT_FOUND ||
+                error.code === BaseErrorCode.SERVICE_UNAVAILABLE ||
+                error.code === BaseErrorCode.TIMEOUT),
           },
-        },
-      );
-    } catch (error) {
-      // If retryWithDelay throws after all attempts, getFinalState effectively failed.
-      // The original getFinalState already logs a warning and returns null if it encounters an error internally
-      // and is designed not to let its failure stop the main operation.
-      // So, if retryWithDelay throws, it means even retries didn't help.
-      finalState = null; // Ensure finalState remains null
-      const errorMsg = error instanceof Error ? error.message : String(error);
-      logger.error(
-        `Failed to retrieve final state for target '${params.targetType} ${targetId ?? ""}' even after retries. Error: ${errorMsg}`,
-        error instanceof Error ? error : undefined,
-        context,
-      );
-      // Do not re-throw here, allow the main process to construct a response with a warning.
+        );
+
+        const formattedStatResult = await createFormattedStatWithTokenCount(
+          stat,
+          writtenContentForStats,
+          context,
+        );
+        formattedStat =
+          formattedStatResult === null ? undefined : formattedStatResult;
+      } catch (error) {
+        finalStateWarning = true;
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        logger.error(
+          `Failed to retrieve final metadata for target '${targetId}' after update. Error: ${errorMsg}`,
+          error instanceof Error ? error : undefined,
+          context,
+        );
+      }
+    } else {
+      try {
+        finalState = await retryWithDelay(
+          async () =>
+            getFinalState(
+              params.targetType,
+              targetId,
+              targetPeriod,
+              obsidianService,
+              context,
+            ),
+          {
+            operationName: "getFinalStateForStatsAfterUpdate",
+            context: { ...context, operation: "getFinalStateForStatsAfterUpdateAttempt" },
+            maxRetries: 3,
+            delayMs: 250,
+            shouldRetry: (error: unknown) =>
+              error instanceof McpError &&
+              (error.code === BaseErrorCode.NOT_FOUND ||
+                error.code === BaseErrorCode.SERVICE_UNAVAILABLE ||
+                error.code === BaseErrorCode.TIMEOUT),
+          },
+        );
+        if (finalState === null) {
+          finalStateWarning = true;
+        }
+      } catch (error) {
+        finalState = null;
+        finalStateWarning = true;
+        const errorMsg = error instanceof Error ? error.message : String(error);
+        logger.error(
+          `Failed to retrieve final state for stats on target '${params.targetType} ${targetId ?? ""}' after update. Error: ${errorMsg}`,
+          error instanceof Error ? error : undefined,
+          context,
+        );
+      }
     }
 
     // --- Step 5: Construct Success Message ---
@@ -711,7 +800,7 @@ export const processObsidianUpdateNote = async (
     logger.info(successMessage, context); // Log initial success message
 
     // Append a warning if the final state couldn't be retrieved
-    if (finalState === null) {
+    if (finalStateWarning) {
       const warningMsg =
         " (Warning: Could not retrieve final file stats/content after update.)";
       successMessage += warningMsg;
@@ -723,17 +812,24 @@ export const processObsidianUpdateNote = async (
 
     // --- Step 6: Build and Return Response ---
     // Format the file statistics (if available) using the shared utility.
-    const finalContentForStat = finalState?.content ?? ""; // Provide content for token counting
-    const formattedStatResult = finalState?.stat
-      ? await createFormattedStatWithTokenCount(
-          finalState.stat,
-          finalContentForStat,
-          context,
-        ) // Await the async utility
-      : undefined;
-    // Ensure stat is undefined if the utility returned null (e.g., token counting failed)
-    const formattedStat =
-      formattedStatResult === null ? undefined : formattedStatResult;
+    if (!formattedStat && finalState?.stat) {
+      const finalContentForStat = finalState?.content ?? "";
+      const formattedStatResult = await createFormattedStatWithTokenCount(
+        finalState.stat,
+        finalContentForStat,
+        context,
+      );
+      formattedStat =
+        formattedStatResult === null ? undefined : formattedStatResult;
+    }
+
+    if (params.targetType !== "filePath" && finalState?.path) {
+      await refreshFileCacheBestEffort(
+        vaultCacheService,
+        finalState.path,
+        { ...context, operation: "postWriteCacheRefresh" },
+      );
+    }
 
     // Construct the final response object.
     const response: ObsidianUpdateNoteResponse = {


### PR DESCRIPTION
## Summary
- harden Bases query/upsert behavior around engine cache invalidation and row alignment
- chunk `bases_upsert_rows` requests and preserve partial/unknown outcomes on transport failure
- keep `obsidian_update_note` responses fast while refreshing shared cache with awaited best-effort semantics

## Validation
- `npm run build`
- `npm run build` in `plugins/obsidian-bases-bridge`
- `git diff --check`
- read-only reviewer pass after fixes

## Notes
- `docs/assets/*.Zone.Identifier` files were intentionally left untracked and out of scope.