### PR TITLE
Add runtime fingerprint and smoke harness

### DIFF
--- a/OPERATIONS.fr.md
+++ b/OPERATIONS.fr.md
@@ -47,14 +47,17 @@ Ce qui reste en RAM :
 Le design final réduit la mémoire de quatre façons :
 
 1. le `stdio` est devenu léger
+
    - Codex parle à `stdio-proxy.js`
    - le backend lourd est réutilisé au lieu d’être relancé
 
 2. le contenu des notes est persisté
+
    - le serveur ne garde plus tout le vault chaud en mémoire
    - le contenu est lu depuis SQLite d’abord, puis depuis le disque ou REST seulement si nécessaire
 
 3. Tasks réutilise la même couche persistée
+
    - le parsing Tasks relit le contenu partagé des notes
    - le serveur évite un second chemin de scan brutal pour un autre MCP Tasks
 
@@ -79,10 +82,12 @@ Le serveur final peut exposer des capacités différentes selon les plugins Obsi
 ### Plugins Obsidian
 
 - Local REST API
+
   - utilisé pour la majorité des opérations live sur les notes
   - configuré via `OBSIDIAN_BASE_URL` et `OBSIDIAN_API_KEY`
 
 - Bases Bridge (REST)
+
   - requis pour le support `.base`
   - expose les endpoints Bases consommés par ce MCP
 
@@ -166,6 +171,7 @@ curl http://127.0.0.1:3010/healthz?integrity=1
 Ce que tu obtiens :
 
 - mode runtime
+- fingerprint runtime : version package, git sha, Node, chemins `dist`, hash de config non sensible
 - état du mode dégradé
 - stats de cache
 - stats sémantiques
@@ -184,6 +190,42 @@ Actions de maintenance supportées :
 - `refresh_semantic_cache`
 - `refresh_tasks_cache`
 - `refresh_all`
+
+### Vérification automatisée locale
+
+Le script de smoke local vérifie le runtime tel qu’il est réellement utilisé :
+
+```bash
+npm run smoke:runtime
+```
+
+Il contrôle :
+
+- `/healthz?integrity=1`
+- le fingerprint runtime
+- la fraîcheur du process par rapport aux fichiers `dist`
+- l’intégrité SQLite
+- la découverte des tools via MCP HTTP
+- la découverte des tools via `stdio-proxy`
+
+Pour vérifier le code avant PR ou merge :
+
+```bash
+npm run verify:code
+```
+
+Ce script enchaîne :
+
+- `npm audit`
+- `npm run build`
+
+Ensuite, redémarre le backend si le build vient de modifier `dist`, puis lance :
+
+```bash
+npm run smoke:runtime
+```
+
+Le smoke échoue volontairement si le process backend est plus vieux que les fichiers `dist`.
 
 ## Setup Codex minimal
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -47,14 +47,17 @@ What stays in RAM:
 The final design reduces memory usage in four ways:
 
 1. `stdio` is now cheap
+
    - Codex talks to `stdio-proxy.js`
    - the heavy backend is reused instead of respawned
 
 2. note content is persisted
+
    - the server does not keep the whole vault hot in memory
    - note content is loaded from SQLite first, then from disk or REST only when needed
 
 3. Tasks reuse the same persisted content
+
    - task parsing reads from shared cached note content
    - the server avoids a second brute-force scan path for a separate Tasks MCP
 
@@ -79,10 +82,12 @@ The final server can expose different capabilities depending on which Obsidian p
 ### Obsidian plugins
 
 - Local REST API
+
   - used for most live Obsidian note operations
   - configured through `OBSIDIAN_BASE_URL` and `OBSIDIAN_API_KEY`
 
 - Bases Bridge (REST)
+
   - required for `.base` support
   - exposes the Bases endpoints used by this MCP
 
@@ -166,6 +171,7 @@ curl http://127.0.0.1:3010/healthz?integrity=1
 What you get:
 
 - runtime mode
+- runtime fingerprint: package version, git sha, Node.js version, `dist` paths, non-sensitive config hash
 - degraded mode state
 - cache stats
 - semantic stats
@@ -184,6 +190,42 @@ Supported maintenance actions:
 - `refresh_semantic_cache`
 - `refresh_tasks_cache`
 - `refresh_all`
+
+### Automated local verification
+
+The local smoke script checks the runtime exactly as Codex uses it:
+
+```bash
+npm run smoke:runtime
+```
+
+It verifies:
+
+- `/healthz?integrity=1`
+- runtime fingerprint
+- process freshness compared with the current `dist` files
+- SQLite integrity
+- tool discovery through MCP HTTP
+- tool discovery through `stdio-proxy`
+
+To verify code before a PR or merge:
+
+```bash
+npm run verify:code
+```
+
+This runs:
+
+- `npm audit`
+- `npm run build`
+
+Then restart the backend if the build changed `dist`, and run:
+
+```bash
+npm run smoke:runtime
+```
+
+The smoke intentionally fails when the backend process is older than the current `dist` files.
 
 ## Minimal Codex Setup
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "start": "node dist/index.js",
     "start:http": "MCP_LOG_LEVEL=debug MCP_TRANSPORT_TYPE=http node dist/index.js",
     "start:daemon": "MCP_LOG_LEVEL=debug MCP_TRANSPORT_TYPE=http node dist/index.js",
+    "smoke:runtime": "node scripts/smoke-runtime.mjs",
+    "verify:code": "npm audit && npm run build",
     "rebuild": "npx ts-node --esm scripts/clean.ts && npm run build",
     "fetch:spec": "npx ts-node --esm scripts/fetch-openapi-spec.ts",
     "docs:generate": "typedoc --tsconfig ./tsconfig.typedoc.json",

--- a/scripts/smoke-runtime.mjs
+++ b/scripts/smoke-runtime.mjs
@@ -1,0 +1,169 @@
+#!/usr/bin/env node
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+
+const httpUrl = process.env.MCP_SMOKE_HTTP_URL ?? "http://127.0.0.1:3010/mcp";
+const healthUrl =
+  process.env.MCP_SMOKE_HEALTH_URL ?? httpUrl.replace(/\/mcp\/?$/u, "/healthz");
+const minTools = Number(process.env.MCP_SMOKE_MIN_TOOLS ?? "20");
+const timeoutMs = Number(process.env.MCP_SMOKE_TIMEOUT_MS ?? "8000");
+const includeStdioProxy =
+  (process.env.MCP_SMOKE_STDIO_PROXY ?? "true").toLowerCase() === "true";
+
+function withTimeout(promise, label) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  return {
+    signal: controller.signal,
+    run: promise(controller.signal).finally(() => clearTimeout(timer)),
+    label,
+  };
+}
+
+async function checkHealth() {
+  const start = Date.now();
+  const timed = withTimeout(
+    (signal) =>
+      fetch(`${healthUrl}${healthUrl.includes("?") ? "&" : "?"}integrity=1`, {
+        headers: { Accept: "application/json" },
+        signal,
+      }),
+    "healthz",
+  );
+  const response = await timed.run;
+  if (!response.ok) {
+    throw new Error(`healthz returned HTTP ${response.status}`);
+  }
+  const body = await response.json();
+  if (!body.ok) {
+    throw new Error(`healthz returned ok=false: ${JSON.stringify(body)}`);
+  }
+  if (body.runtime?.dist?.isNewerThanProcess) {
+    throw new Error(
+      `backend process is older than dist files; restart required. Runtime: ${JSON.stringify(
+        body.runtime,
+      )}`,
+    );
+  }
+  return {
+    ok: true,
+    ms: Date.now() - start,
+    pid: body.pid,
+    transport: body.transport,
+    runtime: body.runtime
+      ? {
+          packageVersion: body.runtime.packageVersion,
+          git: body.runtime.git,
+          configHash: body.runtime.configHash,
+          nodeVersion: body.runtime.nodeVersion,
+        }
+      : undefined,
+    sharedCache: body.sharedCache
+      ? {
+          ready: body.sharedCache.ready,
+          dbFileCount: body.sharedCache.dbFileCount,
+          dbTaskCacheFileCount: body.sharedCache.dbTaskCacheFileCount,
+          dbSemanticVectorCount: body.sharedCache.dbSemanticVectorCount,
+          integrity: body.sharedCache.integrity,
+        }
+      : undefined,
+  };
+}
+
+async function listToolsViaHttp() {
+  const start = Date.now();
+  const transport = new StreamableHTTPClientTransport(new URL(httpUrl));
+  const client = new Client({
+    name: "optimike-runtime-smoke-http",
+    version: "0",
+  });
+  try {
+    await client.connect(transport);
+    const result = await client.listTools();
+    if (result.tools.length < minTools) {
+      throw new Error(
+        `HTTP MCP exposed ${result.tools.length} tools, expected at least ${minTools}`,
+      );
+    }
+    return {
+      ok: true,
+      ms: Date.now() - start,
+      toolCount: result.tools.length,
+      sample: result.tools.slice(0, 8).map((tool) => tool.name),
+    };
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}
+
+async function listToolsViaStdioProxy() {
+  const start = Date.now();
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["dist/stdio-proxy.js"],
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      MCP_HTTP_HOST: new URL(httpUrl).hostname,
+      MCP_HTTP_PORT: new URL(httpUrl).port || "80",
+      MCP_PROXY_START_TIMEOUT_MS: String(timeoutMs),
+    },
+  });
+  const client = new Client({
+    name: "optimike-runtime-smoke-stdio-proxy",
+    version: "0",
+  });
+  try {
+    await client.connect(transport);
+    const result = await client.listTools();
+    if (result.tools.length < minTools) {
+      throw new Error(
+        `stdio proxy exposed ${result.tools.length} tools, expected at least ${minTools}`,
+      );
+    }
+    return {
+      ok: true,
+      ms: Date.now() - start,
+      toolCount: result.tools.length,
+      sample: result.tools.slice(0, 8).map((tool) => tool.name),
+    };
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}
+
+async function main() {
+  const result = {
+    ok: true,
+    target: {
+      httpUrl,
+      healthUrl,
+      minTools,
+      includeStdioProxy,
+    },
+    checks: {
+      health: await checkHealth(),
+      httpMcp: await listToolsViaHttp(),
+      stdioProxy: includeStdioProxy
+        ? await listToolsViaStdioProxy()
+        : "skipped",
+    },
+  };
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch((error) => {
+  console.error(
+    JSON.stringify(
+      {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+      },
+      null,
+      2,
+    ),
+  );
+  process.exit(1);
+});

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -121,9 +121,7 @@ const EnvSchema = z.object({
     .transform((val) => val.toLowerCase() === "true")
     .default("true"),
   // --- Smart Connections Semantic Search ---
-  SMART_SEARCH_MODE: z
-    .enum(["plugin", "smartenv", "files"])
-    .default("plugin"),
+  SMART_SEARCH_MODE: z.enum(["plugin", "smartenv", "files"]).default("plugin"),
   SMART_ENV_DIR: z.string().optional(),
   ENABLE_QUERY_EMBEDDING: z
     .string()
@@ -140,11 +138,7 @@ const EnvSchema = z.object({
   OPENAI_API_KEY: z.string().optional(),
   OPENAI_BASE_URL: z.string().optional(),
   OPENAI_EMBEDDING_DIMENSIONS: z.string().optional(),
-  SMART_ENV_CACHE_TTL_MS: z.coerce
-    .number()
-    .int()
-    .nonnegative()
-    .default(60000),
+  SMART_ENV_CACHE_TTL_MS: z.coerce.number().int().nonnegative().default(60000),
   OBSIDIAN_VAULT: z.string().optional(),
 });
 
@@ -234,6 +228,7 @@ if (!validatedLogsPath) {
  */
 export const config = {
   pkg,
+  projectRoot,
   mcpServerName: env.MCP_SERVER_NAME || pkg.name,
   mcpServerVersion: env.MCP_SERVER_VERSION || pkg.version,
   logLevel: env.MCP_LOG_LEVEL,

--- a/src/services/runtimeState.ts
+++ b/src/services/runtimeState.ts
@@ -1,4 +1,7 @@
+import { createHash } from "node:crypto";
 import { existsSync, statSync } from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
 import { DatabaseSync } from "node:sqlite";
 import { config } from "../config/index.js";
 import { warmSharedTaskCache } from "../mcp-server/tools/tasksShared/logic.js";
@@ -6,6 +9,8 @@ import { BaseErrorCode, McpError } from "../types-global/errors.js";
 import { RequestContext, requestContextService } from "../utils/index.js";
 import { getSemanticCacheService } from "./semanticCache.js";
 import type { VaultCacheService } from "./obsidianRestAPI/vaultCache/index.js";
+
+const PROCESS_STARTED_AT_MS = Math.round(Date.now() - process.uptime() * 1000);
 
 export type RuntimeMaintenanceAction =
   | "integrity_check"
@@ -59,13 +64,129 @@ function readDbCounts() {
   }
 }
 
+type FileFingerprint = {
+  path: string;
+  exists: boolean;
+  sizeBytes?: number;
+  mtimeMs?: number;
+};
+
+function safeFileFingerprint(filePath: string): FileFingerprint {
+  try {
+    const stats = statSync(filePath);
+    return {
+      path: filePath,
+      exists: true,
+      sizeBytes: stats.size,
+      mtimeMs: Math.round(stats.mtimeMs),
+    };
+  } catch {
+    return {
+      path: filePath,
+      exists: false,
+    };
+  }
+}
+
+function readGitSha(): { sha?: string; shortSha?: string; error?: string } {
+  try {
+    const result = spawnSync("git", ["rev-parse", "HEAD"], {
+      cwd: config.projectRoot,
+      encoding: "utf-8",
+      windowsHide: true,
+    });
+    if (result.status !== 0) {
+      return {
+        error: (
+          result.stderr ||
+          result.stdout ||
+          "git rev-parse failed"
+        ).trim(),
+      };
+    }
+    const sha = result.stdout.trim();
+    return {
+      sha,
+      shortSha: sha.slice(0, 7),
+    };
+  } catch (error) {
+    return {
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function hashRuntimeConfig(): {
+  hash: string;
+  fields: Record<string, unknown>;
+} {
+  const fields = {
+    mcpTransportType: config.mcpTransportType,
+    mcpHttpHost: config.mcpHttpHost,
+    mcpHttpPort: config.mcpHttpPort,
+    obsidianBaseUrl: config.obsidianBaseUrl,
+    obsidianVaultPath: config.obsidianVaultPath,
+    obsidianSharedCacheDbPath: config.obsidianSharedCacheDbPath,
+    obsidianContentHotCacheLimit: config.obsidianContentHotCacheLimit,
+    obsidianStartupBlocking: config.obsidianStartupBlocking,
+    smartEnvDir: config.smartEnvDir,
+    enableQueryEmbedding: config.enableQueryEmbedding,
+    queryEmbedder: config.queryEmbedder,
+    queryEmbedderModel: config.queryEmbedderModel,
+    ollamaBaseUrl: config.ollamaBaseUrl,
+    openaiBaseUrl: config.openaiBaseUrl,
+    smartEnvCacheTtlMs: config.smartEnvCacheTtlMs,
+  };
+  return {
+    hash: createHash("sha256").update(JSON.stringify(fields)).digest("hex"),
+    fields,
+  };
+}
+
+function collectRuntimeFingerprint(): Record<string, unknown> {
+  const configHash = hashRuntimeConfig();
+  const distIndex = safeFileFingerprint(
+    path.join(config.projectRoot, "dist", "index.js"),
+  );
+  const distStdioProxy = safeFileFingerprint(
+    path.join(config.projectRoot, "dist", "stdio-proxy.js"),
+  );
+  const newestDistMtimeMs = Math.max(
+    distIndex.mtimeMs ?? 0,
+    distStdioProxy.mtimeMs ?? 0,
+  );
+  const distIsNewerThanProcess =
+    newestDistMtimeMs > 0 && newestDistMtimeMs > PROCESS_STARTED_AT_MS + 1000;
+
+  return {
+    packageName: config.pkg.name,
+    packageVersion: config.pkg.version,
+    git: readGitSha(),
+    nodeVersion: process.version,
+    platform: process.platform,
+    arch: process.arch,
+    pid: process.pid,
+    processStartedAtMs: PROCESS_STARTED_AT_MS,
+    processUptimeSec: Math.round(process.uptime()),
+    cwd: process.cwd(),
+    projectRoot: config.projectRoot,
+    entrypoint: process.argv[1],
+    dist: {
+      index: distIndex,
+      stdioProxy: distStdioProxy,
+      newestMtimeMs: newestDistMtimeMs || undefined,
+      isNewerThanProcess: distIsNewerThanProcess,
+    },
+    configHash: configHash.hash,
+    configFields: configHash.fields,
+  };
+}
+
 export async function collectRuntimeStatus(
   vaultCacheService: VaultCacheService | undefined,
   options: RuntimeStatusOptions = {},
 ): Promise<Record<string, unknown>> {
-  const semanticCache = config.smartEnvDir
-    ? getSemanticCacheService()
-    : null;
+  const semanticCache = config.smartEnvDir ? getSemanticCacheService() : null;
   const sharedDb = readDbCounts();
   const integrity =
     options.includeIntegrity && vaultCacheService
@@ -76,6 +197,7 @@ export async function collectRuntimeStatus(
     ok: integrity ? integrity.ok : true,
     pid: process.pid,
     transport: config.mcpTransportType,
+    runtime: collectRuntimeFingerprint(),
     sharedCache: {
       ...(vaultCacheService?.getStats() ?? {
         dbPath: config.obsidianSharedCacheDbPath,
@@ -122,9 +244,7 @@ export async function runRuntimeMaintenance(
     );
   }
 
-  const semanticCache = config.smartEnvDir
-    ? getSemanticCacheService()
-    : null;
+  const semanticCache = config.smartEnvDir ? getSemanticCacheService() : null;
 
   switch (action) {
     case "integrity_check":


### PR DESCRIPTION
## Ce que change cette PR

- Ajoute un fingerprint runtime exposé par `/healthz` et `obsidian_runtime_status` : package/version, git sha, Node, cwd, project root, chemins `dist`, fraîcheur du process et hash de config non sensible.
- Ajoute `scripts/smoke-runtime.mjs` et `npm run smoke:runtime` pour vérifier le runtime réel : health, intégrité SQLite, discovery MCP HTTP et discovery via `stdio-proxy`.
- Ajoute `npm run verify:code` pour enchaîner audit npm et build.
- Documente ces jalons dans les guides d'exploitation.

## Pourquoi

Après le durcissement sécurité, le principal risque restant était la parité implicite : ne pas savoir si le backend en mémoire correspond vraiment au repo et au `dist` courant. Le fingerprint et le smoke strict rendent cette parité vérifiable.

## Validation

- `npm run verify:code` -> OK
- backend local redémarré sur `127.0.0.1:3010`
- `npm run smoke:runtime` -> OK
- smoke HTTP MCP -> 21 tools
- smoke `stdio-proxy` -> 21 tools