### PR TITLE
Support Kairélys 2.5.2 in the Bridge

### DIFF
--- a/docs/kairelys-cutover.fr.md
+++ b/docs/kairelys-cutover.fr.md
@@ -1,6 +1,6 @@
 # Bascule contrôlée d’Operon vers Kairélys
 
-La première version distribuée est Kairélys `2.5.1`, basée sur Operon `2.5.0`. Ce numéro distinct évite toute collision entre les tags et packs de langue du fork et ceux d’upstream.
+La première version distribuée est Kairélys `2.5.1`, basée sur Operon `2.5.0`. Kairélys `2.5.2` durcit le cycle de vie de l’API publique et les transitions terminales avec timer actif, sans changer le format des tâches. Ces numéros distincts évitent toute collision entre les tags et packs de langue du fork et ceux d’upstream.
 
 Kairélys utilise un identifiant Obsidian distinct (`kairelys`). Les tâches restent dans le Markdown
 et conservent leurs `operonId`; seuls le plugin, ses réglages et son état durable changent de dossier.

--- a/docs/operon-rest-contract.md
+++ b/docs/operon-rest-contract.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-The Bridge projects the active Operon-compatible engine's live index through Obsidian Local REST API. Reads work with official Operon `2.4.0` and `2.5.0`, and with Kairélys `2.5.1` (based on Operon `2.5.0`). Mutations are exposed only when the loaded instance implements `OperonPublicApiV1`; there is no raw Markdown or private-reflection fallback.
+The Bridge projects the active Operon-compatible engine's live index through Obsidian Local REST API. Reads work with official Operon `2.4.0` and `2.5.0`, and with Kairélys `2.5.1` or `2.5.2` (based on Operon `2.5.0`). Mutations are exposed only when the loaded instance implements `OperonPublicApiV1`; there is no raw Markdown or private-reflection fallback.
 
 Prefix:
 
@@ -15,11 +15,11 @@ All routes inherit Local REST API authentication and TLS behavior.
 ## Compatibility and capabilities
 
 - Bridge contract: `1`
-- Latest tested compatible engine version: Kairélys `2.5.1`
-- Read allowlist: `2.4.0`, `2.5.0`, `2.5.1`
+- Latest tested compatible engine version: Kairélys `2.5.2`
+- Read allowlist: `2.4.0`, `2.5.0`, `2.5.1`, `2.5.2`
 - Mutation contract: Operon Public API `1`
 - Official Operon `2.5.0`: read-only
-- Kairélys `2.5.1` with Public API v1: read-write
+- Kairélys `2.5.1` or `2.5.2` with Public API v1: read-write
 
 `GET /status` reports `bridge.mode` as `read-only` or `read-write` and exposes each capability independently. A future Operon version is not assumed compatible merely because its Markdown looks similar.
 

--- a/plugins/obsidian-operon-bridge/README.md
+++ b/plugins/obsidian-operon-bridge/README.md
@@ -15,7 +15,7 @@ If both plugins are enabled, the Bridge refuses to choose an owner. Disable one 
 
 - Obsidian Desktop
 - Operon `2.4.0` or `2.5.0` for reads
-- Kairélys `2.5.1` (based on Operon `2.5.0`) with Public API v1 for mutations
+- Kairélys `2.5.1` and `2.5.2` (based on Operon `2.5.0`) with Public API v1 for mutations
 - Obsidian Local REST API
 
 ## Routes

--- a/plugins/obsidian-operon-bridge/manifest.json
+++ b/plugins/obsidian-operon-bridge/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "optimike-operon-bridge",
   "name": "Optimike Kairélys / Operon Bridge",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "minAppVersion": "1.7.2",
   "description": "Versioned Local REST API bridge from Kairélys or Operon's live task engine to Optimike Obsidian MCP.",
   "author": "Optimike",

--- a/plugins/obsidian-operon-bridge/package-lock.json
+++ b/plugins/obsidian-operon-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optimike-operon-bridge",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optimike-operon-bridge",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "esbuild": "^0.25.0",

--- a/plugins/obsidian-operon-bridge/package.json
+++ b/plugins/obsidian-operon-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optimike-operon-bridge",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/obsidian-operon-bridge/src/contract.test.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.test.ts
@@ -105,7 +105,8 @@ test("version compatibility is an explicit tested-version allowlist", () => {
   assert.equal(isVersionCompatible("2.4.0"), true);
   assert.equal(isVersionCompatible("2.5.0"), true);
   assert.equal(isVersionCompatible("2.5.1"), true);
-  assert.equal(isVersionCompatible("2.5.2"), false);
+  assert.equal(isVersionCompatible("2.5.2"), true);
+  assert.equal(isVersionCompatible("2.5.3"), false);
   assert.equal(isVersionCompatible("2.9.1"), false);
   assert.equal(isVersionCompatible("2.3.9"), false);
   assert.equal(isVersionCompatible("3.0.0"), false);

--- a/plugins/obsidian-operon-bridge/src/contract.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.ts
@@ -1,6 +1,6 @@
 export const OPERON_BRIDGE_CONTRACT_VERSION = "1" as const;
-export const OPERON_BRIDGE_TESTED_VERSION = "2.5.1" as const;
-export const OPERON_BRIDGE_SUPPORTED_VERSIONS = ["2.4.0", "2.5.0", OPERON_BRIDGE_TESTED_VERSION] as const;
+export const OPERON_BRIDGE_TESTED_VERSION = "2.5.2" as const;
+export const OPERON_BRIDGE_SUPPORTED_VERSIONS = ["2.4.0", "2.5.0", "2.5.1", OPERON_BRIDGE_TESTED_VERSION] as const;
 
 export type OperonTaskSource = "inline" | "file";
 export type OperonCheckboxState = "open" | "done" | "cancelled";


### PR DESCRIPTION
## Summary
- allow Kairélys 2.5.2 while preserving 2.5.1 and official Operon compatibility
- bump the companion Bridge to 0.4.1
- document the public API lifecycle/timer hardening release

## Validation
- Bridge typecheck — PASS
- Bridge tests — PASS (12/12)
- Bridge build — PASS
- Bridge dependency audit — 0 vulnerabilities