### PR TITLE
Publish the public ÉLYSIA Task Gouverneur skill

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -26,7 +26,7 @@ Recommandation Codex : pointer la config MCP vers `dist/stdio-proxy.js`, pas dir
   - Local REST API (obligatoire pour les outils REST live) : https://github.com/coddingtonbear/obsidian-local-rest-api
   - Smart Connections (obligatoire pour la recherche sémantique) : https://github.com/brianpetro/obsidian-smart-connections
   - Bases Bridge (REST) (obligatoire pour les outils `.base` live/plugin-backed, inclus dans ce repo)
-  - Operon `2.5.0` avec Public API v1 et Optimike Operon Bridge (requis pour les mutations Operon live ; Bridge inclus dans ce repo)
+  - Kairélys `2.5.3`, ou une release Operon compatible avec Public API v1, et Optimike Operon Bridge (requis pour les mutations live ; Bridge inclus dans ce repo)
   - plugin Obsidian Tasks (obligatoire pour un comportement Tasks canonique)
 - Pour la recherche sémantique, assure-toi que ton vault contient un dossier `.smart-env`
 
@@ -152,9 +152,9 @@ Le serveur expose des tools MCP “Base” via Obsidian MCP :
 
 Les clés protégées ou virtuelles (`file.*`, `formula.*`, `création`/`creation`, `modification`) sont refusées avant écriture. Les timeouts `processFrontMatter` du Bridge remontent en `write_timeout` retryable : les traiter d’abord comme signal “Obsidian occupé/indexing/locked”, pas comme une donnée forcément invalide.
 
-## Moteur de tâches Operon
+## Moteur de tâches Kairélys / Operon
 
-Operon reste le moteur métier des tâches et l’interface humaine. L’Optimike Operon Bridge inclus projette son index live et sa Public API versionnée via Local REST API ; le MCP ajoute validation, snapshots stale, politique d’écriture, révisions optimistes, idempotence durable et journal d’audit.
+Kairélys ou une release Operon compatible reste le moteur métier des tâches et l’interface humaine. L’Optimike Operon Bridge inclus projette son index live et sa Public API versionnée via Local REST API ; le MCP ajoute validation, snapshots stale, politique d’écriture, révisions optimistes, idempotence durable et journal d’audit.
 
 Les 13 outils sont :
 
@@ -484,7 +484,7 @@ Garder le mode auto et laisser chaque utilisateur surcharger par variables d’e
 - Profil serveur headless dédié : [docs/headless-server-profile.fr.md](docs/headless-server-profile.fr.md)
 - Guide de routage agent : [docs/mcp-routing-guide.fr.md](docs/mcp-routing-guide.fr.md)
 - Surface actuelle des tools : [docs/obsidian_mcp_tools_spec.md](docs/obsidian_mcp_tools_spec.md)
-- Profil public de gestion des tâches ÉLYSIA : [profiles/elysia-tasks/README.fr.md](profiles/elysia-tasks/README.fr.md)
+- Profil public de gestion des tâches ÉLYSIA et skill agentique portable : [profiles/elysia-tasks/README.fr.md](profiles/elysia-tasks/README.fr.md)
 - README anglais : [README.md](README.md)
 
 ## Crédits

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Recommended for Codex: point your MCP config to `dist/stdio-proxy.js`, not direc
   - Local REST API (required for live REST tools): https://github.com/coddingtonbear/obsidian-local-rest-api
   - Smart Connections (required for semantic search): https://github.com/brianpetro/obsidian-smart-connections
   - Bases Bridge (REST) (required for live/plugin-backed `.base` tools, bundled in this repo)
-  - Operon `2.5.0` with Public API v1 plus Optimike Operon Bridge (required for live Operon mutations; Bridge bundled in this repo)
+  - Kairélys `2.5.3`, or a compatible Operon release with Public API v1, plus Optimike Operon Bridge (required for live task mutations; Bridge bundled in this repo)
   - Obsidian Tasks plugin (required for canonical Tasks behavior)
 - For semantic search, make sure your vault has a `.smart-env` folder
 
@@ -152,9 +152,9 @@ This server exposes “Base” MCP tools:
 
 Protected or virtual keys (`file.*`, `formula.*`, `création`/`creation`, `modification`) are refused before writing. Bridge-side `processFrontMatter` timeouts are surfaced as retryable `write_timeout` errors; treat them as an Obsidian busy/indexing/locked signal before blaming the payload.
 
-## Operon task engine
+## Kairélys / Operon task engine
 
-Operon remains the task-domain engine and human UI. The bundled Optimike Operon Bridge projects its live index and versioned Public API through Local REST API; the MCP adds validation, stale snapshots, write policy, optimistic revisions, durable idempotency, and audit records.
+Kairélys or a compatible Operon release remains the task-domain engine and human UI. The bundled Optimike Operon Bridge projects its live index and versioned Public API through Local REST API; the MCP adds validation, stale snapshots, write policy, optimistic revisions, durable idempotency, and audit records.
 
 The 13 tools are:
 
@@ -522,7 +522,7 @@ Keep auto mode and let each user override via env vars.
 - Dedicated headless server profile: [docs/headless-server-profile.md](docs/headless-server-profile.md)
 - Agent routing guide: [docs/mcp-routing-guide.md](docs/mcp-routing-guide.md)
 - Current tool surface: [docs/obsidian_mcp_tools_spec.md](docs/obsidian_mcp_tools_spec.md)
-- Public ÉLYSIA task-management profile (French): [profiles/elysia-tasks/README.fr.md](profiles/elysia-tasks/README.fr.md)
+- Public ÉLYSIA task-management profile and portable agent skill (French): [profiles/elysia-tasks/README.fr.md](profiles/elysia-tasks/README.fr.md)
 - French README: [README.fr.md](README.fr.md)
 
 ## Credits

--- a/profiles/elysia-tasks/README.fr.md
+++ b/profiles/elysia-tasks/README.fr.md
@@ -36,3 +36,27 @@ La V1 est un contrat documenté et validable, pas un importeur aveugle. Avant ap
 5. valider avec `operon_validate` et les cinq filtres canoniques.
 
 Le fichier de référence est [`v1/profile.json`](v1/profile.json).
+
+## Skill agentique publique
+
+La skill portable [`elysia-task-gouverneur`](skills/elysia-task-gouverneur/SKILL.md) permet à un agent de piloter ce profil via les 13 outils `operon_*` du MCP Optimike.
+
+Elle couvre :
+
+- création, adoption, mise à jour, transition, conversion et relocalisation ;
+- audit et triage par saved filters ;
+- cycle de vie des backlogs de projet ;
+- diagnostic du runtime et du cache ;
+- dry-run, révisions optimistes, idempotence et preuve après application.
+
+La skill ne contient aucun chemin absolu, aucune tâche réelle, aucun identifiant privé et aucune copie de configuration `data.json`. Les règles propres à un coffre doivent être fournies comme politique locale au moment de l’exécution.
+
+La version publique suit son propre versionnement et n’est pas un miroir automatique d’une configuration privée. Toute évolution doit être promue après contrôle de portabilité et de non-régression.
+
+Pour l’installer dans un runtime Agent Skills, copier le dossier complet :
+
+```text
+profiles/elysia-tasks/skills/elysia-task-gouverneur/
+```
+
+Conserver aussi `profiles/elysia-tasks/v1/profile.json` accessible à l’agent lorsqu’il doit vérifier ou installer la conformité complète au profil.

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/SKILL.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: elysia-task-gouverneur
+description: 'Orchestre les tâches d’un coffre compatible avec le profil public ÉLYSIA Tasks : opérations ponctuelles, audits, triage, cycle de vie et santé du runtime Kairélys/Operon via les outils operon_*, avec IDs stables, dry-run et validation humaine.'
+metadata:
+  version: '1.0.0'
+  skill_structure: graph
+  portability_class: profile-bound-portable
+  profile_id: elysia.tasks
+  profile_schema_version: 1
+  mcp_namespace: operon_*
+  reference_gate: true
+---
+
+# Skill — ÉLYSIA Task Gouverneur
+
+Utilise le profil public `elysia.tasks` et la configuration live du moteur pour gérer des tâches sans écrire directement dans le Markdown.
+
+## Quand l’utiliser
+
+- Créer, adopter, modifier, terminer, convertir ou déplacer une tâche.
+- Auditer ou trier un backlog compatible avec le profil ÉLYSIA Tasks.
+- Contrôler les filtres canoniques et le respect du propriétaire unique.
+- Diagnostiquer un runtime Kairélys/Operon stale, incompatible ou incohérent.
+
+## Invariants
+
+- `operon_*` est le namespace MCP stable, que le moteur soit Kairélys ou Operon officiel.
+- Lire `operon_get_configuration` et `operon_status` avant toute décision dépendant des pipelines, statuts, priorités, chemins ou capacités.
+- Utiliser les IDs stables ; les libellés français ou anglais ne sont pas des identités.
+- Ne jamais muter une tâche par regex, patch Markdown, édition YAML brute ou déplacement de fichier.
+- Toute mutation d’une tâche existante passe par `expectedRevision`, `idempotencyKey`, dry-run, validation humaine, apply, relecture et `operon_validate`.
+- Runtime stale/non-live, capacité absente ou référence critique inaccessible : lecture seulement.
+- Une tâche appartient à un seul moteur. Ne jamais écrire en miroir dans Operon, Tasks et TaskNotes.
+
+## Reference Gate Map
+
+| Intention | `module_route` | Modules obligatoires |
+|---|---|---|
+| Créer, adopter, modifier, terminer, convertir, déplacer | `operation-ponctuelle` | [operations-ponctuelles.md](references/operations-ponctuelles.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
+| Audit, triage, conformité ou saved filters | `audit-triage` | [audits-et-triage.md](references/audits-et-triage.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
+| Changement de phase d’un projet ou nettoyage de backlog | `cycle-vie-projet` | [cycle-de-vie-projet.md](references/cycle-de-vie-projet.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
+| Cache stale, incident, incompatibilité ou lenteur | `sante-performance` | [sante-et-performance.md](references/sante-et-performance.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
+
+## Routage rapide
+
+- Opération sur une tâche -> ouvrir `operations-ponctuelles` puis `runtime-et-mutations`.
+- Audit ou cockpit -> ouvrir `audits-et-triage` puis `runtime-et-mutations`.
+- Projet qui change de phase -> ouvrir `cycle-de-vie-projet` puis `runtime-et-mutations`.
+- Runtime stale ou incident -> ouvrir `sante-et-performance` puis `runtime-et-mutations`.
+
+## Profile Gate
+
+La distribution complète contient le contrat machine-readable dans `profiles/elysia-tasks/v1/profile.json` ; depuis le dossier de cette skill, le chemin relatif est `../../v1/profile.json`.
+
+- Pour auditer ou installer le profil, ouvrir ce fichier et comparer ses IDs à `operon_get_configuration`.
+- Pour une opération ponctuelle sur un coffre déjà configuré, la configuration live et les IDs de la tâche peuvent suffire.
+- Si ni le profil ni une configuration live compatible ne sont accessibles, ne pas appliquer de mutation.
+
+## Preuve d’ouverture
+
+Toute décision sensible renseigne `references_ouvertes` :
+
+```yaml
+- path: chemin ou ressource exacte
+  type: skill_reference | public_profile | local_policy | runtime
+  raison: pourquoi cette source est requise
+  impact_sur_decision: ce qu'elle autorise, interdit ou précise
+```
+
+Lire seulement `SKILL.md` ne compte pas comme usage complet de la skill. Une référence obligatoire manquante impose `sortie_finale_autorisee: non` pour toute mutation.
+
+## Workflow universel
+
+1. Qualifier l’intention et choisir `module_route`.
+2. Ouvrir les modules requis et, si pertinent, le profil public ou la politique locale du coffre.
+3. Lire la configuration live, l’état du runtime et les capacités.
+4. Lire la tâche ou le périmètre avec les outils `operon_*`.
+5. Produire un diagnostic et, si utile, un dry-run précis.
+6. Appliquer seulement après validation humaine explicite.
+7. Relire, exécuter `operon_validate` et rapporter le résultat prouvé.
+
+## Sortie
+
+Appliquer [contrat-de-sortie.md](references/contrat-de-sortie.md) et renseigner `module_route`, `etape_pipeline_en_cours`, `references_ouvertes` et `sortie_finale_autorisee`. Une passe analytique peut conclure `apply_propose: aucun`.
+
+## Navigation
+
+- Runtime et mutations : [runtime-et-mutations.md](references/runtime-et-mutations.md)
+- Opérations ponctuelles : [operations-ponctuelles.md](references/operations-ponctuelles.md)
+- Audits et triage : [audits-et-triage.md](references/audits-et-triage.md)
+- Cycle de vie projet : [cycle-de-vie-projet.md](references/cycle-de-vie-projet.md)
+- Santé et performance : [sante-et-performance.md](references/sante-et-performance.md)
+- Contrat de sortie : [contrat-de-sortie.md](references/contrat-de-sortie.md)
+
+## Exemples de déclencheurs
+
+- « Crée cette tâche dans le projet et mets-la dans le statut planifié. »
+- « Termine cette tâche via Operon sans modifier le Markdown. »
+- « Audite les tâches hors des racines autorisées par le profil ÉLYSIA. »
+- « Why is the Operon runtime stale? »

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/audits-et-triage.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/audits-et-triage.md
@@ -1,0 +1,32 @@
+# Audits et triage
+
+## Profil requis
+
+Pour un audit de conformité ÉLYSIA, ouvrir `profiles/elysia-tasks/v1/profile.json` et comparer la configuration live aux IDs, racines, filtres et contraintes du profil.
+
+## Modes
+
+- `audit_reel` : compter les tâches, doublons, états et chemins réellement observés.
+- `audit_conformite` : comparer la configuration et les tâches au profil public et à la politique locale.
+- `triage_operationnel` : classer les actions proposées par impact sans modifier le backlog.
+- `hygiene_periodique` : détecter les tâches dormantes, hors zone, orphelines ou incohérentes.
+
+## Filtres canoniques du profil V1
+
+- `fs_elysia_now`
+- `fs_elysia_inbox`
+- `fs_elysia_north`
+- `fs_elysia_audit`
+- `fs_elysia_folder_open` avec un `scopePath` explicite
+
+Appeler `operon_query_saved_filter` ; ne pas reconstruire la logique du filtre côté agent.
+
+## Méthode
+
+1. Exécuter le préflight live.
+2. Déclarer le périmètre et la politique de référence.
+3. Interroger le saved filter ou les tâches concernées.
+4. Séparer faits, écarts au profil, politique locale et interprétation.
+5. Proposer uniquement les mutations nécessaires.
+
+`apply_propose: aucun` est une conclusion valide. Les comptages avant/après ne sont rapportés que s’ils ont été réellement mesurés.

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/contrat-de-sortie.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/contrat-de-sortie.md
@@ -1,0 +1,42 @@
+# Contrat de sortie
+
+```yaml
+module_route: operation-ponctuelle | audit-triage | cycle-vie-projet | sante-performance
+etape_pipeline_en_cours: routage | lecture | dry-run | attente_apply | application | verification | termine
+runtime_preflight:
+  source: operon-live | operon-cache | indisponible
+  stale: true | false | inconnu
+  configuration_lue: true | false
+  capacite_requise: nom | aucune
+  capacite_disponible: true | false | non_applicable
+references_ouvertes:
+  - path: ressource exacte
+    type: skill_reference | public_profile | local_policy | runtime
+    raison: pourquoi elle était requise
+    impact_sur_decision: ce qu'elle a changé ou confirmé
+diagnostic:
+  - constat factuel
+plan_action:
+  - étape classée par impact
+apply_propose: aucun | liste de mutations dry-run
+kpi_avant_apres: non_applicable | mesures réellement observées
+next_step: action immédiate ou aucun
+sortie_finale_autorisee: oui | non
+```
+
+`sortie_finale_autorisee: oui` signifie que les preuves suffisent pour la conclusion. Cela ne vaut jamais autorisation d’appliquer une mutation.
+
+Une référence critique manquante, un runtime stale/non-live ou une capacité absente impose `sortie_finale_autorisee: non` pour toute mutation.
+
+Après application, ajouter :
+
+```yaml
+preuve_application:
+  operation_id: identifiant retourné
+  relecture_effectuee: true | false
+  resultat_attendu_obtenu: true | false | incertain
+  operon_validate: résultat réel
+  divergence: aucune | description
+```
+
+Si l’état final ne peut pas être relu, le résultat reste `incertain` et ne doit pas être retenté aveuglément.

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/cycle-de-vie-projet.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/cycle-de-vie-projet.md
@@ -1,0 +1,23 @@
+# Cycle de vie projet
+
+## Portée
+
+Le profil public définit la gestion des tâches, pas le schéma de projet propre à chaque coffre. Avant de requalifier un backlog de projet, charger la politique locale qui définit les phases du projet et la note ou l’objet qui fait foi.
+
+## Questions obligatoires
+
+- Le projet est-il encore actif selon la politique locale ?
+- Existe-t-il une prochaine action crédible ?
+- Les tâches ouvertes ont-elles encore un propriétaire, un contexte et une reprise réelle ?
+- Une tâche doit-elle être terminée, annulée, déplacée ou conservée ?
+
+## Règles
+
+- Ne pas conserver un backlog ouvert par inertie dans un projet inactif.
+- Ne pas normaliser toutes les tâches en lot sans relire leur contexte.
+- Déplacer une tâche survivante vers un projet actif seulement si sa destination est explicite.
+- Une modification des métadonnées du projet suit la politique du coffre ; elle ne passe pas automatiquement par les outils Operon.
+
+## Restitution
+
+Indiquer la phase recommandée, la prochaine action, le sort des tâches ouvertes et la politique locale utilisée. Si aucun changement n’est requis, le dire explicitement.

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/operations-ponctuelles.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/operations-ponctuelles.md
@@ -1,0 +1,40 @@
+# Opérations ponctuelles
+
+## Dépendances
+
+- Ouvrir [runtime-et-mutations.md](runtime-et-mutations.md).
+- Lire la politique locale du chemin source et du chemin cible.
+- Utiliser les racines, pipelines, statuts et priorités remontés par la configuration live.
+
+## Routes
+
+### Créer
+
+Utiliser `operon_create_task` pour une action qui n’existe pas encore. Résoudre la description, la destination autorisée, le pipeline, le statut initial, la priorité et les dates réellement justifiées.
+
+### Adopter
+
+Utiliser `operon_adopt_task` pour promouvoir une checkbox existante qui constitue une vraie action. Verrouiller le chemin, le numéro de ligne et le contenu attendu.
+
+### Modifier
+
+Utiliser `operon_update_task` et envoyer seulement les champs intentionnellement modifiés. Préserver les propriétés inconnues.
+
+### Changer d’état
+
+Utiliser `operon_transition_task` pour terminer, annuler, rouvrir ou changer de statut. Utiliser un `statusId` live et vérifier les effets métier après application.
+
+### Convertir
+
+Utiliser `operon_convert_task` pour inline ↔ fichier lorsque la forme cible apporte un gain réel. Vérifier le mode d’écriture requis et résoudre la destination avant le dry-run.
+
+### Déplacer
+
+Utiliser exclusivement `operon_relocate_task`. Vérifier la politique locale du dossier cible et la conservation de l’identité `operonId`.
+
+## Heuristiques portables
+
+- Une tâche atomique reste inline ; une tâche riche peut devenir fichier.
+- Un projet reste une note ou un objet de projet, pas une tâche géante.
+- Une tâche longue peut rester une tâche maître avec une progression documentaire simple.
+- Si la destination, le statut ou la propriété est ambigu, arrêter au diagnostic ou au dry-run.

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/runtime-et-mutations.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/runtime-et-mutations.md
@@ -1,0 +1,65 @@
+# Runtime et mutations
+
+## Sources de vérité
+
+1. La configuration réellement chargée, via `operon_get_configuration`.
+2. L’état live, via `operon_status`.
+3. Le profil public `elysia.tasks` fourni dans `profiles/elysia-tasks/v1/profile.json` pour les conventions portables.
+4. La politique locale du coffre pour les règles qui ne font pas partie du profil public.
+
+La configuration live décide des capacités et des IDs utilisables. Le profil permet de mesurer la compatibilité ; il ne remplace pas l’état du runtime.
+
+## Préflight
+
+Autoriser une mutation seulement si :
+
+- `source = operon-live` ;
+- `stale = false` ;
+- le moteur et le Bridge sont compatibles ;
+- la capacité demandée est annoncée ;
+- la tâche et sa révision courante ont été relues lorsqu’elles existent déjà.
+
+Un snapshot stale peut servir à un diagnostic explicitement limité, jamais à une mutation.
+
+## Surface MCP
+
+Lecture :
+
+- `operon_status`
+- `operon_get_configuration`
+- `operon_list_tasks`
+- `operon_get_task`
+- `operon_query_tasks`
+- `operon_query_saved_filter`
+- `operon_validate`
+
+Mutation :
+
+- `operon_adopt_task`
+- `operon_create_task`
+- `operon_update_task`
+- `operon_transition_task`
+- `operon_convert_task`
+- `operon_relocate_task`
+
+## Protocole
+
+Pour une tâche existante :
+
+1. Lire la tâche et sa `revision`.
+2. Construire une `idempotencyKey` liée à l’intention.
+3. Exécuter le même outil avec `dryRun: true` et `expectedRevision`.
+4. Présenter l’avant, la demande et l’après attendu.
+5. Attendre une validation humaine explicite.
+6. Appliquer avec la révision encore valide.
+7. Relire la tâche et appeler `operon_validate`.
+
+Pour une création, aucune révision antérieure n’existe : destination, pipeline, statut initial et clé d’idempotence doivent être explicites. Pour une adoption, verrouiller le chemin, la ligne et le contenu attendu de la checkbox.
+
+## Interdits
+
+- Aucun fallback silencieux vers le Markdown brut.
+- Aucun déplacement hors `operon_relocate_task`.
+- Aucune écriture miroir vers un autre moteur de tâches.
+- Aucune opération bulk avant un dry-run borné.
+- Aucun succès annoncé si l’état final n’a pas été relu.

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/sante-et-performance.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/sante-et-performance.md
@@ -1,0 +1,25 @@
+# Santé et performance
+
+## Diagnostic
+
+1. Relever `source`, `stale`, âge du snapshot, versions moteur/Bridge, compatibilité et capacités.
+2. Appeler `operon_validate` et distinguer erreurs, avertissements et doublons.
+3. Vérifier si l’incident concerne le Bridge, le moteur, l’index, le cache, une capacité, une version ou une donnée malformée.
+4. Reproduire sur une lecture bornée avant d’accuser le volume global.
+5. Mesurer toute affirmation de performance sur la même requête, le même périmètre et le même état de cache.
+
+## Documentation publique utile
+
+- `docs/operon-local-validation.md`
+- `docs/operon-mcp-contract.md`
+- `docs/kairelys-cutover.fr.md`
+- `plugins/obsidian-operon-bridge/README.md`
+
+Les versions réellement chargées viennent du runtime, pas d’une documentation statique.
+
+## Garde-fous
+
+- Runtime stale/non-live : diagnostic seulement.
+- Une validation sans violation ne prouve pas la performance.
+- Ne pas réindexer, réinstaller ou effectuer un rollback sans sauvegarde et validation explicite.
+- Après correction, rejouer le même test et rapporter le delta mesuré.

--- a/scripts/test-elysia-task-profile.mjs
+++ b/scripts/test-elysia-task-profile.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import Ajv2020 from "ajv/dist/2020.js";
+import { load as parseYaml } from "js-yaml";
 
 const profileUrl = new URL("../profiles/elysia-tasks/v1/profile.json", import.meta.url);
 const schemaUrl = new URL("../profiles/elysia-tasks/v1/schema.json", import.meta.url);
@@ -26,4 +27,68 @@ for (const testCase of rejectedProfiles) {
   assert.equal(validate(candidate), false, `${testCase.name} should be rejected`);
 }
 
-console.log(`ÉLYSIA task profile schema tests passed: ${rejectedProfiles.length + 1} assertions`);
+const skillUrl = new URL(
+  "../profiles/elysia-tasks/skills/elysia-task-gouverneur/SKILL.md",
+  import.meta.url,
+);
+const skill = await readFile(skillUrl, "utf8");
+const frontmatterMatch = skill.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
+assert.ok(frontmatterMatch, "public task skill must have YAML frontmatter");
+const frontmatter = parseYaml(frontmatterMatch[1]);
+
+assert.equal(frontmatter.name, "elysia-task-gouverneur");
+assert.equal(frontmatter.metadata.version, "1.0.0");
+assert.equal(frontmatter.metadata.skill_structure, "graph");
+assert.equal(frontmatter.metadata.portability_class, "profile-bound-portable");
+assert.equal(frontmatter.metadata.profile_id, profile.profileId);
+assert.equal(frontmatter.metadata.profile_schema_version, profile.schemaVersion);
+assert.equal(frontmatter.metadata.reference_gate, true);
+
+const requiredSkillTokens = [
+  "operon_get_configuration",
+  "operon_status",
+  "expectedRevision",
+  "idempotencyKey",
+  "references_ouvertes",
+  "module_route",
+  "etape_pipeline_en_cours",
+  "sortie_finale_autorisee",
+  "apply_propose: aucun",
+  "Lire seulement `SKILL.md` ne compte pas comme usage complet",
+];
+for (const token of requiredSkillTokens) {
+  assert.ok(skill.includes(token), `public task skill is missing ${token}`);
+}
+
+const markdownLinks = [...skill.matchAll(/\]\(([^)]+)\)/g)].map(match => match[1]);
+const referenceLinks = markdownLinks.filter(link => link.startsWith("references/"));
+assert.equal(new Set(referenceLinks).size, 6, "public task skill must expose six graph modules");
+for (const link of markdownLinks) {
+  await readFile(new URL(link, skillUrl), "utf8");
+}
+
+const publicSkillFiles = [
+  skill,
+  ...await Promise.all(
+    [...new Set(referenceLinks)].map(link => readFile(new URL(link, skillUrl), "utf8")),
+  ),
+];
+const publicSkillCorpus = publicSkillFiles.join("\n");
+const forbiddenPrivateMarkers = [
+  /\b[A-Z]:\\/,
+  /\/Users\//,
+  /\/home\//,
+  /\.agents[\\/]/,
+  /\bMike\b/,
+  /Micka[eë]l/,
+  /Efforts\/Domaines/,
+  /SOP — Gouvernance Tasks/,
+  /Standard — Usage Tasks/,
+];
+for (const marker of forbiddenPrivateMarkers) {
+  assert.equal(marker.test(publicSkillCorpus), false, `private marker leaked: ${marker}`);
+}
+
+console.log(
+  `ÉLYSIA task profile and public skill tests passed: ${rejectedProfiles.length + 1} profile assertions, 6 skill modules`,
+);


### PR DESCRIPTION
## What changed

- publishes `elysia-task-gouverneur` 1.0.0 under the existing public ÉLYSIA Tasks profile
- adds six graph modules for safe task operations, audits, project lifecycle, runtime health and output proof
- documents installation and the intentional private-runtime/public-distribution split
- updates the English and French MCP documentation for Kairélys 2.5.3 or compatible Operon engines
- extends the profile test to validate frontmatter, graph links, required safety tokens and private-marker exclusion

## Why

The public task profile already defines portable workflow and filter IDs, but agents still lacked a distributable operating skill. This adds the behavior layer without publishing a vault configuration, private canon, task content or machine-specific path.

## Safety and portability

- no absolute vault or user paths
- no real task or `operonId`
- no private SOP or Standard dependency
- stable IDs and live configuration instead of localized labels
- no raw Markdown mutation path
- fail-closed behavior for stale runtimes, missing capabilities and missing references
- `expectedRevision`, `idempotencyKey`, dry-run and human apply gate

## Validation

- `quick_validate.py`: PASS
- `validate_skill_graph_codex.py`: PASS
- `npm run test:profiles`: PASS
- `npm run test:runtime`: PASS across all configured runtime smoke modes
- `npm pack --dry-run --json`: PASS; all seven skill files included
- `git diff --check`: PASS
