### PR TITLE
Publish the ÉLYSIA task-management profile

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -484,6 +484,7 @@ Garder le mode auto et laisser chaque utilisateur surcharger par variables d’e
 - Profil serveur headless dédié : [docs/headless-server-profile.fr.md](docs/headless-server-profile.fr.md)
 - Guide de routage agent : [docs/mcp-routing-guide.fr.md](docs/mcp-routing-guide.fr.md)
 - Surface actuelle des tools : [docs/obsidian_mcp_tools_spec.md](docs/obsidian_mcp_tools_spec.md)
+- Profil public de gestion des tâches ÉLYSIA : [profiles/elysia-tasks/README.fr.md](profiles/elysia-tasks/README.fr.md)
 - README anglais : [README.md](README.md)
 
 ## Crédits

--- a/README.md
+++ b/README.md
@@ -522,6 +522,7 @@ Keep auto mode and let each user override via env vars.
 - Dedicated headless server profile: [docs/headless-server-profile.md](docs/headless-server-profile.md)
 - Agent routing guide: [docs/mcp-routing-guide.md](docs/mcp-routing-guide.md)
 - Current tool surface: [docs/obsidian_mcp_tools_spec.md](docs/obsidian_mcp_tools_spec.md)
+- Public ÉLYSIA task-management profile (French): [profiles/elysia-tasks/README.fr.md](profiles/elysia-tasks/README.fr.md)
 - French README: [README.fr.md](README.fr.md)
 
 ## Credits

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "docs/operon-migration-plan.md",
     "docs/operon-rest-contract.md",
     "docs/kairelys-cutover.fr.md",
+    "profiles/elysia-tasks",
     "plugins/obsidian-operon-bridge/build",
     "plugins/obsidian-operon-bridge/manifest.json",
     "plugins/obsidian-operon-bridge/README.md",

--- a/profiles/elysia-tasks/README.fr.md
+++ b/profiles/elysia-tasks/README.fr.md
@@ -1,0 +1,38 @@
+# Profil de gestion des tâches ÉLYSIA
+
+Ce dossier publie les conventions portables de gestion des tâches ÉLYSIA sans publier le `data.json` d’un coffre.
+
+Le profil décrit :
+
+- les identifiants stables du pipeline, des statuts et des priorités ;
+- les libellés français et anglais ;
+- les racines autorisées pour les tâches actives et les captures ;
+- la politique de création et de template ;
+- les cinq filtres canoniques ;
+- le contrat de mutation pour les agents.
+
+Il ne contient ni tâche, ni `operonId` réel, ni chemin absolu, ni layout personnel, ni cache, ni réglage privé.
+
+## Choix de langue
+
+Le profil est français par défaut. Les automatisations doivent utiliser les IDs (`pl_project`, `st_project_planned`, etc.), jamais les libellés visibles. Les traductions anglaises sont fournies pour construire un profil anglais compatible sans casser les clients MCP.
+
+Changer les libellés d’un pipeline déjà utilisé modifie les valeurs visibles stockées dans les tâches. Une migration FR ↔ EN doit donc être faite comme une migration de données : inventaire, dry-run, transitions par `statusId`, validation puis application. Changer seulement la langue de l’interface Kairélys ne nécessite pas de réécrire les tâches.
+
+## Templates
+
+ÉLYSIA utilise le template minimal natif du pipeline. Il doit ajouter uniquement les champs canoniques nécessaires : `operonId`, création, modification, statut et priorité. Les conventions de projet, de création ou de note quotidienne restent la responsabilité des templates ÉLYSIA/Obsidian ; elles ne doivent pas être recopiées dans un template de tâche Kairélys.
+
+Cette séparation évite qu’une modification de template Obsidian change silencieusement la sémantique MCP des tâches.
+
+## Application
+
+La V1 est un contrat documenté et validable, pas un importeur aveugle. Avant application dans un coffre :
+
+1. lire la configuration live avec `operon_get_configuration` ;
+2. comparer les IDs, chemins et sémantiques ;
+3. produire un dry-run des changements ;
+4. appliquer par petits lots via l’API publique du moteur ;
+5. valider avec `operon_validate` et les cinq filtres canoniques.
+
+Le fichier de référence est [`v1/profile.json`](v1/profile.json).

--- a/profiles/elysia-tasks/v1/profile.json
+++ b/profiles/elysia-tasks/v1/profile.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "./schema.json",
+  "schemaVersion": 1,
+  "profileId": "elysia.tasks",
+  "profileVersion": "1.0.0",
+  "defaultLocale": "fr",
+  "supportedLocales": ["fr", "en"],
+  "engine": {
+    "preferredPluginId": "kairelys",
+    "fallbackPluginId": "operon",
+    "publicApiVersion": "1",
+    "singleOwnerRequired": true
+  },
+  "paths": {
+    "activeTaskRoots": ["Efforts/Projets", "Efforts/Créations"],
+    "captureRoot": "Calendrier/NOTES PÉRIODIQUES",
+    "excludedFolders": ["tmp", ".trash", "Efforts/Projets/_TaskNotes"]
+  },
+  "workflow": {
+    "id": "pl_project",
+    "name": "ÉLYSIA",
+    "descriptions": {
+      "fr": "Workflow canonique ÉLYSIA : clarifier, planifier, exécuter, terminer, mettre en pause ou abandonner sans confondre état d’exécution et importance stratégique.",
+      "en": "Canonical ÉLYSIA workflow: clarify, plan, execute, finish, pause or drop work without confusing execution state with strategic importance."
+    },
+    "statuses": [
+      {
+        "id": "st_project_brainstorming",
+        "labels": { "fr": "À clarifier", "en": "To clarify" },
+        "semantics": { "finished": false, "cancelled": false, "scheduledTarget": false, "trackingTarget": false }
+      },
+      {
+        "id": "st_project_planned",
+        "labels": { "fr": "Planifié", "en": "Planned" },
+        "semantics": { "finished": false, "cancelled": false, "scheduledTarget": true, "trackingTarget": false }
+      },
+      {
+        "id": "st_project_in_progress",
+        "labels": { "fr": "En cours", "en": "In progress" },
+        "semantics": { "finished": false, "cancelled": false, "scheduledTarget": false, "trackingTarget": true }
+      },
+      {
+        "id": "st_project_finished",
+        "labels": { "fr": "Terminé", "en": "Finished" },
+        "semantics": { "finished": true, "cancelled": false, "scheduledTarget": false, "trackingTarget": false }
+      },
+      {
+        "id": "st_project_paused",
+        "labels": { "fr": "En pause", "en": "Paused" },
+        "semantics": { "finished": false, "cancelled": false, "scheduledTarget": false, "trackingTarget": false }
+      },
+      {
+        "id": "st_project_dropped",
+        "labels": { "fr": "Abandonné", "en": "Dropped" },
+        "semantics": { "finished": false, "cancelled": true, "scheduledTarget": false, "trackingTarget": false }
+      }
+    ]
+  },
+  "priorities": {
+    "defaultId": "pr_c",
+    "items": [
+      { "id": "pr_s", "label": "S", "color": "#e41a1b", "descriptions": { "fr": "Critique : incident, blocage majeur ou coût immédiat.", "en": "Critical: incident, major blocker or immediate cost." } },
+      { "id": "pr_a", "label": "A", "color": "#ff7124", "descriptions": { "fr": "Engagement prioritaire à exécuter très prochainement.", "en": "Priority commitment to execute very soon." } },
+      { "id": "pr_b", "label": "B", "color": "#a1b752", "descriptions": { "fr": "Travail important à placer après les priorités A.", "en": "Important work to schedule after A priorities." } },
+      { "id": "pr_c", "label": "C", "color": "#3f84a8", "descriptions": { "fr": "Travail opérationnel normal ; valeur par défaut.", "en": "Normal operational work; default value." } },
+      { "id": "pr_d", "label": "D", "color": "#0e6175", "descriptions": { "fr": "Maintenance ou amélioration facilement différable.", "en": "Maintenance or improvement that can be deferred easily." } },
+      { "id": "pr_e", "label": "E", "color": "#024959", "descriptions": { "fr": "Backlog crédible, sans engagement actuel.", "en": "Credible backlog without a current commitment." } },
+      { "id": "pr_f", "label": "F", "color": "#504e4e", "descriptions": { "fr": "Travail optionnel ou parqué.", "en": "Optional or parked work." } }
+    ]
+  },
+  "creation": {
+    "inlineTaskSaveMode": "ask-every-time",
+    "defaultToFileTask": false,
+    "fileTasksFolder": "Efforts/Projets/_Operon",
+    "parentInlineTargetMode": "same-folder",
+    "parentFileTargetMode": "same-folder",
+    "template": {
+      "kind": "builtin-pipeline-minimal",
+      "pipelineId": "pl_project",
+      "initialStatusId": "st_project_brainstorming",
+      "requiredCanonicalFields": ["operonId", "datetimeCreated", "datetimeModified", "status", "priority"]
+    }
+  },
+  "automation": {
+    "autoCompleteParentWhenAllChildrenTerminal": false,
+    "cascadeCancelToDescendants": false,
+    "fileTaskAutoArchiveEnabled": false,
+    "fileRepeatDestination": "same-folder"
+  },
+  "filters": [
+    {
+      "id": "fs_elysia_now",
+      "names": { "fr": "ÉLYSIA — Maintenant", "en": "ÉLYSIA — Now" },
+      "icon": "circle-play",
+      "all": [
+        { "field": "checkbox", "operator": "isOpen" },
+        { "field": "folders", "operator": "isInAnyFolderTree", "values": ["Efforts/Projets", "Efforts/Créations"] },
+        { "field": "statusId", "operator": "isNot", "value": "st_project_brainstorming" },
+        { "field": "tags", "operator": "noneContain", "value": "north-star" }
+      ],
+      "sort": ["priority:asc", "dateDue:asc", "dateScheduled:asc"]
+    },
+    {
+      "id": "fs_elysia_inbox",
+      "names": { "fr": "ÉLYSIA — Boîte de réception", "en": "ÉLYSIA — Inbox" },
+      "icon": "inbox",
+      "all": [
+        { "field": "checkbox", "operator": "isOpen" },
+        { "field": "folders", "operator": "isInFolderTree", "value": "Calendrier/NOTES PÉRIODIQUES" },
+        { "field": "statusId", "operator": "is", "value": "st_project_brainstorming" }
+      ],
+      "sort": ["dateCreated:asc"]
+    },
+    {
+      "id": "fs_elysia_north",
+      "names": { "fr": "ÉLYSIA — Étoile du Nord", "en": "ÉLYSIA — North Star" },
+      "icon": "star",
+      "all": [
+        { "field": "checkbox", "operator": "isOpen" },
+        { "field": "tags", "operator": "anyContains", "value": "north-star" }
+      ],
+      "sort": ["priority:asc", "dateDue:asc"]
+    },
+    {
+      "id": "fs_elysia_audit",
+      "names": { "fr": "ÉLYSIA — Audit anti-pollution", "en": "ÉLYSIA — Anti-pollution audit" },
+      "icon": "shield-alert",
+      "all": [
+        { "field": "checkbox", "operator": "isOpen" },
+        { "field": "folders", "operator": "isOutsideAllFolderTrees", "values": ["Efforts/Projets", "Efforts/Créations", "Calendrier/NOTES PÉRIODIQUES"] }
+      ],
+      "sort": ["folders:asc"]
+    },
+    {
+      "id": "fs_elysia_folder_open",
+      "names": { "fr": "ÉLYSIA — Tâches ouvertes du dossier", "en": "ÉLYSIA — Open tasks in folder" },
+      "icon": "list-todo",
+      "scope": "current-folder",
+      "all": [{ "field": "checkbox", "operator": "isOpen" }],
+      "sort": ["dateDue:asc", "priority:asc", "dateScheduled:asc"]
+    }
+  ],
+  "agentContract": {
+    "readConfigurationBeforeQueries": true,
+    "queryAndTransitionByStableIds": true,
+    "mutationsRequireExpectedRevision": true,
+    "mutationsRequireIdempotencyKey": true,
+    "dryRunBeforeApply": true,
+    "rawMarkdownMutationAllowed": false
+  },
+  "excludedFromProfile": [
+    "plugin data.json",
+    "runtime and cache state",
+    "documentation folder",
+    "absolute vault paths",
+    "user interface layout",
+    "personal saved filters",
+    "task content and identifiers"
+  ]
+}

--- a/profiles/elysia-tasks/v1/schema.json
+++ b/profiles/elysia-tasks/v1/schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/optimikelabs/optimike-obsidian-mcp/blob/main/profiles/elysia-tasks/v1/schema.json",
+  "title": "ÉLYSIA task management profile",
+  "type": "object",
+  "required": ["schemaVersion", "profileId", "profileVersion", "defaultLocale", "engine", "paths", "workflow", "priorities", "creation", "automation", "filters", "agentContract"],
+  "properties": {
+    "$schema": { "type": "string" },
+    "schemaVersion": { "const": 1 },
+    "profileId": { "const": "elysia.tasks" },
+    "profileVersion": { "type": "string", "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$" },
+    "defaultLocale": { "enum": ["fr", "en"] },
+    "supportedLocales": { "type": "array", "items": { "enum": ["fr", "en"] }, "uniqueItems": true },
+    "engine": { "type": "object" },
+    "paths": { "type": "object" },
+    "workflow": { "type": "object" },
+    "priorities": { "type": "object" },
+    "creation": { "type": "object" },
+    "automation": { "type": "object" },
+    "filters": { "type": "array" },
+    "agentContract": { "type": "object" },
+    "excludedFromProfile": { "type": "array", "items": { "type": "string" } }
+  },
+  "additionalProperties": false
+}


### PR DESCRIPTION
## What changed

- publishes a versioned, sanitized ÉLYSIA task-management profile
- defines stable workflow, status, priority and filter IDs
- carries French and English labels while keeping French as the default
- documents the minimal Kairélys template policy and the agent mutation contract
- adds a JSON Schema and includes the profile in the npm package

## Privacy and portability

The profile contains no task, real `operonId`, absolute vault path, plugin `data.json`, runtime/cache state, personal layout or private saved filter. Vault-local documentation paths and UI state are deliberately excluded.

## Architecture

The file is a semantic contract, not an unsafe `data.json` replacement. Automations use stable IDs; visible labels may be localized. Applying a profile to an existing vault remains a guarded migration because changing workflow labels changes values stored in tasks.

## Validation

- JSON parsing and duplicate-ID checks: PASS
- PowerShell JSON Schema validation: PASS
- semantic invariants (6 statuses, 7 priorities, 5 filters, single owner, no raw Markdown mutations): PASS
- root TypeScript build: PASS
- `npm pack --dry-run`: PASS; profile files included