### PR TITLE
perf: prewarm semantic search

### DIFF
--- a/OPERATIONS.fr.md
+++ b/OPERATIONS.fr.md
@@ -140,6 +140,8 @@ Persisté :
 - manifest sémantique
 - métadonnées vecteurs
 - dimension dominante et état de cache associé
+- snapshot sémantique en mémoire pendant `SMART_ENV_CACHE_TTL_MS`
+- normes de vecteurs pour accélérer les classements répétés
 
 Toujours vivant au moment de la requête :
 
@@ -149,6 +151,8 @@ Exemples :
 
 - si ton vault sémantique repose sur Ollama, Ollama doit toujours être joignable pour exécuter une requête sémantique
 - si Ollama tombe, le MCP renvoie maintenant une erreur propre au lieu de sembler freezer
+
+Au démarrage, le backend préchauffe la recherche sémantique en chargeant le snapshot et en envoyant une petite requête d’embedding au provider configuré. Désactivation possible avec `SEMANTIC_SEARCH_PREWARM=false` ; texte de warmup surchargeable avec `SEMANTIC_SEARCH_PREWARM_TEXT`.
 
 ## Mode dégradé
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -140,6 +140,8 @@ Persisted:
 - semantic manifest
 - semantic vector metadata
 - dominant dimension and related semantic cache state
+- in-process semantic snapshot during `SMART_ENV_CACHE_TTL_MS`
+- vector norms for faster repeated ranking
 
 Still live at query time:
 
@@ -149,6 +151,8 @@ Examples:
 
 - if your vault semantic setup relies on Ollama, Ollama still needs to be reachable for semantic queries
 - if Ollama is down, the MCP now returns a clean error instead of silently hanging
+
+At startup, the backend prewarms semantic search by loading the semantic snapshot and sending a small embedding request to the configured provider. Disable it with `SEMANTIC_SEARCH_PREWARM=false`; override the warmup text with `SEMANTIC_SEARCH_PREWARM_TEXT`.
 
 ## Degraded Mode
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -298,10 +298,13 @@ Le serveur :
 - choisit la dimension dominante
 - encode la requête avec le même modèle que le vault
 - persiste un manifest sémantique dans SQLite pour accélérer les refreshs à chaud
+- préchauffe la recherche sémantique au démarrage en chargeant le snapshot et en réveillant l’embedder de requête
+- renvoie `timings_ms`, `vector_count` et `filtered_count` pour diagnostiquer le coût réel
 
 Important :
 - l’exécution d’une requête sémantique exige toujours un provider de requête joignable
 - si le vault repose sur Ollama et qu’Ollama est down, l’erreur remonte clairement au lieu de bloquer silencieusement
+- `SEMANTIC_SEARCH_PREWARM=false` désactive le préchauffage au démarrage
 
 Autrement dit :
 

--- a/README.md
+++ b/README.md
@@ -331,10 +331,13 @@ The server:
 - selects the dominant dimension
 - embeds the query with the same model as the vault
 - persists a semantic manifest in SQLite for faster warm refreshes
+- prewarms semantic search on startup by loading the snapshot and warming the query embedder
+- returns `timings_ms`, `vector_count`, and `filtered_count` for operational diagnosis
 
 Important:
 - semantic query execution still requires a reachable query embedder provider
 - if the vault was built with Ollama embeddings, an unreachable Ollama instance will produce a clear error instead of a silent hang
+- set `SEMANTIC_SEARCH_PREWARM=false` to disable startup prewarm
 
 That means:
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -139,6 +139,13 @@ const EnvSchema = z.object({
   OPENAI_BASE_URL: z.string().optional(),
   OPENAI_EMBEDDING_DIMENSIONS: z.string().optional(),
   SMART_ENV_CACHE_TTL_MS: z.coerce.number().int().nonnegative().default(60000),
+  SEMANTIC_SEARCH_PREWARM: z
+    .string()
+    .transform((val) => val.toLowerCase() === "true")
+    .default("true"),
+  SEMANTIC_SEARCH_PREWARM_TEXT: z
+    .string()
+    .default("optimike semantic search warmup"),
   OBSIDIAN_VAULT: z.string().optional(),
 });
 
@@ -276,6 +283,8 @@ export const config = {
   openaiBaseUrl: env.OPENAI_BASE_URL,
   openaiEmbeddingDimensions: env.OPENAI_EMBEDDING_DIMENSIONS,
   smartEnvCacheTtlMs: env.SMART_ENV_CACHE_TTL_MS,
+  semanticSearchPrewarm: env.SEMANTIC_SEARCH_PREWARM,
+  semanticSearchPrewarmText: env.SEMANTIC_SEARCH_PREWARM_TEXT,
   obsidianVaultPath: env.OBSIDIAN_VAULT,
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ import { logger, McpLogLevel } from "./utils/internal/logger.js"; // Import logg
 // Import Services
 import { ObsidianRestApiService } from "./services/obsidianRestAPI/index.js";
 import { VaultCacheService } from "./services/obsidianRestAPI/vaultCache/index.js"; // Import VaultCacheService
+import { prewarmSemanticSearch } from "./mcp-server/tools/semanticSearchTool/registration.js";
 
 /**
  * The main MCP server instance (only stored globally for stdio shutdown).
@@ -351,6 +352,36 @@ const start = async () => {
         });
     }
     // --- End Cache Build Trigger ---
+
+    if (config.semanticSearchPrewarm) {
+      logger.info(
+        "Triggering background semantic search prewarm...",
+        startupContext,
+      );
+      prewarmSemanticSearch()
+        .then((result) => {
+          logger.info("Semantic search prewarm completed.", {
+            ...startupContext,
+            semanticPrewarm: result,
+          });
+        })
+        .catch((prewarmError) => {
+          logger.warning("Background semantic search prewarm failed.", {
+            ...startupContext,
+            error:
+              prewarmError instanceof Error
+                ? prewarmError.message
+                : String(prewarmError),
+            stack:
+              prewarmError instanceof Error ? prewarmError.stack : undefined,
+          });
+        });
+    } else {
+      logger.info(
+        "Semantic search prewarm is disabled by configuration.",
+        startupContext,
+      );
+    }
 
     // --- Signal and Error Handling Setup ---
 

--- a/src/mcp-server/tools/semanticSearchTool/registration.ts
+++ b/src/mcp-server/tools/semanticSearchTool/registration.ts
@@ -11,7 +11,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { promises as fs } from "fs";
 import path from "path";
-import { cosine, type SmartVec } from "../../../services/smartEnv.js";
+import { type SmartVec } from "../../../services/smartEnv.js";
 import { getSemanticCacheService } from "../../../services/semanticCache.js";
 import { getQueryEmbedder } from "../../../adapters/embed/index.js";
 import { resolveNoteAbsolutePath } from "./resolvePath.js";
@@ -33,6 +33,19 @@ const Out = z.object({
   query_model: z.string().optional(),
   query_dim: z.number().optional(),
   ollama_base_url: z.string().optional(),
+  vector_count: z.number().optional(),
+  filtered_count: z.number().optional(),
+  timings_ms: z
+    .object({
+      total: z.number(),
+      semantic_cache: z.number().optional(),
+      embedder_setup: z.number().optional(),
+      query_embedding: z.number().optional(),
+      filter: z.number().optional(),
+      ranking: z.number().optional(),
+      snippets: z.number().optional(),
+    })
+    .optional(),
   results: z.array(
     z.object({
       path: z.string(),
@@ -45,6 +58,8 @@ const Out = z.object({
 
 type InType = z.infer<typeof In>;
 type OutType = z.infer<typeof Out>;
+
+const vectorNormCache = new WeakMap<number[], number>();
 
 function getEnv() {
   const env = process.env;
@@ -65,6 +80,9 @@ function getEnv() {
   const CACHE_TTL = Number.isFinite(Number(env.SMART_ENV_CACHE_TTL_MS))
     ? Number(env.SMART_ENV_CACHE_TTL_MS)
     : 60000;
+  const SEMANTIC_SEARCH_PREWARM_TEXT =
+    env.SEMANTIC_SEARCH_PREWARM_TEXT?.trim() ||
+    "optimike semantic search warmup";
 
   return {
     SMART_ENV_DIR,
@@ -78,7 +96,65 @@ function getEnv() {
     OPENAI_EMBEDDING_DIMENSIONS,
     OBSIDIAN_VAULT,
     CACHE_TTL,
+    SEMANTIC_SEARCH_PREWARM_TEXT,
   };
+}
+
+function nowMs(): number {
+  return Date.now();
+}
+
+function elapsedSince(startMs: number): number {
+  return nowMs() - startMs;
+}
+
+function vectorNorm(vector: number[]): number {
+  const cached = vectorNormCache.get(vector);
+  if (cached !== undefined) return cached;
+
+  let sum = 0;
+  for (const value of vector) {
+    sum += value * value;
+  }
+
+  const norm = Math.sqrt(sum);
+  vectorNormCache.set(vector, norm);
+  return norm;
+}
+
+function cosineWithCachedNorm(
+  queryVector: number[],
+  queryNorm: number,
+  itemVector: number[],
+): number {
+  const itemNorm = vectorNorm(itemVector);
+  if (!queryNorm || !itemNorm) return 0;
+
+  let dot = 0;
+  for (let index = 0; index < queryVector.length; index += 1) {
+    dot += queryVector[index] * itemVector[index];
+  }
+
+  return dot / (queryNorm * itemNorm);
+}
+
+function insertRankedTopK<T>(
+  ranked: Array<{ item: T; score: number }>,
+  candidate: { item: T; score: number },
+  limit: number,
+): void {
+  const insertAt = ranked.findIndex((entry) => candidate.score > entry.score);
+  if (insertAt === -1) {
+    if (ranked.length < limit) {
+      ranked.push(candidate);
+    }
+    return;
+  }
+
+  ranked.splice(insertAt, 0, candidate);
+  if (ranked.length > limit) {
+    ranked.pop();
+  }
 }
 
 function pickDominantDimension(items: SmartVec[]): number {
@@ -199,6 +275,10 @@ function makeErrorResult(error: unknown) {
 }
 
 async function performSearch(input: InType): Promise<OutType> {
+  const startedAt = nowMs();
+  const timings: NonNullable<OutType["timings_ms"]> = {
+    total: 0,
+  };
   const {
     SMART_ENV_DIR,
     ENABLE_QUERY_EMBEDDING,
@@ -222,6 +302,7 @@ async function performSearch(input: InType): Promise<OutType> {
 
   const query = input.query.trim();
   if (!query) {
+    timings.total = elapsedSince(startedAt);
     return {
       model: undefined,
       dim: undefined,
@@ -229,12 +310,17 @@ async function performSearch(input: InType): Promise<OutType> {
       query_model: undefined,
       query_dim: undefined,
       ollama_base_url: undefined,
+      vector_count: 0,
+      filtered_count: 0,
+      timings_ms: timings,
       results: [],
     };
   }
 
   const semanticCache = getSemanticCacheService();
+  const semanticCacheStartedAt = nowMs();
   const snapshot = await semanticCache.getSnapshot();
+  timings.semantic_cache = elapsedSince(semanticCacheStartedAt);
   const items = snapshot.items;
   if (!items.length) {
     throw new Error(`No embeddings found in ${SMART_ENV_DIR}`);
@@ -256,6 +342,7 @@ async function performSearch(input: InType): Promise<OutType> {
     OLLAMA_BASE_URL?.trim() ||
     (await detectOllamaBaseUrlFromSmartEnv(SMART_ENV_DIR, model));
 
+  const embedderSetupStartedAt = nowMs();
   const selection = await getQueryEmbedder({
     provider: QUERY_EMBEDDER,
     modelHint: QUERY_EMBEDDER_MODEL_HINT,
@@ -267,8 +354,11 @@ async function performSearch(input: InType): Promise<OutType> {
     openaiBaseUrl: OPENAI_BASE_URL,
     openaiDimensions,
   });
+  timings.embedder_setup = elapsedSince(embedderSetupStartedAt);
 
+  const queryEmbeddingStartedAt = nowMs();
   const queryVector = await selection.embed(query);
+  timings.query_embedding = elapsedSince(queryEmbeddingStartedAt);
 
   if (queryVector.length !== dimension) {
     throw new Error(
@@ -276,6 +366,7 @@ async function performSearch(input: InType): Promise<OutType> {
     );
   }
 
+  const filterStartedAt = nowMs();
   const filtered = itemsWithDim.filter((item) => {
     const folderOk =
       !input.folders ||
@@ -285,17 +376,27 @@ async function performSearch(input: InType): Promise<OutType> {
       (item.tags ?? []).some((tag) => input.tags?.includes(tag));
     return folderOk && tagsOk;
   });
+  timings.filter = elapsedSince(filterStartedAt);
 
-  const ranked = filtered
-    .map((item) => ({
-      item,
-      score: cosine(queryVector, item.vec),
-    }))
-    .sort((a, b) => b.score - a.score)
-    .slice(0, input.top_k);
+  const rankingStartedAt = nowMs();
+  const queryNorm = vectorNorm(queryVector);
+  const ranked: Array<{ item: SmartVec; score: number }> = [];
+
+  for (const item of filtered) {
+    insertRankedTopK(
+      ranked,
+      {
+        item,
+        score: cosineWithCachedNorm(queryVector, queryNorm, item.vec),
+      },
+      input.top_k,
+    );
+  }
+  timings.ranking = elapsedSince(rankingStartedAt);
 
   const results: OutType["results"] = [];
 
+  const snippetsStartedAt = nowMs();
   for (const { item, score } of ranked) {
     let snippet: string | undefined;
 
@@ -316,6 +417,8 @@ async function performSearch(input: InType): Promise<OutType> {
       snippet,
     });
   }
+  timings.snippets = elapsedSince(snippetsStartedAt);
+  timings.total = elapsedSince(startedAt);
 
   return {
     model,
@@ -325,7 +428,115 @@ async function performSearch(input: InType): Promise<OutType> {
     query_dim: queryVector.length,
     ollama_base_url:
       selection.provider === "ollama" ? inferredOllamaBaseUrl : undefined,
+    vector_count: itemsWithDim.length,
+    filtered_count: filtered.length,
+    timings_ms: timings,
     results,
+  };
+}
+
+export type SemanticSearchPrewarmResult = {
+  ok: boolean;
+  skipped?: string;
+  model?: string;
+  dim?: number;
+  query_provider?: string;
+  query_model?: string;
+  query_dim?: number;
+  vector_count?: number;
+  ollama_base_url?: string;
+  timings_ms: NonNullable<OutType["timings_ms"]>;
+};
+
+export async function prewarmSemanticSearch(): Promise<SemanticSearchPrewarmResult> {
+  const startedAt = nowMs();
+  const timings: NonNullable<OutType["timings_ms"]> = {
+    total: 0,
+  };
+  const {
+    SMART_ENV_DIR,
+    ENABLE_QUERY_EMBEDDING,
+    QUERY_EMBEDDER,
+    QUERY_EMBEDDER_MODEL,
+    QUERY_EMBEDDER_MODEL_HINT,
+    OLLAMA_BASE_URL,
+    OPENAI_API_KEY,
+    OPENAI_BASE_URL,
+    OPENAI_EMBEDDING_DIMENSIONS,
+    SEMANTIC_SEARCH_PREWARM_TEXT,
+  } = getEnv();
+
+  const skipped = (reason: string): SemanticSearchPrewarmResult => {
+    timings.total = elapsedSince(startedAt);
+    return {
+      ok: true,
+      skipped: reason,
+      timings_ms: timings,
+    };
+  };
+
+  if (!SMART_ENV_DIR) {
+    return skipped("SMART_ENV_DIR is not set");
+  }
+
+  if (!ENABLE_QUERY_EMBEDDING) {
+    return skipped("ENABLE_QUERY_EMBEDDING=false");
+  }
+
+  const semanticCacheStartedAt = nowMs();
+  const snapshot = await getSemanticCacheService().getSnapshot();
+  timings.semantic_cache = elapsedSince(semanticCacheStartedAt);
+
+  if (!snapshot.items.length) {
+    return skipped(`No embeddings found in ${SMART_ENV_DIR}`);
+  }
+
+  const dimension = snapshot.dominantDim ?? pickDominantDimension(snapshot.items);
+  if (!dimension) {
+    return skipped("Embeddings are missing vector data");
+  }
+
+  const itemsWithDim = snapshot.items.filter(
+    (item) => item.vec?.length === dimension,
+  );
+  const model = snapshot.dominantModel ?? pickDominantModel(itemsWithDim);
+  const openaiDimensions = Number.isFinite(Number(OPENAI_EMBEDDING_DIMENSIONS))
+    ? Number(OPENAI_EMBEDDING_DIMENSIONS)
+    : undefined;
+  const inferredOllamaBaseUrl =
+    OLLAMA_BASE_URL?.trim() ||
+    (await detectOllamaBaseUrlFromSmartEnv(SMART_ENV_DIR, model));
+
+  const embedderSetupStartedAt = nowMs();
+  const selection = await getQueryEmbedder({
+    provider: QUERY_EMBEDDER,
+    modelHint: QUERY_EMBEDDER_MODEL_HINT,
+    model: QUERY_EMBEDDER_MODEL,
+    vaultModel: model,
+    dimension,
+    ollamaBaseUrl: inferredOllamaBaseUrl,
+    openaiApiKey: OPENAI_API_KEY,
+    openaiBaseUrl: OPENAI_BASE_URL,
+    openaiDimensions,
+  });
+  timings.embedder_setup = elapsedSince(embedderSetupStartedAt);
+
+  const queryEmbeddingStartedAt = nowMs();
+  const warmupVector = await selection.embed(SEMANTIC_SEARCH_PREWARM_TEXT);
+  timings.query_embedding = elapsedSince(queryEmbeddingStartedAt);
+  timings.total = elapsedSince(startedAt);
+
+  return {
+    ok: true,
+    model,
+    dim: dimension,
+    query_provider: selection.provider,
+    query_model: selection.model,
+    query_dim: warmupVector.length,
+    vector_count: itemsWithDim.length,
+    ollama_base_url:
+      selection.provider === "ollama" ? inferredOllamaBaseUrl : undefined,
+    timings_ms: timings,
   };
 }
 

--- a/src/services/runtimeState.ts
+++ b/src/services/runtimeState.ts
@@ -136,6 +136,8 @@ function hashRuntimeConfig(): {
     ollamaBaseUrl: config.ollamaBaseUrl,
     openaiBaseUrl: config.openaiBaseUrl,
     smartEnvCacheTtlMs: config.smartEnvCacheTtlMs,
+    semanticSearchPrewarm: config.semanticSearchPrewarm,
+    semanticSearchPrewarmText: config.semanticSearchPrewarmText,
   };
   return {
     hash: createHash("sha256").update(JSON.stringify(fields)).digest("hex"),

--- a/src/services/semanticCache.ts
+++ b/src/services/semanticCache.ts
@@ -165,16 +165,16 @@ export class SemanticCacheService {
         operation: "SemanticCacheService.getSnapshot",
       });
 
-    const sourceState = await scanSmartEnvSourceState(this.smartEnvDir);
     const now = Date.now();
 
     if (
       this.memorySnapshot &&
-      this.memorySnapshot.sourceSignature === sourceState.signature &&
       (this.ttlMs === 0 || now - this.memorySnapshotLoadedAt < this.ttlMs)
     ) {
       return this.memorySnapshot;
     }
+
+    const sourceState = await scanSmartEnvSourceState(this.smartEnvDir);
 
     const manifest = this.readManifest();
     if (


### PR DESCRIPTION
## Summary
- prewarm semantic search on backend startup so weak local GPUs/CPU do not pay the first-query cost interactively
- keep the semantic snapshot in memory during SMART_ENV_CACHE_TTL_MS before rescanning .smart-env
- add bounded top-k ranking, cached vector norms, and timings in smart_semantic_search responses
- document the runtime knobs and diagnosis fields

## Verification
- npm run verify:code
- npm run smoke:runtime
- MCP smart_semantic_search on 2697 vectors: ~140-180 ms warm, ranking ~4-23 ms