### PR TITLE
Harden ÉLYSIA task profile filter validation

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -22,4 +22,5 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run test:runtime
+      - run: npm run test:profiles
       - run: npm pack --dry-run

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
       "devDependencies": {
         "@types/js-yaml": "^4.0.9",
         "@types/node": "^22.0.0",
+        "ajv": "^8.17.1",
         "prettier": "^3.5.3",
         "ts-node": "^10.9.2",
         "typedoc": "^0.28.5",
@@ -295,6 +296,28 @@
         "mcp-inspector-client": "bin/start.js"
       }
     },
+    "node_modules/@modelcontextprotocol/inspector-client/node_modules/ajv": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/inspector-client/node_modules/json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "license": "MIT"
+    },
     "node_modules/@modelcontextprotocol/inspector-server": {
       "version": "0.21.2",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/inspector-server/-/inspector-server-0.21.2.tgz",
@@ -354,28 +377,6 @@
           "optional": false
         }
       }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/@modelcontextprotocol/sdk/node_modules/pkce-challenge": {
       "version": "5.0.1",
@@ -1513,15 +1514,15 @@
       }
     },
     "node_modules/ajv": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
-      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
       "dependencies": {
-        "fast-deep-equal": "^3.1.1",
-        "fast-json-stable-stringify": "^2.0.0",
-        "json-schema-traverse": "^0.4.1",
-        "uri-js": "^4.2.2"
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
       },
       "funding": {
         "type": "github",
@@ -1544,28 +1545,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/ajv-formats/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/ajv-formats/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "license": "MIT"
     },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
@@ -3035,9 +3014,9 @@
       }
     },
     "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT"
     },
     "node_modules/json-schema-typed": {

--- a/package.json
+++ b/package.json
@@ -79,7 +79,8 @@
     "build:operon-bridge": "npm --prefix plugins/obsidian-operon-bridge run build",
     "check:operon": "npm run build && npm run test:operon-contract && npm run test:operon-service && npm --prefix plugins/obsidian-operon-bridge run check",
     "smoke:operon-mutations": "node scripts/smoke-operon-mutations.mjs",
-    "smoke:operon-rich-mutations": "node scripts/smoke-operon-rich-mutations.mjs"
+    "smoke:operon-rich-mutations": "node scripts/smoke-operon-rich-mutations.mjs",
+    "test:profiles": "node scripts/test-elysia-task-profile.mjs"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.14",
@@ -130,6 +131,7 @@
   "devDependencies": {
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^22.0.0",
+    "ajv": "^8.17.1",
     "prettier": "^3.5.3",
     "ts-node": "^10.9.2",
     "typedoc": "^0.28.5",

--- a/profiles/elysia-tasks/v1/schema.json
+++ b/profiles/elysia-tasks/v1/schema.json
@@ -17,9 +17,78 @@
     "priorities": { "type": "object" },
     "creation": { "type": "object" },
     "automation": { "type": "object" },
-    "filters": { "type": "array" },
+    "filters": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 5,
+      "items": { "$ref": "#/$defs/filter" },
+      "allOf": [
+        { "contains": { "type": "object", "properties": { "id": { "const": "fs_elysia_now" } }, "required": ["id"] }, "minContains": 1, "maxContains": 1 },
+        { "contains": { "type": "object", "properties": { "id": { "const": "fs_elysia_inbox" } }, "required": ["id"] }, "minContains": 1, "maxContains": 1 },
+        { "contains": { "type": "object", "properties": { "id": { "const": "fs_elysia_north" } }, "required": ["id"] }, "minContains": 1, "maxContains": 1 },
+        { "contains": { "type": "object", "properties": { "id": { "const": "fs_elysia_audit" } }, "required": ["id"] }, "minContains": 1, "maxContains": 1 },
+        { "contains": { "type": "object", "properties": { "id": { "const": "fs_elysia_folder_open" } }, "required": ["id"] }, "minContains": 1, "maxContains": 1 }
+      ]
+    },
     "agentContract": { "type": "object" },
     "excludedFromProfile": { "type": "array", "items": { "type": "string" } }
+  },
+  "$defs": {
+    "localizedNames": {
+      "type": "object",
+      "required": ["fr", "en"],
+      "properties": {
+        "fr": { "type": "string", "minLength": 1 },
+        "en": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    },
+    "condition": {
+      "type": "object",
+      "required": ["field", "operator"],
+      "properties": {
+        "field": { "type": "string", "minLength": 1 },
+        "operator": { "type": "string", "minLength": 1 },
+        "value": {},
+        "values": { "type": "array", "minItems": 1 }
+      },
+      "anyOf": [
+        { "type": "object", "properties": { "value": {} }, "required": ["value"] },
+        { "type": "object", "properties": { "values": { "type": "array" } }, "required": ["values"] },
+        { "type": "object", "properties": { "operator": { "const": "isOpen" } } }
+      ],
+      "additionalProperties": false
+    },
+    "filter": {
+      "type": "object",
+      "required": ["id", "names", "icon", "all", "sort"],
+      "properties": {
+        "id": {
+          "enum": [
+            "fs_elysia_now",
+            "fs_elysia_inbox",
+            "fs_elysia_north",
+            "fs_elysia_audit",
+            "fs_elysia_folder_open"
+          ]
+        },
+        "names": { "$ref": "#/$defs/localizedNames" },
+        "icon": { "type": "string", "minLength": 1 },
+        "scope": { "const": "current-folder" },
+        "all": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/condition" }
+        },
+        "sort": {
+          "type": "array",
+          "minItems": 1,
+          "uniqueItems": true,
+          "items": { "type": "string", "pattern": "^[^:]+:(asc|desc)$" }
+        }
+      },
+      "additionalProperties": false
+    }
   },
   "additionalProperties": false
 }

--- a/scripts/test-elysia-task-profile.mjs
+++ b/scripts/test-elysia-task-profile.mjs
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import Ajv2020 from "ajv/dist/2020.js";
+
+const profileUrl = new URL("../profiles/elysia-tasks/v1/profile.json", import.meta.url);
+const schemaUrl = new URL("../profiles/elysia-tasks/v1/schema.json", import.meta.url);
+const profile = JSON.parse(await readFile(profileUrl, "utf8"));
+const schema = JSON.parse(await readFile(schemaUrl, "utf8"));
+const validate = new Ajv2020({ allErrors: true, strict: true }).compile(schema);
+
+assert.equal(validate(profile), true, JSON.stringify(validate.errors));
+
+const rejectedProfiles = [
+  { name: "empty filter catalog", mutate: value => { value.filters = []; } },
+  { name: "missing canonical filter", mutate: value => { value.filters.pop(); } },
+  { name: "duplicate canonical filter id", mutate: value => { value.filters[4].id = value.filters[0].id; } },
+  { name: "filter without conditions", mutate: value => { value.filters[0].all = []; } },
+  { name: "condition without field or operator", mutate: value => { value.filters[0].all[0] = {}; } },
+];
+
+for (const testCase of rejectedProfiles) {
+  const candidate = structuredClone(profile);
+  testCase.mutate(candidate);
+  assert.equal(validate(candidate), false, `${testCase.name} should be rejected`);
+}
+
+console.log(`ÉLYSIA task profile schema tests passed: ${rejectedProfiles.length + 1} assertions`);


### PR DESCRIPTION
## Summary
- require exactly the five canonical ÉLYSIA saved-filter IDs in the V1 profile schema
- validate localized names, non-empty filter conditions, and sort clauses
- add positive and negative AJV 2020 regression tests on Linux and Windows CI

## Validation
- `npm run test:profiles` — PASS (6 assertions)
- `npm run build` — PASS
- `npm pack --dry-run` — PASS

Follow-up to the automated review on merged PR #10.