### PR TITLE
Fix engine-scoped compatibility and folder-filter scope

### DIFF
--- a/docs/kairelys-cutover.fr.md
+++ b/docs/kairelys-cutover.fr.md
@@ -1,6 +1,6 @@
 # Bascule contrôlée d’Operon vers Kairélys
 
-La première version distribuée est Kairélys `2.5.1`, basée sur Operon `2.5.0`. Kairélys `2.5.2` durcit le cycle de vie de l’API publique et les transitions terminales avec timer actif, sans changer le format des tâches. Ces numéros distincts évitent toute collision entre les tags et packs de langue du fork et ceux d’upstream.
+La première version distribuée est Kairélys `2.5.1`, basée sur Operon `2.5.0`. Kairélys `2.5.2` durcit le cycle de vie de l’API publique et les transitions terminales avec timer actif ; `2.5.3` ajoute une protection contre le remplacement concurrent du timer. Ces versions ne changent pas le format des tâches. Leurs numéros distincts évitent toute collision entre les tags et packs de langue du fork et ceux d’upstream.
 
 Kairélys utilise un identifiant Obsidian distinct (`kairelys`). Les tâches restent dans le Markdown
 et conservent leurs `operonId`; seuls le plugin, ses réglages et son état durable changent de dossier.

--- a/docs/operon-rest-contract.md
+++ b/docs/operon-rest-contract.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-The Bridge projects the active Operon-compatible engine's live index through Obsidian Local REST API. Reads work with official Operon `2.4.0` and `2.5.0`, and with Kairélys `2.5.1` or `2.5.2` (based on Operon `2.5.0`). Mutations are exposed only when the loaded instance implements `OperonPublicApiV1`; there is no raw Markdown or private-reflection fallback.
+The Bridge projects the active Operon-compatible engine's live index through Obsidian Local REST API. Reads work with official Operon `2.4.0` and `2.5.0`, and with Kairélys `2.5.1` through `2.5.3` (based on Operon `2.5.0`). Compatibility is decided by plugin ID and version together. Mutations are exposed only when the loaded instance implements `OperonPublicApiV1`; there is no raw Markdown or private-reflection fallback.
 
 Prefix:
 
@@ -15,11 +15,12 @@ All routes inherit Local REST API authentication and TLS behavior.
 ## Compatibility and capabilities
 
 - Bridge contract: `1`
-- Latest tested compatible engine version: Kairélys `2.5.2`
-- Read allowlist: `2.4.0`, `2.5.0`, `2.5.1`, `2.5.2`
+- Latest tested compatible engine version: Kairélys `2.5.3`
+- Official Operon read allowlist: `2.4.0`, `2.5.0`
+- Kairélys read allowlist: `2.5.1`, `2.5.2`, `2.5.3`
 - Mutation contract: Operon Public API `1`
 - Official Operon `2.5.0`: read-only
-- Kairélys `2.5.1` or `2.5.2` with Public API v1: read-write
+- Kairélys `2.5.1` through `2.5.3` with Public API v1: read-write
 
 `GET /status` reports `bridge.mode` as `read-only` or `read-write` and exposes each capability independently. A future Operon version is not assumed compatible merely because its Markdown looks similar.
 

--- a/plugins/obsidian-operon-bridge/README.md
+++ b/plugins/obsidian-operon-bridge/README.md
@@ -15,7 +15,7 @@ If both plugins are enabled, the Bridge refuses to choose an owner. Disable one 
 
 - Obsidian Desktop
 - Operon `2.4.0` or `2.5.0` for reads
-- Kairélys `2.5.1` and `2.5.2` (based on Operon `2.5.0`) with Public API v1 for mutations
+- Kairélys `2.5.1` through `2.5.3` (based on Operon `2.5.0`) with Public API v1 for mutations
 - Obsidian Local REST API
 
 ## Routes

--- a/plugins/obsidian-operon-bridge/manifest.json
+++ b/plugins/obsidian-operon-bridge/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "optimike-operon-bridge",
   "name": "Optimike Kairélys / Operon Bridge",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "minAppVersion": "1.7.2",
   "description": "Versioned Local REST API bridge from Kairélys or Operon's live task engine to Optimike Obsidian MCP.",
   "author": "Optimike",

--- a/plugins/obsidian-operon-bridge/package-lock.json
+++ b/plugins/obsidian-operon-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optimike-operon-bridge",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optimike-operon-bridge",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "esbuild": "^0.25.0",

--- a/plugins/obsidian-operon-bridge/package.json
+++ b/plugins/obsidian-operon-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optimike-operon-bridge",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/obsidian-operon-bridge/src/contract.test.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.test.ts
@@ -102,14 +102,15 @@ function normalized(): OperonBridgeTask {
 }
 
 test("version compatibility is an explicit tested-version allowlist", () => {
-  assert.equal(isVersionCompatible("2.4.0"), true);
-  assert.equal(isVersionCompatible("2.5.0"), true);
-  assert.equal(isVersionCompatible("2.5.1"), true);
-  assert.equal(isVersionCompatible("2.5.2"), true);
-  assert.equal(isVersionCompatible("2.5.3"), false);
-  assert.equal(isVersionCompatible("2.9.1"), false);
-  assert.equal(isVersionCompatible("2.3.9"), false);
-  assert.equal(isVersionCompatible("3.0.0"), false);
+  assert.equal(isVersionCompatible("operon", "2.4.0"), true);
+  assert.equal(isVersionCompatible("operon", "2.5.0"), true);
+  assert.equal(isVersionCompatible("operon", "2.5.1"), false);
+  assert.equal(isVersionCompatible("operon", "2.5.2"), false);
+  assert.equal(isVersionCompatible("kairelys", "2.5.0"), false);
+  assert.equal(isVersionCompatible("kairelys", "2.5.1"), true);
+  assert.equal(isVersionCompatible("kairelys", "2.5.2"), true);
+  assert.equal(isVersionCompatible("kairelys", "2.5.3"), true);
+  assert.equal(isVersionCompatible("kairelys", "2.5.4"), false);
 });
 
 test("index readiness refuses startup, recovery, sync, and dirty states", () => {

--- a/plugins/obsidian-operon-bridge/src/contract.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.ts
@@ -1,6 +1,9 @@
 export const OPERON_BRIDGE_CONTRACT_VERSION = "1" as const;
-export const OPERON_BRIDGE_TESTED_VERSION = "2.5.2" as const;
-export const OPERON_BRIDGE_SUPPORTED_VERSIONS = ["2.4.0", "2.5.0", "2.5.1", OPERON_BRIDGE_TESTED_VERSION] as const;
+export const OPERON_BRIDGE_TESTED_VERSION = "2.5.3" as const;
+export const OPERON_BRIDGE_SUPPORTED_VERSIONS = {
+  operon: ["2.4.0", "2.5.0"],
+  kairelys: ["2.5.1", "2.5.2", OPERON_BRIDGE_TESTED_VERSION],
+} as const;
 
 export type OperonTaskSource = "inline" | "file";
 export type OperonCheckboxState = "open" | "done" | "cancelled";
@@ -292,8 +295,8 @@ export interface OperonTaskPage {
 const DEFAULT_LIMIT = 100;
 const MAX_LIMIT = 500;
 
-export function isVersionCompatible(version: string): boolean {
-  return (OPERON_BRIDGE_SUPPORTED_VERSIONS as readonly string[]).includes(version.trim());
+export function isVersionCompatible(pluginId: "kairelys" | "operon", version: string): boolean {
+  return (OPERON_BRIDGE_SUPPORTED_VERSIONS[pluginId] as readonly string[]).includes(version.trim());
 }
 
 export interface RuntimeIndexDiagnostics {

--- a/plugins/obsidian-operon-bridge/src/main.ts
+++ b/plugins/obsidian-operon-bridge/src/main.ts
@@ -398,7 +398,7 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       pluginName: resolved.name,
       api: this.readPublicApi(plugin),
       version,
-      compatible: isVersionCompatible(version),
+      compatible: isVersionCompatible(resolved.id, version),
       indexer,
       pipelines: Array.isArray(plugin?.settings?.pipelines)
         ? plugin.settings.pipelines
@@ -717,7 +717,9 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
         version: runtime?.version ?? null,
         compatible: Boolean(runtime?.compatible),
         testedAgainst: OPERON_BRIDGE_TESTED_VERSION,
-        supportedRange: OPERON_BRIDGE_SUPPORTED_VERSIONS.join(", "),
+        supportedRange: Object.entries(OPERON_BRIDGE_SUPPORTED_VERSIONS)
+          .map(([pluginId, versions]) => `${pluginId}: ${versions.join(", ")}`)
+          .join("; "),
       },
       index: {
         ready,
@@ -746,7 +748,7 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
     }
     if (!runtime.compatible) {
       throw new Error(
-        `${runtime.pluginName} ${runtime.version || "unknown"} is not in the tested Bridge allowlist (${OPERON_BRIDGE_SUPPORTED_VERSIONS.join(", ")}).`,
+        `${runtime.pluginName} ${runtime.version || "unknown"} is not in the tested Bridge allowlist (${Object.entries(OPERON_BRIDGE_SUPPORTED_VERSIONS).map(([pluginId, versions]) => `${pluginId}: ${versions.join(", ")}`).join("; ")}).`,
       );
     }
     return runtime;

--- a/profiles/elysia-tasks/v1/schema.json
+++ b/profiles/elysia-tasks/v1/schema.json
@@ -87,6 +87,17 @@
           "items": { "type": "string", "pattern": "^[^:]+:(asc|desc)$" }
         }
       },
+      "allOf": [
+        {
+          "if": {
+            "type": "object",
+            "properties": { "id": { "const": "fs_elysia_folder_open" } },
+            "required": ["id"]
+          },
+          "then": { "type": "object", "properties": { "scope": { "const": "current-folder" } }, "required": ["scope"] },
+          "else": { "not": { "type": "object", "properties": { "scope": {} }, "required": ["scope"] } }
+        }
+      ],
       "additionalProperties": false
     }
   },

--- a/scripts/test-elysia-task-profile.mjs
+++ b/scripts/test-elysia-task-profile.mjs
@@ -16,6 +16,8 @@ const rejectedProfiles = [
   { name: "duplicate canonical filter id", mutate: value => { value.filters[4].id = value.filters[0].id; } },
   { name: "filter without conditions", mutate: value => { value.filters[0].all = []; } },
   { name: "condition without field or operator", mutate: value => { value.filters[0].all[0] = {}; } },
+  { name: "folder filter without current-folder scope", mutate: value => { delete value.filters[4].scope; } },
+  { name: "non-folder filter with folder scope", mutate: value => { value.filters[0].scope = "current-folder"; } },
 ];
 
 for (const testCase of rejectedProfiles) {


### PR DESCRIPTION
## Summary
- key Bridge compatibility by plugin ID and version, keeping Kairélys-only releases unavailable to official Operon
- support Kairélys 2.5.3 and bump Bridge to 0.4.2
- require `scope: current-folder` only on the canonical folder-open filter

## Validation
- ÉLYSIA profile schema — PASS (8 assertions)
- Bridge typecheck — PASS
- Bridge tests — PASS (12/12)
- Bridge build — PASS
- MCP build — PASS