### PR TITLE
config: default write mode to full

### DIFF
--- a/OPERATIONS.fr.md
+++ b/OPERATIONS.fr.md
@@ -76,7 +76,7 @@ Variables de tuning utiles :
 - `MCP_GUARDED_MAX_BATCH_OPERATIONS`
 - `OBSIDIAN_STARTUP_BLOCKING=false` pour un démarrage non bloquant plus confortable sous WSL
 
-Pour une distribution publique ou ÉLYSIA OS, garder `MCP_WRITE_MODE=guarded` sauf choix explicite de l’hôte vers `readonly` ou `full`. Le mode guarded est appliqué dans le serveur ; l’agent n’a pas à choisir un mode à chaque écriture.
+Le comportement d’écriture par défaut est `MCP_WRITE_MODE=full`. Les hôtes qui veulent une posture publique/runtime plus stricte peuvent définir explicitement `MCP_WRITE_MODE=guarded` ou `MCP_WRITE_MODE=readonly` ; l’agent n’a pas à choisir un mode à chaque écriture.
 
 ## Dépendances requises
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -76,7 +76,7 @@ Useful tuning:
 - `MCP_GUARDED_MAX_BATCH_OPERATIONS`
 - `OBSIDIAN_STARTUP_BLOCKING=false` for faster non-blocking startup in WSL-heavy setups
 
-For public or ÉLYSIA OS distribution, keep `MCP_WRITE_MODE=guarded` unless the host explicitly opts into `readonly` or `full`. Guarded mode is enforced inside the server; agents do not need to choose a mode per write.
+Default write behavior is `MCP_WRITE_MODE=full`. Hosts that want a stricter public/runtime posture can explicitly set `MCP_WRITE_MODE=guarded` or `MCP_WRITE_MODE=readonly`; agents do not need to choose a mode per write.
 
 ## Required Dependencies
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -154,7 +154,7 @@ Variables utiles :
 - `OBSIDIAN_CONTENT_HOT_CACHE_LIMIT`
 - `OBSIDIAN_CACHE_SOURCE=auto|filesystem|rest` pour choisir la source de refresh cache (`auto` privilégie le vault local quand il existe)
 - `OBSIDIAN_CACHE_CONCURRENCY` pour borner le travail filesystem local
-- `MCP_WRITE_MODE=readonly|guarded|full` pour imposer la sécurité d’écriture côté serveur (`guarded` est le défaut public)
+- `MCP_WRITE_MODE=readonly|guarded|full` pour imposer la sécurité d’écriture côté serveur (`full` est le défaut ; définir explicitement `guarded` ou `readonly` pour durcir un hôte)
 - `MCP_GUARDED_MAX_WRITE_CHARS` et `MCP_GUARDED_MAX_BATCH_OPERATIONS` pour régler les limites du mode guarded
 
 Le MCP principal absorbe aussi la surface `Tasks`, donc Codex n’a plus besoin d’un deuxième `optimike-obsidian-tasks-mcp`.
@@ -180,11 +180,11 @@ Et via MCP :
 - `obsidian_runtime_status`
 - `obsidian_runtime_maintenance`
 
-Sécurité runtime publique :
+Sécurité d’écriture runtime :
 
 - `readonly` bloque tous les outils d’écriture hors opérations de validation pure
 - `guarded` autorise les écritures explicites et bornées, mais bloque suppression, overwrite, unset frontmatter, regex replace-all large et gros batchs
-- `full` restaure le comportement d’écriture complet pour un environnement local de confiance
+- `full` est le défaut et conserve le comportement d’écriture complet pour un environnement local de confiance
 
 Contrôle du contexte agent :
 

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Useful env overrides:
 - `OBSIDIAN_CONTENT_HOT_CACHE_LIMIT` to tune the bounded in-memory hot set
 - `OBSIDIAN_CACHE_SOURCE=auto|filesystem|rest` to choose cache refresh source (`auto` prefers the local vault path when available)
 - `OBSIDIAN_CACHE_CONCURRENCY` to bound local filesystem refresh work
-- `MCP_WRITE_MODE=readonly|guarded|full` to enforce server-side write safety (`guarded` is the public default)
+- `MCP_WRITE_MODE=readonly|guarded|full` to enforce server-side write safety (`full` is the default; set `guarded` or `readonly` explicitly to harden a host)
 - `MCP_GUARDED_MAX_WRITE_CHARS` and `MCP_GUARDED_MAX_BATCH_OPERATIONS` to tune guarded-mode limits
 
 This runtime exposes the Tasks surface directly from the main MCP, so Codex no longer needs a second dedicated `optimike-obsidian-tasks-mcp` entry when using this server.
@@ -182,11 +182,11 @@ Extended health / maintenance:
   - `refresh_tasks_cache`
   - `refresh_all`
 
-Public runtime safety:
+Runtime write safety:
 
 - `readonly` blocks all write tools except validation-only operations
 - `guarded` allows bounded explicit writes and blocks destructive operations such as delete, overwrite, frontmatter unset, broad regex replace-all, and large batches
-- `full` restores unrestricted write behavior for trusted local environments
+- `full` is the default and keeps unrestricted write behavior for trusted local environments
 
 Agent-context controls:
 

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -125,7 +125,7 @@ const EnvSchema = z.object({
     .transform((val) => val.toLowerCase() === "true")
     .default("true"),
   // --- Public runtime safety ---
-  MCP_WRITE_MODE: z.enum(["readonly", "guarded", "full"]).default("guarded"),
+  MCP_WRITE_MODE: z.enum(["readonly", "guarded", "full"]).default("full"),
   MCP_GUARDED_MAX_WRITE_CHARS: z.coerce
     .number()
     .int()


### PR DESCRIPTION
## Summary
- change MCP_WRITE_MODE default from guarded to full
- keep readonly and guarded as explicit hardening opt-ins
- update README/OPERATIONS docs to match

## Verification
- npm run verify:code