### PR TITLE
harden: public runtime guards

### DIFF
--- a/OPERATIONS.fr.md
+++ b/OPERATIONS.fr.md
@@ -69,7 +69,14 @@ Variables de tuning utiles :
 
 - `OBSIDIAN_CONTENT_HOT_CACHE_LIMIT`
 - `OBSIDIAN_SHARED_CACHE_DB_PATH`
+- `OBSIDIAN_CACHE_SOURCE=auto|filesystem|rest`
+- `OBSIDIAN_CACHE_CONCURRENCY`
+- `MCP_WRITE_MODE=readonly|guarded|full`
+- `MCP_GUARDED_MAX_WRITE_CHARS`
+- `MCP_GUARDED_MAX_BATCH_OPERATIONS`
 - `OBSIDIAN_STARTUP_BLOCKING=false` pour un démarrage non bloquant plus confortable sous WSL
+
+Pour une distribution publique ou ÉLYSIA OS, garder `MCP_WRITE_MODE=guarded` sauf choix explicite de l’hôte vers `readonly` ou `full`. Le mode guarded est appliqué dans le serveur ; l’agent n’a pas à choisir un mode à chaque écriture.
 
 ## Dépendances requises
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -69,7 +69,14 @@ Useful tuning:
 
 - `OBSIDIAN_CONTENT_HOT_CACHE_LIMIT`
 - `OBSIDIAN_SHARED_CACHE_DB_PATH`
+- `OBSIDIAN_CACHE_SOURCE=auto|filesystem|rest`
+- `OBSIDIAN_CACHE_CONCURRENCY`
+- `MCP_WRITE_MODE=readonly|guarded|full`
+- `MCP_GUARDED_MAX_WRITE_CHARS`
+- `MCP_GUARDED_MAX_BATCH_OPERATIONS`
 - `OBSIDIAN_STARTUP_BLOCKING=false` for faster non-blocking startup in WSL-heavy setups
+
+For public or ÉLYSIA OS distribution, keep `MCP_WRITE_MODE=guarded` unless the host explicitly opts into `readonly` or `full`. Guarded mode is enforced inside the server; agents do not need to choose a mode per write.
 
 ## Required Dependencies
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -152,6 +152,10 @@ Variables utiles :
 
 - `OBSIDIAN_SHARED_CACHE_DB_PATH`
 - `OBSIDIAN_CONTENT_HOT_CACHE_LIMIT`
+- `OBSIDIAN_CACHE_SOURCE=auto|filesystem|rest` pour choisir la source de refresh cache (`auto` privilégie le vault local quand il existe)
+- `OBSIDIAN_CACHE_CONCURRENCY` pour borner le travail filesystem local
+- `MCP_WRITE_MODE=readonly|guarded|full` pour imposer la sécurité d’écriture côté serveur (`guarded` est le défaut public)
+- `MCP_GUARDED_MAX_WRITE_CHARS` et `MCP_GUARDED_MAX_BATCH_OPERATIONS` pour régler les limites du mode guarded
 
 Le MCP principal absorbe aussi la surface `Tasks`, donc Codex n’a plus besoin d’un deuxième `optimike-obsidian-tasks-mcp`.
 Les refreshs sémantiques à chaud relisent SQLite d’abord, puis seulement `.smart-env` si nécessaire.
@@ -175,6 +179,19 @@ Et via MCP :
 
 - `obsidian_runtime_status`
 - `obsidian_runtime_maintenance`
+
+Sécurité runtime publique :
+
+- `readonly` bloque tous les outils d’écriture hors opérations de validation pure
+- `guarded` autorise les écritures explicites et bornées, mais bloque suppression, overwrite, unset frontmatter, regex replace-all large et gros batchs
+- `full` restaure le comportement d’écriture complet pour un environnement local de confiance
+
+Contrôle du contexte agent :
+
+- `obsidian_list_notes` supporte `responseMode="compact"`, `limit` et `cursor`
+- `obsidian_global_search` supporte `responseMode="compact"` en gardant la pagination `page/pageSize`
+- `list_all_tasks` et `query_tasks` supportent `responseMode="compact"|"detailed"`, `responseLimit` et `cursor`
+- la lecture d’une note identifiée reste complète via `obsidian_read_note`
 
 Checks typiques :
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,10 @@ Useful env overrides:
 
 - `OBSIDIAN_SHARED_CACHE_DB_PATH` to move the shared SQLite file
 - `OBSIDIAN_CONTENT_HOT_CACHE_LIMIT` to tune the bounded in-memory hot set
+- `OBSIDIAN_CACHE_SOURCE=auto|filesystem|rest` to choose cache refresh source (`auto` prefers the local vault path when available)
+- `OBSIDIAN_CACHE_CONCURRENCY` to bound local filesystem refresh work
+- `MCP_WRITE_MODE=readonly|guarded|full` to enforce server-side write safety (`guarded` is the public default)
+- `MCP_GUARDED_MAX_WRITE_CHARS` and `MCP_GUARDED_MAX_BATCH_OPERATIONS` to tune guarded-mode limits
 
 This runtime exposes the Tasks surface directly from the main MCP, so Codex no longer needs a second dedicated `optimike-obsidian-tasks-mcp` entry when using this server.
 Warm semantic refreshes now load from SQLite first instead of re-reading the whole `.smart-env` path every time.
@@ -177,6 +181,19 @@ Extended health / maintenance:
   - `refresh_semantic_cache`
   - `refresh_tasks_cache`
   - `refresh_all`
+
+Public runtime safety:
+
+- `readonly` blocks all write tools except validation-only operations
+- `guarded` allows bounded explicit writes and blocks destructive operations such as delete, overwrite, frontmatter unset, broad regex replace-all, and large batches
+- `full` restores unrestricted write behavior for trusted local environments
+
+Agent-context controls:
+
+- `obsidian_list_notes` supports `responseMode="compact"`, `limit`, and `cursor`
+- `obsidian_global_search` supports `responseMode="compact"` while keeping existing page/pageSize pagination
+- `list_all_tasks` and `query_tasks` support `responseMode="compact"|"detailed"`, `responseLimit`, and `cursor`
+- reading an identified note remains full-fidelity through `obsidian_read_note`
 
 Typical checks:
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -104,6 +104,10 @@ const EnvSchema = z.object({
     .int()
     .positive()
     .default(30000),
+  OBSIDIAN_CACHE_SOURCE: z
+    .enum(["auto", "rest", "filesystem"])
+    .default("auto"),
+  OBSIDIAN_CACHE_CONCURRENCY: z.coerce.number().int().positive().default(8),
   OBSIDIAN_SHARED_CACHE_DB_PATH: z.string().optional(),
   OBSIDIAN_CONTENT_HOT_CACHE_LIMIT: z.coerce
     .number()
@@ -120,6 +124,21 @@ const EnvSchema = z.object({
     .string()
     .transform((val) => val.toLowerCase() === "true")
     .default("true"),
+  // --- Public runtime safety ---
+  MCP_WRITE_MODE: z.enum(["readonly", "guarded", "full"]).default("guarded"),
+  MCP_GUARDED_MAX_WRITE_CHARS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(100000),
+  MCP_GUARDED_MAX_BATCH_OPERATIONS: z.coerce
+    .number()
+    .int()
+    .positive()
+    .default(25),
+  MCP_PROTECTED_FRONTMATTER_KEYS: z
+    .string()
+    .default("création,modification"),
   // --- Smart Connections Semantic Search ---
   SMART_SEARCH_MODE: z.enum(["plugin", "smartenv", "files"]).default("plugin"),
   SMART_ENV_DIR: z.string().optional(),
@@ -258,6 +277,8 @@ export const config = {
   obsidianCacheRefreshIntervalMin: env.OBSIDIAN_CACHE_REFRESH_INTERVAL_MIN,
   obsidianEnableCache: env.OBSIDIAN_ENABLE_CACHE,
   obsidianApiSearchTimeoutMs: env.OBSIDIAN_API_SEARCH_TIMEOUT_MS,
+  obsidianCacheSource: env.OBSIDIAN_CACHE_SOURCE,
+  obsidianCacheConcurrency: env.OBSIDIAN_CACHE_CONCURRENCY,
   obsidianSharedCacheDbPath:
     env.OBSIDIAN_SHARED_CACHE_DB_PATH ||
     path.join(
@@ -272,6 +293,12 @@ export const config = {
   obsidianStartupMaxRetries: env.OBSIDIAN_STARTUP_MAX_RETRIES,
   obsidianStartupRetryDelayMs: env.OBSIDIAN_STARTUP_RETRY_DELAY_MS,
   obsidianStartupBlocking: env.OBSIDIAN_STARTUP_BLOCKING,
+  mcpWriteMode: env.MCP_WRITE_MODE,
+  mcpGuardedMaxWriteChars: env.MCP_GUARDED_MAX_WRITE_CHARS,
+  mcpGuardedMaxBatchOperations: env.MCP_GUARDED_MAX_BATCH_OPERATIONS,
+  mcpProtectedFrontmatterKeys: env.MCP_PROTECTED_FRONTMATTER_KEYS.split(",")
+    .map((key) => key.trim())
+    .filter(Boolean),
   smartSearchMode: env.SMART_SEARCH_MODE,
   smartEnvDir: env.SMART_ENV_DIR,
   enableQueryEmbedding: env.ENABLE_QUERY_EMBEDDING,

--- a/src/mcp-server/tools/basesCreateTool/logic.ts
+++ b/src/mcp-server/tools/basesCreateTool/logic.ts
@@ -13,6 +13,7 @@ import {
   RequestContext,
   requestContextService,
 } from "../../../utils/index.js";
+import { assertWriteAllowed } from "../../../services/writePolicy.js";
 
 export const BasesCreateInputSchema = z
   .object({
@@ -45,6 +46,18 @@ export async function processBasesCreate(
   parentContext: RequestContext,
   obsidianService: ObsidianRestApiService,
 ): Promise<BaseCreateResponse> {
+  assertWriteAllowed({
+    operation: "bases_create",
+    action: params.validateOnly ? "validateOnly" : "create",
+    target: params.path,
+    allowInReadonly: params.validateOnly,
+    destructive: params.overwrite,
+    guardedReason: params.overwrite
+      ? "base overwrite requires MCP_WRITE_MODE=full"
+      : undefined,
+    context: parentContext,
+  });
+
   const payload: BaseCreateRequest = {
     path: params.path,
     spec: params.spec,

--- a/src/mcp-server/tools/basesUpsertConfigTool/logic.ts
+++ b/src/mcp-server/tools/basesUpsertConfigTool/logic.ts
@@ -14,6 +14,7 @@ import {
   requestContextService,
 } from "../../../utils/index.js";
 import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
+import { assertWriteAllowed } from "../../../services/writePolicy.js";
 
 const RawBasesUpsertConfigInputSchema = z
   .object({
@@ -49,6 +50,18 @@ export async function processBasesUpsertConfig(
   parentContext: RequestContext,
   obsidianService: ObsidianRestApiService,
 ): Promise<BaseConfigUpsertResponse> {
+  assertWriteAllowed({
+    operation: "bases_upsert_config",
+    action: params.validateOnly ? "validateOnly" : "upsert_config",
+    target: params.base_id,
+    allowInReadonly: params.validateOnly,
+    destructive: !params.validateOnly,
+    guardedReason: !params.validateOnly
+      ? "base config replacement requires MCP_WRITE_MODE=full"
+      : undefined,
+    context: parentContext,
+  });
+
   if (!params.yaml && !params.json) {
     throw new McpError(
       BaseErrorCode.VALIDATION_ERROR,

--- a/src/mcp-server/tools/basesUpsertRowsTool/logic.ts
+++ b/src/mcp-server/tools/basesUpsertRowsTool/logic.ts
@@ -14,6 +14,7 @@ import {
   RequestContext,
   requestContextService,
 } from "../../../utils/index.js";
+import { assertWriteAllowed } from "../../../services/writePolicy.js";
 
 const UPSERT_CHUNK_SIZE = 25;
 
@@ -79,6 +80,26 @@ export async function processBasesUpsertRows(
   parentContext: RequestContext,
   obsidianService: ObsidianRestApiService,
 ): Promise<BaseUpsertResponse> {
+  assertWriteAllowed({
+    operation: "bases_upsert_rows",
+    action: "upsert_rows",
+    target: params.base_id,
+    batchCount: params.operations.length,
+    frontmatterKeys: params.operations.flatMap((operation) => [
+      ...Object.keys(operation.set ?? {}),
+      ...(operation.unset ?? []),
+    ]),
+    destructive: params.operations.some(
+      (operation) => operation.unset && operation.unset.length > 0,
+    ),
+    guardedReason: params.operations.some(
+      (operation) => operation.unset && operation.unset.length > 0,
+    )
+      ? "frontmatter unset operations require MCP_WRITE_MODE=full"
+      : undefined,
+    context: parentContext,
+  });
+
   const context = requestContextService.createRequestContext({
     parentContext,
     operation: "BasesUpsertRows",

--- a/src/mcp-server/tools/obsidianDeleteNoteTool/logic.ts
+++ b/src/mcp-server/tools/obsidianDeleteNoteTool/logic.ts
@@ -10,6 +10,7 @@ import {
   RequestContext,
   retryWithDelay,
 } from "../../../utils/index.js";
+import { assertWriteAllowed } from "../../../services/writePolicy.js";
 
 // ====================================================================================
 // Schema Definitions for Input Validation
@@ -93,6 +94,14 @@ export const processObsidianDeleteNote = async (
     `Processing obsidian_delete_note request for path: ${originalFilePath}`,
     context,
   );
+
+  assertWriteAllowed({
+    operation: "obsidian_delete_note",
+    action: "delete",
+    target: originalFilePath,
+    destructive: true,
+    context,
+  });
 
   const shouldRetryNotFound = (err: unknown) =>
     err instanceof McpError && err.code === BaseErrorCode.NOT_FOUND;

--- a/src/mcp-server/tools/obsidianGlobalSearchTool/logic.ts
+++ b/src/mcp-server/tools/obsidianGlobalSearchTool/logic.ts
@@ -83,6 +83,13 @@ const ObsidianGlobalSearchInputSchema = z
       .optional()
       .default(5)
       .describe("Maximum number of matches to show per file. Defaults to 5."),
+    responseMode: z
+      .enum(["detailed", "compact"])
+      .optional()
+      .default("detailed")
+      .describe(
+        "Response shape. 'detailed' returns match snippets; 'compact' returns file-level hits with counts and metadata only.",
+      ),
   })
   .describe(
     "Performs search across vault content using text or regex. Supports filtering by modification date, directory path, pagination, and limiting matches per file.",
@@ -114,17 +121,26 @@ export interface GlobalSearchResult {
   numericMtime: number; // Numeric mtime for robust sorting
 }
 
+export interface CompactGlobalSearchResult {
+  path: string;
+  filename: string;
+  matchCount: number;
+  modifiedTime: string;
+  createdTime: string;
+}
+
 // Added alsoFoundInFiles
 export interface ObsidianGlobalSearchResponse {
   success: boolean;
   message: string;
-  results: GlobalSearchResult[];
+  results: Array<GlobalSearchResult | CompactGlobalSearchResult>;
   totalFilesFound: number; // Total files matching query *before* pagination
   totalMatchesFound: number; // Total matches across all found files *before* pagination
   currentPage: number;
   pageSize: number;
   totalPages: number;
   alsoFoundInFiles?: string[]; // List of filenames found but not on the current page
+  responseMode?: "detailed" | "compact";
 }
 
 // ====================================================================================
@@ -483,6 +499,16 @@ export const processObsidianGlobalSearch = async (
   });
 
   const paginatedResults = allFilteredResults.slice(startIndex, endIndex);
+  const responseResults =
+    params.responseMode === "compact"
+      ? paginatedResults.map((result) => ({
+          path: result.path,
+          filename: result.filename,
+          matchCount: result.matches.length,
+          modifiedTime: result.modifiedTime,
+          createdTime: result.createdTime,
+        }))
+      : paginatedResults;
 
   // 5. Determine alsoFoundInFiles
   let alsoFoundInFiles: string[] | undefined = undefined;
@@ -500,13 +526,14 @@ export const processObsidianGlobalSearch = async (
   const response: ObsidianGlobalSearchResponse = {
     success: true, // Indicate overall tool success, even if fallback was used or results are empty
     message: finalMessage,
-    results: paginatedResults,
+    results: responseResults,
     totalFilesFound: totalFilesFound,
     totalMatchesFound: totalMatchesCount,
     currentPage: currentPage,
     pageSize: pageSize,
     totalPages: totalPages,
     alsoFoundInFiles: alsoFoundInFiles, // Add the list here
+    responseMode: params.responseMode,
   };
 
   logger.info(`Global search processing completed. ${finalMessage}`, opContext);

--- a/src/mcp-server/tools/obsidianListNotesTool/logic.ts
+++ b/src/mcp-server/tools/obsidianListNotesTool/logic.ts
@@ -68,6 +68,24 @@ export const ObsidianListNotesInputSchema = z
       .describe(
         "Maximum recursion depth. 0 for no recursion, -1 for infinite (default).",
       ),
+    responseMode: z
+      .enum(["tree", "compact"])
+      .optional()
+      .default("tree")
+      .describe(
+        "Response shape. 'tree' preserves the legacy tree string; 'compact' returns paginated path entries for agent context efficiency.",
+      ),
+    limit: z
+      .number()
+      .int()
+      .positive()
+      .max(500)
+      .optional()
+      .describe("Maximum compact entries to return. Only applies to responseMode='compact'."),
+    cursor: z
+      .string()
+      .optional()
+      .describe("Opaque cursor returned by a previous compact response."),
   })
   .describe(
     "Input parameters for listing files and subdirectories within a specified Obsidian vault directory, with optional filtering and recursion.",
@@ -93,13 +111,25 @@ interface FileTreeNode {
   children: FileTreeNode[];
 }
 
+interface CompactFileEntry {
+  path: string;
+  name: string;
+  type: "file" | "directory";
+}
+
 /**
  * Defines the structure of the successful response returned by the core logic function.
  */
 export interface ObsidianListNotesResponse {
   directoryPath: string;
-  tree: string;
+  tree?: string;
+  entries?: CompactFileEntry[];
   totalEntries: number;
+  count?: number;
+  limit?: number;
+  nextCursor?: string;
+  hasMore?: boolean;
+  responseMode?: "tree" | "compact";
 }
 
 // ====================================================================================
@@ -135,6 +165,42 @@ function formatTree(
   });
 
   return { tree: treeString, count };
+}
+
+function parseCursor(cursor?: string): number {
+  if (!cursor) return 0;
+  const parsed = Number(cursor);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new McpError(
+      BaseErrorCode.VALIDATION_ERROR,
+      `Invalid cursor '${cursor}'. Use nextCursor from the previous compact response.`,
+    );
+  }
+  return parsed;
+}
+
+function flattenTree(
+  nodes: FileTreeNode[],
+  parentPath: string,
+): CompactFileEntry[] {
+  const entries: CompactFileEntry[] = [];
+  for (const node of nodes) {
+    const cleanName =
+      node.type === "directory" ? node.name.replace(/\/$/u, "") : node.name;
+    const entryPath =
+      parentPath === "/" || parentPath === ""
+        ? cleanName
+        : path.posix.join(parentPath, cleanName);
+    entries.push({
+      path: node.type === "directory" ? `${entryPath}/` : entryPath,
+      name: node.name,
+      type: node.type,
+    });
+    if (node.children.length > 0) {
+      entries.push(...flattenTree(node.children, entryPath));
+    }
+  }
+  return entries;
 }
 
 /**
@@ -316,16 +382,38 @@ export const processObsidianListNotes = async (
         directoryPath: dirPathForLog,
         tree: "(empty or all items filtered)",
         totalEntries: 0,
+        count: 0,
+        hasMore: false,
+        responseMode: params.responseMode,
       };
     }
 
     const { tree, count } = formatTree(fileTree);
+    if (params.responseMode === "compact") {
+      const allEntries = flattenTree(fileTree, dirPathForLog);
+      const offset = parseCursor(params.cursor);
+      const limit = params.limit ?? 100;
+      const entries = allEntries.slice(offset, offset + limit);
+      const nextOffset = offset + entries.length;
+      const hasMore = nextOffset < allEntries.length;
+      return {
+        directoryPath: dirPathForLog,
+        entries,
+        totalEntries: allEntries.length,
+        count: entries.length,
+        limit,
+        nextCursor: hasMore ? String(nextOffset) : undefined,
+        hasMore,
+        responseMode: "compact",
+      };
+    }
 
     // --- Step 3: Construct and return the response ---
     const response: ObsidianListNotesResponse = {
       directoryPath: dirPathForLog,
       tree: tree.trimEnd(), // Remove trailing newline
       totalEntries: count,
+      responseMode: "tree",
     };
 
     logger.debug(

--- a/src/mcp-server/tools/obsidianManageFrontmatterTool/logic.ts
+++ b/src/mcp-server/tools/obsidianManageFrontmatterTool/logic.ts
@@ -12,6 +12,7 @@ import {
   RequestContext,
   retryWithDelay,
 } from "../../../utils/index.js";
+import { assertWriteAllowed } from "../../../services/writePolicy.js";
 
 // ====================================================================================
 // Schema Definitions
@@ -88,6 +89,21 @@ export const processObsidianManageFrontmatter = async (
   });
 
   const { filePath, operation, key, value } = params;
+
+  if (operation !== "get") {
+    assertWriteAllowed({
+      operation: "obsidian_manage_frontmatter",
+      action: operation,
+      target: filePath,
+      frontmatterKeys: [key],
+      destructive: operation === "delete",
+      guardedReason:
+        operation === "delete"
+          ? "frontmatter key deletion requires MCP_WRITE_MODE=full"
+          : undefined,
+      context,
+    });
+  }
 
   const shouldRetryNotFound = (err: unknown) =>
     err instanceof McpError && err.code === BaseErrorCode.NOT_FOUND;

--- a/src/mcp-server/tools/obsidianManageTagsTool/logic.ts
+++ b/src/mcp-server/tools/obsidianManageTagsTool/logic.ts
@@ -12,6 +12,7 @@ import {
   retryWithDelay,
 } from "../../../utils/index.js";
 import { sanitization } from "../../../utils/security/sanitization.js";
+import { assertWriteAllowed } from "../../../services/writePolicy.js";
 
 // ====================================================================================
 // Schema Definitions
@@ -65,6 +66,21 @@ export const processObsidianManageTags = async (
 
   const { filePath, operation, tags: inputTags } = params;
   const sanitizedTags = inputTags.map((t) => sanitization.sanitizeTagName(t));
+
+  if (operation !== "list") {
+    assertWriteAllowed({
+      operation: "obsidian_manage_tags",
+      action: operation,
+      target: filePath,
+      batchCount: sanitizedTags.length,
+      destructive: operation === "remove",
+      guardedReason:
+        operation === "remove"
+          ? "tag removal requires MCP_WRITE_MODE=full"
+          : undefined,
+      context,
+    });
+  }
 
   const shouldRetryNotFound = (err: unknown) =>
     err instanceof McpError && err.code === BaseErrorCode.NOT_FOUND;

--- a/src/mcp-server/tools/obsidianSearchReplaceTool/logic.ts
+++ b/src/mcp-server/tools/obsidianSearchReplaceTool/logic.ts
@@ -12,6 +12,7 @@ import {
   RequestContext,
   retryWithDelay,
 } from "../../../utils/index.js";
+import { assertWriteAllowed } from "../../../services/writePolicy.js";
 
 // ====================================================================================
 // Schema Definitions for Input Validation
@@ -349,6 +350,24 @@ export const processObsidianSearchReplace = async (
     flexibleWhitespace,
     wholeWord,
     returnContent,
+  });
+
+  assertWriteAllowed({
+    operation: "obsidian_search_replace",
+    action: "replace",
+    target: targetIdentifier,
+    targetType,
+    contentLength: replacements.reduce(
+      (total, replacement) =>
+        total + replacement.search.length + replacement.replace.length,
+      0,
+    ),
+    batchCount: replacements.length,
+    guardedReason:
+      initialUseRegex && replaceAll
+        ? "regex replaceAll is blocked in guarded mode; use exact replacement, replaceAll=false, or MCP_WRITE_MODE=full"
+        : undefined,
+    context,
   });
 
   // --- Step 1: Read Initial Content (with case-insensitive fallback for filePath) ---

--- a/src/mcp-server/tools/obsidianUpdateNoteTool/logic.ts
+++ b/src/mcp-server/tools/obsidianUpdateNoteTool/logic.ts
@@ -11,6 +11,7 @@ import {
   RequestContext,
   retryWithDelay,
 } from "../../../utils/index.js";
+import { assertWriteAllowed } from "../../../services/writePolicy.js";
 
 // ====================================================================================
 // Schema Definitions for Input Validation
@@ -377,6 +378,20 @@ export const processObsidianUpdateNote = async (
     }
     targetPeriod = parseResult.data;
   }
+
+  assertWriteAllowed({
+    operation: "obsidian_update_note",
+    action: mode,
+    target: targetId,
+    targetType: params.targetType,
+    contentLength: contentString.length,
+    destructive: mode === "overwrite" && params.overwriteIfExists,
+    guardedReason:
+      mode === "overwrite" && params.overwriteIfExists
+        ? "overwriting an existing target requires MCP_WRITE_MODE=full"
+        : undefined,
+    context,
+  });
 
   try {
     // --- Step 1: Pre-operation Existence Check ---

--- a/src/mcp-server/tools/tasksShared/logic.ts
+++ b/src/mcp-server/tools/tasksShared/logic.ts
@@ -52,8 +52,10 @@ const ListAllTasksArgsSchema = z.object({
   metaFallbackToFile: z.boolean().optional(),
   applyGlobalFilter: z.boolean().optional(),
   responseFormat: z.enum(["json", "markdown"]).optional(),
+  responseMode: z.enum(["legacy", "compact", "detailed"]).optional(),
   useCache: z.boolean().optional(),
   responseLimit: z.number().int().positive().optional(),
+  cursor: z.string().optional(),
 });
 
 const QueryTasksArgsSchema = z.object({
@@ -68,8 +70,10 @@ const QueryTasksArgsSchema = z.object({
   metaFallbackToFile: z.boolean().optional(),
   applyGlobalFilter: z.boolean().optional(),
   responseFormat: z.enum(["json", "markdown"]).optional(),
+  responseMode: z.enum(["legacy", "compact", "detailed"]).optional(),
   useCache: z.boolean().optional(),
   responseLimit: z.number().int().positive().optional(),
+  cursor: z.string().optional(),
 });
 
 export const ListAllTasksInputSchemaShape = ListAllTasksArgsSchema.shape;
@@ -864,6 +868,80 @@ function serializeTasksToMarkdown(tasks: Task[]): string {
   return tasks.map(taskToString).join("\n");
 }
 
+function parseCursor(cursor?: string): number {
+  if (!cursor) return 0;
+  const parsed = Number(cursor);
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new McpError(
+      BaseErrorCode.VALIDATION_ERROR,
+      `Invalid cursor '${cursor}'. Use nextCursor from the previous tasks response.`,
+    );
+  }
+  return parsed;
+}
+
+function compactTask(task: Task): Record<string, unknown> {
+  return {
+    id: task.id,
+    description: task.description,
+    status: task.status,
+    statusSymbol: task.statusSymbol,
+    filePath: task.filePath,
+    lineNumber: task.lineNumber,
+    tags: task.tags,
+    dueDate: task.dueDate,
+    scheduledDate: task.scheduledDate,
+    priority: task.priority,
+  };
+}
+
+function serializeTasksResponse(
+  tasks: Task[],
+  options: {
+    responseFormat: "json" | "markdown";
+    responseMode?: "legacy" | "compact" | "detailed";
+    responseLimit?: number;
+    cursor?: string;
+  },
+): string {
+  const responseMode = options.responseMode ?? "legacy";
+  const offset = parseCursor(options.cursor);
+  const limit = options.responseLimit;
+  const finalTasks = limit && limit > 0
+    ? tasks.slice(offset, offset + limit)
+    : tasks.slice(offset);
+  const nextOffset = offset + finalTasks.length;
+  const hasMore = nextOffset < tasks.length;
+
+  if (responseMode === "legacy" && !options.cursor) {
+    return options.responseFormat === "markdown"
+      ? serializeTasksToMarkdown(finalTasks)
+      : serializeTasksToJson(finalTasks);
+  }
+
+  const payload = {
+    responseMode,
+    total: tasks.length,
+    count: finalTasks.length,
+    limit,
+    cursor: String(offset),
+    nextCursor: hasMore ? String(nextOffset) : undefined,
+    hasMore,
+    tasks: responseMode === "compact" ? finalTasks.map(compactTask) : finalTasks,
+  };
+
+  if (options.responseFormat === "markdown") {
+    const lines = finalTasks.map(taskToString);
+    if (hasMore) {
+      lines.push(``);
+      lines.push(`More tasks available. Re-run with cursor="${nextOffset}".`);
+    }
+    return lines.join("\n");
+  }
+
+  return JSON.stringify(payload, null, 2);
+}
+
 function needsFileMetadata(queryText: string): boolean {
   return /file\s+(created|modified)\s+(before|after|on)\s+\d{4}-\d{2}-\d{2}/i.test(
     queryText,
@@ -989,15 +1067,16 @@ export async function processListAllTasks(
     ? queryTasks(tasks, effectiveGlobalFilter)
     : tasks;
   const responseFormat = validated.responseFormat ?? "json";
-  const finalTasks =
-    limit && limit > 0 ? filteredTasks.slice(0, limit) : filteredTasks;
   logger.debug("Processed list_all_tasks request", {
     ...context,
-    resultCount: finalTasks.length,
+    resultCount: filteredTasks.length,
   });
-  return responseFormat === "markdown"
-    ? serializeTasksToMarkdown(finalTasks)
-    : serializeTasksToJson(finalTasks);
+  return serializeTasksResponse(filteredTasks, {
+    responseFormat,
+    responseMode: validated.responseMode,
+    responseLimit: limit,
+    cursor: validated.cursor,
+  });
 }
 
 export async function processQueryTasks(
@@ -1054,13 +1133,14 @@ export async function processQueryTasks(
   const filteredTasks = queryTasks(allTasks, mergedQuery);
   const responseFormat = validated.responseFormat ?? "json";
   const limit = validated.responseLimit;
-  const finalTasks =
-    limit && limit > 0 ? filteredTasks.slice(0, limit) : filteredTasks;
   logger.debug("Processed query_tasks request", {
     ...context,
-    resultCount: finalTasks.length,
+    resultCount: filteredTasks.length,
   });
-  return responseFormat === "markdown"
-    ? serializeTasksToMarkdown(finalTasks)
-    : serializeTasksToJson(finalTasks);
+  return serializeTasksResponse(filteredTasks, {
+    responseFormat,
+    responseMode: validated.responseMode,
+    responseLimit: limit,
+    cursor: validated.cursor,
+  });
 }

--- a/src/services/obsidianRestAPI/vaultCache/service.ts
+++ b/src/services/obsidianRestAPI/vaultCache/service.ts
@@ -7,6 +7,8 @@
 import { DatabaseSync } from "node:sqlite";
 import { createHash } from "node:crypto";
 import { existsSync, mkdirSync } from "node:fs";
+import type { Dirent } from "node:fs";
+import fs from "node:fs/promises";
 import path from "node:path";
 import { config } from "../../../config/index.js";
 import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
@@ -35,6 +37,7 @@ export interface CacheIndexEntry {
 }
 
 type CacheRow = CacheIndexEntry & { content: string };
+type CacheRefreshSource = "rest" | "filesystem";
 
 const CREATE_SCHEMA_SQL = `
 CREATE TABLE IF NOT EXISTS file_cache (
@@ -66,6 +69,37 @@ function normalizeDirPath(dirPath: string): string {
     candidate.startsWith("/") ? candidate : `/${candidate}`,
   );
   return normalized === "." ? "/" : normalized;
+}
+
+function getVaultRoot(): string | undefined {
+  return config.obsidianVaultPath
+    ? path.resolve(config.obsidianVaultPath)
+    : undefined;
+}
+
+function vaultRelativePathFromAbsolute(filePath: string, vaultRoot: string): string {
+  return `/${path.relative(vaultRoot, filePath).replace(/\\/g, "/")}`;
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  worker: (item: T) => Promise<R>,
+): Promise<R[]> {
+  const results: R[] = [];
+  let index = 0;
+  const workers = Array.from(
+    { length: Math.min(Math.max(concurrency, 1), items.length || 1) },
+    async () => {
+      while (index < items.length) {
+        const currentIndex = index;
+        index += 1;
+        results[currentIndex] = await worker(items[currentIndex]);
+      }
+    },
+  );
+  await Promise.all(workers);
+  return results;
 }
 
 /**
@@ -147,6 +181,9 @@ export class VaultCacheService {
   public getStats(): Record<string, unknown> {
     return {
       dbPath: config.obsidianSharedCacheDbPath,
+      refreshSource: this.readMetadataValue("last_refresh_source"),
+      configuredRefreshSource: config.obsidianCacheSource,
+      refreshConcurrency: config.obsidianCacheConcurrency,
       schemaVersion:
         this.readMetadataValue("schema_version") ?? SHARED_CACHE_SCHEMA_VERSION,
       ready: this.isCacheReady,
@@ -332,7 +369,11 @@ export class VaultCacheService {
 
     try {
       const startTime = Date.now();
-      const remoteFiles = await this.listAllMarkdownFiles("/", context);
+      const refreshSource = await this.pickRefreshSource();
+      const remoteFiles =
+        refreshSource === "filesystem"
+          ? await this.listAllMarkdownFilesFromFilesystem(context)
+          : await this.listAllMarkdownFiles("/", context);
       const remoteFileSet = new Set(remoteFiles);
       const cachedFileSet = new Set(this.metadataCache.keys());
 
@@ -347,8 +388,39 @@ export class VaultCacheService {
         }
       }
 
-      for (const filePath of remoteFiles) {
+      const processFile = async (filePath: string): Promise<"added" | "updated" | "skipped" | "failed"> => {
         try {
+          const cachedEntry = this.metadataCache.get(filePath);
+          if (refreshSource === "filesystem") {
+            const vaultRoot = getVaultRoot();
+            if (!vaultRoot) {
+              return "failed";
+            }
+            const absolutePath = path.join(vaultRoot, filePath.replace(/^\/+/u, ""));
+            const stats = await fs.stat(absolutePath);
+            const remoteMtime = Math.round(stats.mtimeMs);
+            const remoteSize = stats.size;
+            const needsRefresh =
+              !cachedEntry ||
+              cachedEntry.mtime < remoteMtime ||
+              cachedEntry.size !== remoteSize;
+
+            if (!needsRefresh) {
+              return "skipped";
+            }
+
+            const content = await fs.readFile(absolutePath, "utf-8");
+            this.upsertRow({
+              path: filePath,
+              ctime: Math.round(stats.ctimeMs),
+              mtime: remoteMtime,
+              size: remoteSize,
+              hash: computeContentHash(content),
+              content,
+            });
+            return cachedEntry ? "updated" : "added";
+          }
+
           const fileMetadata = await this.obsidianService.getFileMetadata(
             filePath,
             context,
@@ -359,10 +431,9 @@ export class VaultCacheService {
               `Skipping file during cache refresh due to missing or invalid metadata: ${filePath}`,
               { ...context, filePath },
             );
-            continue;
+            return "failed";
           }
 
-          const cachedEntry = this.metadataCache.get(filePath);
           const remoteMtime = fileMetadata.mtime;
           const remoteSize = fileMetadata.size;
           const needsRefresh =
@@ -371,7 +442,7 @@ export class VaultCacheService {
             cachedEntry.size !== remoteSize;
 
           if (!needsRefresh) {
-            continue;
+            return "skipped";
           }
 
           const noteJson = (await this.obsidianService.getFileContent(
@@ -389,26 +460,43 @@ export class VaultCacheService {
             content: noteJson.content,
           });
 
-          if (!cachedEntry) {
-            filesAdded++;
-          } else {
-            filesUpdated++;
-          }
+          return cachedEntry ? "updated" : "added";
         } catch (error) {
           logger.error(
             `Failed to process file during cache refresh: ${filePath}. Skipping. Error: ${error instanceof Error ? error.message : String(error)}`,
-            { ...context, filePath },
+            { ...context, filePath, refreshSource },
           );
+          return "failed";
+        }
+      };
+
+      const outcomes =
+        refreshSource === "filesystem"
+          ? await mapWithConcurrency(
+              remoteFiles,
+              config.obsidianCacheConcurrency,
+              processFile,
+            )
+          : [];
+
+      if (refreshSource === "rest") {
+        for (const filePath of remoteFiles) {
+          const outcome = await processFile(filePath);
+          outcomes.push(outcome);
         }
       }
+
+      filesAdded += outcomes.filter((outcome) => outcome === "added").length;
+      filesUpdated += outcomes.filter((outcome) => outcome === "updated").length;
 
       const duration = (Date.now() - startTime) / 1000;
       this.isCacheReady = true;
       this.upsertMetadataValue("last_refresh_at", String(Date.now()));
+      this.upsertMetadataValue("last_refresh_source", refreshSource);
       logger.info(
         `${
           isInitialBuild ? "Initial vault cache build" : "Vault cache refresh"
-        } completed in ${duration.toFixed(2)}s. Added: ${filesAdded}, Updated: ${filesUpdated}, Removed: ${filesRemoved}. Total indexed: ${this.metadataCache.size}.`,
+        } completed in ${duration.toFixed(2)}s via ${refreshSource}. Added: ${filesAdded}, Updated: ${filesUpdated}, Removed: ${filesRemoved}. Total indexed: ${this.metadataCache.size}.`,
         context,
       );
     } catch (error) {
@@ -600,5 +688,59 @@ export class VaultCacheService {
         opContext,
       );
     }
+  }
+
+  private async pickRefreshSource(): Promise<CacheRefreshSource> {
+    if (config.obsidianCacheSource === "rest") {
+      return "rest";
+    }
+    if (config.obsidianCacheSource === "filesystem") {
+      return getVaultRoot() && existsSync(getVaultRoot()!) ? "filesystem" : "rest";
+    }
+    const vaultRoot = getVaultRoot();
+    return vaultRoot && existsSync(vaultRoot) ? "filesystem" : "rest";
+  }
+
+  private async listAllMarkdownFilesFromFilesystem(
+    context: RequestContext,
+  ): Promise<string[]> {
+    const vaultRoot = getVaultRoot();
+    if (!vaultRoot) {
+      return [];
+    }
+
+    const markdownFiles: string[] = [];
+    const walk = async (directory: string): Promise<void> => {
+      let entries: Dirent[];
+      try {
+        entries = await fs.readdir(directory, { withFileTypes: true });
+      } catch (error) {
+        logger.warning(
+          `Failed to read local vault directory during cache refresh: ${directory}`,
+          {
+            ...context,
+            operation: "listAllMarkdownFilesFromFilesystem",
+            error: error instanceof Error ? error.message : String(error),
+          },
+        );
+        return;
+      }
+
+      for (const entry of entries) {
+        if (entry.name === ".obsidian" || entry.name === ".trash" || entry.name === ".git") {
+          continue;
+        }
+        const fullPath = path.join(directory, entry.name);
+        if (entry.isDirectory()) {
+          await walk(fullPath);
+        } else if (entry.isFile() && entry.name.toLowerCase().endsWith(".md")) {
+          markdownFiles.push(vaultRelativePathFromAbsolute(fullPath, vaultRoot));
+        }
+      }
+    };
+
+    await walk(vaultRoot);
+    markdownFiles.sort((a, b) => a.localeCompare(b));
+    return markdownFiles;
   }
 }

--- a/src/services/runtimeState.ts
+++ b/src/services/runtimeState.ts
@@ -8,6 +8,7 @@ import { warmSharedTaskCache } from "../mcp-server/tools/tasksShared/logic.js";
 import { BaseErrorCode, McpError } from "../types-global/errors.js";
 import { RequestContext, requestContextService } from "../utils/index.js";
 import { getSemanticCacheService } from "./semanticCache.js";
+import { getWritePolicyStatus } from "./writePolicy.js";
 import type { VaultCacheService } from "./obsidianRestAPI/vaultCache/index.js";
 
 const PROCESS_STARTED_AT_MS = Math.round(Date.now() - process.uptime() * 1000);
@@ -128,7 +129,13 @@ function hashRuntimeConfig(): {
     obsidianVaultPath: config.obsidianVaultPath,
     obsidianSharedCacheDbPath: config.obsidianSharedCacheDbPath,
     obsidianContentHotCacheLimit: config.obsidianContentHotCacheLimit,
+    obsidianCacheSource: config.obsidianCacheSource,
+    obsidianCacheConcurrency: config.obsidianCacheConcurrency,
     obsidianStartupBlocking: config.obsidianStartupBlocking,
+    mcpWriteMode: config.mcpWriteMode,
+    mcpGuardedMaxWriteChars: config.mcpGuardedMaxWriteChars,
+    mcpGuardedMaxBatchOperations: config.mcpGuardedMaxBatchOperations,
+    mcpProtectedFrontmatterKeys: config.mcpProtectedFrontmatterKeys,
     smartEnvDir: config.smartEnvDir,
     enableQueryEmbedding: config.enableQueryEmbedding,
     queryEmbedder: config.queryEmbedder,
@@ -226,6 +233,7 @@ export async function collectRuntimeStatus(
       ],
       writeToolsRequireApi: true,
     },
+    writePolicy: getWritePolicyStatus(),
   };
 }
 

--- a/src/services/writePolicy.ts
+++ b/src/services/writePolicy.ts
@@ -1,0 +1,121 @@
+import { config } from "../config/index.js";
+import { BaseErrorCode, McpError } from "../types-global/errors.js";
+import type { RequestContext } from "../utils/index.js";
+
+export type WriteOperation =
+  | "obsidian_delete_note"
+  | "obsidian_update_note"
+  | "obsidian_search_replace"
+  | "obsidian_manage_frontmatter"
+  | "obsidian_manage_tags"
+  | "bases_create"
+  | "bases_upsert_config"
+  | "bases_upsert_rows";
+
+type GuardCheck = {
+  operation: WriteOperation;
+  action: string;
+  target?: string;
+  destructive?: boolean;
+  targetType?: string;
+  contentLength?: number;
+  batchCount?: number;
+  frontmatterKeys?: string[];
+  allowInReadonly?: boolean;
+  allowInGuarded?: boolean;
+  guardedReason?: string;
+  context?: RequestContext;
+};
+
+function normalizeKey(key: string): string {
+  return key.trim().toLowerCase();
+}
+
+function protectedKeyMatches(keys: string[] | undefined): string[] {
+  if (!keys?.length) return [];
+  const protectedKeys = new Set(
+    config.mcpProtectedFrontmatterKeys.map((key) => normalizeKey(key)),
+  );
+  return keys.filter((key) => protectedKeys.has(normalizeKey(key)));
+}
+
+function reject(check: GuardCheck, reason: string): never {
+  throw new McpError(
+    BaseErrorCode.FORBIDDEN,
+    `${check.operation} blocked by MCP_WRITE_MODE=${config.mcpWriteMode}: ${reason}`,
+    {
+      ...(check.context ?? {}),
+      writeMode: config.mcpWriteMode,
+      operation: check.operation,
+      action: check.action,
+      target: check.target,
+    },
+  );
+}
+
+export function assertWriteAllowed(check: GuardCheck): void {
+  if (config.mcpWriteMode === "full") {
+    return;
+  }
+
+  if (config.mcpWriteMode === "readonly") {
+    if (check.allowInReadonly) return;
+    reject(check, "server is running in read-only mode");
+  }
+
+  if (check.allowInGuarded) {
+    return;
+  }
+
+  if (check.destructive) {
+    reject(check, "destructive operations require MCP_WRITE_MODE=full");
+  }
+
+  if (check.targetType && check.targetType !== "filePath") {
+    reject(
+      check,
+      "guarded mode requires an explicit vault-relative filePath target",
+    );
+  }
+
+  if (
+    typeof check.contentLength === "number" &&
+    check.contentLength > config.mcpGuardedMaxWriteChars
+  ) {
+    reject(
+      check,
+      `write content is ${check.contentLength} characters, above MCP_GUARDED_MAX_WRITE_CHARS=${config.mcpGuardedMaxWriteChars}`,
+    );
+  }
+
+  if (
+    typeof check.batchCount === "number" &&
+    check.batchCount > config.mcpGuardedMaxBatchOperations
+  ) {
+    reject(
+      check,
+      `batch contains ${check.batchCount} operations, above MCP_GUARDED_MAX_BATCH_OPERATIONS=${config.mcpGuardedMaxBatchOperations}`,
+    );
+  }
+
+  const blockedKeys = protectedKeyMatches(check.frontmatterKeys);
+  if (blockedKeys.length > 0) {
+    reject(
+      check,
+      `protected frontmatter keys cannot be modified in guarded mode: ${blockedKeys.join(", ")}`,
+    );
+  }
+
+  if (check.guardedReason) {
+    reject(check, check.guardedReason);
+  }
+}
+
+export function getWritePolicyStatus(): Record<string, unknown> {
+  return {
+    mode: config.mcpWriteMode,
+    guardedMaxWriteChars: config.mcpGuardedMaxWriteChars,
+    guardedMaxBatchOperations: config.mcpGuardedMaxBatchOperations,
+    protectedFrontmatterKeys: config.mcpProtectedFrontmatterKeys,
+  };
+}


### PR DESCRIPTION
## Summary
- add server-side MCP_WRITE_MODE=readonly|guarded|full with guarded public default
- block destructive/large/ambiguous writes in guarded mode and expose write policy in runtime status
- add compact/paginated response modes for list_notes, global search, and Tasks tools
- add OBSIDIAN_CACHE_SOURCE auto|filesystem|rest plus bounded local filesystem refresh when OBSIDIAN_VAULT is available
- document public runtime knobs and agent-context controls

## Verification
- npm run verify:code
- npm run smoke:runtime
- obsidian_list_notes compact smoke
- query_tasks compact smoke
- obsidian_global_search compact smoke
- obsidian_delete_note blocked in guarded mode before deletion
- obsidian_runtime_maintenance refresh_vault_cache via filesystem: ~3s, 7052 files indexed