### PR TITLE
docs: preserve automation compatibility across Kairélys and Operon

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -23,4 +23,6 @@ jobs:
       - run: npm ci
       - run: npm run test:runtime
       - run: npm run test:profiles
+      - if: runner.os == 'Windows'
+        run: npm run test:migrations:windows
       - run: npm pack --dry-run

--- a/docs/kairelys-cutover.fr.md
+++ b/docs/kairelys-cutover.fr.md
@@ -52,12 +52,25 @@ Kairélys est encore actif.
 
 ## Rollback
 
-1. Désactiver Kairélys.
-2. Réactiver Operon.
-3. Recharger le Bridge.
-4. Recharger les plugins d’automatisation concernés ; le fallback `operon` doit reprendre sans modifier les scripts.
-5. Vérifier `operon_status` et la configuration.
+Quand Operon officiel expose l’API publique V1 compatible, préparer son build ou son dossier de release,
+puis exécuter d’abord le retour en dry-run :
 
-Les tâches ne nécessitent aucune reconversion : leur format reste celui d’Operon. Si un retour
-intervient après des modifications de réglages dans Kairélys, exporter ou recopier explicitement la
-configuration voulue avant de reprendre Operon.
+```powershell
+pwsh -File scripts/migrate-kairelys-to-operon.ps1 `
+  -VaultPath "F:\OBSIDIAN\ÉLYSIA" `
+  -OperonBuildPath "C:\chemin\vers\operon-officiel"
+```
+
+Le plan retourne le hash SHA-256 de `kairelys/data.json`. Pour appliquer :
+
+1. Désactiver Kairélys et vérifier qu’Operon est également désactivé.
+2. Relancer le script avec `-Apply` et `-ExpectedSourceDataSha256`.
+3. Activer Operon.
+4. Recharger le Bridge.
+5. Recharger les plugins d’automatisation concernés ; le fallback `operon` doit reprendre sans modifier les scripts.
+6. Vérifier `operon_status`, `operon_get_configuration`, `operon_validate`, le nombre de tâches et la signature des réglages.
+
+Le script sauvegarde tout dossier Operon existant dans `.obsidian/plugins/.optimike-backups/`,
+transfère les réglages et états durables modifiés sous Kairélys, et laisse `runtime/` ainsi que `cache/`
+être reconstruits. Les tâches ne nécessitent aucune reconversion : leur Markdown et leurs `operonId`
+restent inchangés.

--- a/docs/kairelys-cutover.fr.md
+++ b/docs/kairelys-cutover.fr.md
@@ -5,6 +5,18 @@ La première version distribuée est Kairélys `2.5.1`, basée sur Operon `2.5.0
 Kairélys utilise un identifiant Obsidian distinct (`kairelys`). Les tâches restent dans le Markdown
 et conservent leurs `operonId`; seuls le plugin, ses réglages et son état durable changent de dossier.
 
+Les automatisations locales Obsidian ne sont pas migrées par le changement de dossier. Un script
+QuickAdd, Templater ou CustomJS qui accède directement à `app.plugins.plugins.operon` doit résoudre
+`kairelys` en priorité et conserver `operon` comme fallback :
+
+```js
+const plugins = app.plugins?.plugins;
+const taskEngine = [plugins?.kairelys, plugins?.operon]
+  .find((plugin) => plugin?.api?.version === "1");
+```
+
+Les commandes MCP restent dans le namespace stable `operon_*`.
+
 ## Ce qui est transféré
 
 - `data.json` : réglages, langue, pipelines, statuts, priorités, key mappings et profils d’interface ;
@@ -32,6 +44,7 @@ précondition.
 4. Recharger `optimike-operon-bridge`.
 5. Vérifier `operon_status`, puis `operon_get_configuration`.
 6. Confirmer le même pipeline, les mêmes statuts, priorités, key mappings et nombre de tâches.
+7. Recharger les plugins d’automatisation concernés et tester une capture sans dépendre d’un libellé visible.
 
 Le script sauvegarde tout dossier Kairélys existant dans
 `.obsidian/plugins/.optimike-backups/`. Il n’active aucun plugin et refuse d’écrire si Operon ou
@@ -42,7 +55,8 @@ Kairélys est encore actif.
 1. Désactiver Kairélys.
 2. Réactiver Operon.
 3. Recharger le Bridge.
-4. Vérifier `operon_status` et la configuration.
+4. Recharger les plugins d’automatisation concernés ; le fallback `operon` doit reprendre sans modifier les scripts.
+5. Vérifier `operon_status` et la configuration.
 
 Les tâches ne nécessitent aucune reconversion : leur format reste celui d’Operon. Si un retour
 intervient après des modifications de réglages dans Kairélys, exporter ou recopier explicitement la

--- a/docs/kairelys-cutover.fr.md
+++ b/docs/kairelys-cutover.fr.md
@@ -11,12 +11,14 @@ QuickAdd, Templater ou CustomJS qui accède directement à `app.plugins.plugins.
 
 ```js
 const plugins = app.plugins?.plugins;
-const taskEngines = [plugins?.kairelys, plugins?.operon]
-  .filter((plugin) => plugin?.api?.version === "1");
-if (taskEngines.length !== 1) {
-  throw new Error(`Un moteur de tâches V1 doit être actif, trouvé : ${taskEngines.length}.`);
+const loadedTaskEngines = [plugins?.kairelys, plugins?.operon].filter(Boolean);
+if (loadedTaskEngines.length !== 1) {
+  throw new Error(`Un seul moteur de tâches doit être chargé, trouvé : ${loadedTaskEngines.length}.`);
 }
-const [taskEngine] = taskEngines;
+const [taskEngine] = loadedTaskEngines;
+if (taskEngine.api?.version !== "1") {
+  throw new Error("Le moteur chargé n’expose pas la Public API V1.");
+}
 ```
 
 Les commandes MCP restent dans le namespace stable `operon_*`. L’automatisation refuse donc le

--- a/docs/kairelys-cutover.fr.md
+++ b/docs/kairelys-cutover.fr.md
@@ -39,7 +39,8 @@ pwsh -File scripts/migrate-operon-to-kairelys.ps1 `
 ```
 
 Le plan affiche le hash SHA-256 de `operon/data.json`. Pour l’application, réutiliser ce hash comme
-précondition.
+précondition. Le dossier de build doit rester extérieur à `.obsidian/plugins/kairelys`, car la cible
+existante peut être déplacée vers la sauvegarde pendant l’application.
 
 ## Application
 
@@ -67,6 +68,9 @@ pwsh -File scripts/migrate-kairelys-to-operon.ps1 `
 ```
 
 Le plan retourne le hash SHA-256 de `kairelys/data.json`. Pour appliquer :
+
+Le dossier de build officiel doit rester extérieur à `.obsidian/plugins/operon` ; le dry-run expose
+`buildPathSafeForApply` et l’application refuse une source située dans la cible qu’elle remplace.
 
 1. Désactiver Kairélys et vérifier qu’Operon est également désactivé.
 2. Relancer le script avec `-Apply` et `-ExpectedSourceDataSha256`.

--- a/docs/kairelys-cutover.fr.md
+++ b/docs/kairelys-cutover.fr.md
@@ -11,11 +11,16 @@ QuickAdd, Templater ou CustomJS qui accède directement à `app.plugins.plugins.
 
 ```js
 const plugins = app.plugins?.plugins;
-const taskEngine = [plugins?.kairelys, plugins?.operon]
-  .find((plugin) => plugin?.api?.version === "1");
+const taskEngines = [plugins?.kairelys, plugins?.operon]
+  .filter((plugin) => plugin?.api?.version === "1");
+if (taskEngines.length !== 1) {
+  throw new Error(`Un moteur de tâches V1 doit être actif, trouvé : ${taskEngines.length}.`);
+}
+const [taskEngine] = taskEngines;
 ```
 
-Les commandes MCP restent dans le namespace stable `operon_*`.
+Les commandes MCP restent dans le namespace stable `operon_*`. L’automatisation refuse donc le
+double chargement, comme le Bridge, au lieu de choisir silencieusement le premier moteur.
 
 ## Ce qui est transféré
 

--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
     "check:operon": "npm run build && npm run test:operon-contract && npm run test:operon-service && npm --prefix plugins/obsidian-operon-bridge run check",
     "smoke:operon-mutations": "node scripts/smoke-operon-mutations.mjs",
     "smoke:operon-rich-mutations": "node scripts/smoke-operon-rich-mutations.mjs",
-    "test:profiles": "node scripts/test-elysia-task-profile.mjs"
+    "test:profiles": "node scripts/test-elysia-task-profile.mjs",
+    "test:migrations:windows": "pwsh -NoProfile -File scripts/test-task-engine-migrations.ps1"
   },
   "dependencies": {
     "@hono/node-server": "^1.19.14",

--- a/profiles/elysia-tasks/README.fr.md
+++ b/profiles/elysia-tasks/README.fr.md
@@ -19,6 +19,22 @@ Le profil est français par défaut. Les automatisations doivent utiliser les ID
 
 Changer les libellés d’un pipeline déjà utilisé modifie les valeurs visibles stockées dans les tâches. Une migration FR ↔ EN doit donc être faite comme une migration de données : inventaire, dry-run, transitions par `statusId`, validation puis application. Changer seulement la langue de l’interface Kairélys ne nécessite pas de réécrire les tâches.
 
+## Automatisations Obsidian
+
+Le profil déclare `kairelys` comme plugin préféré et `operon` comme fallback. Une automatisation
+QuickAdd, Templater ou CustomJS doit appliquer la même résolution et vérifier l’API publique V1,
+plutôt que figer un seul identifiant de plugin :
+
+```js
+const plugins = app.plugins?.plugins;
+const taskEngine = [plugins?.kairelys, plugins?.operon]
+  .find((plugin) => plugin?.api?.version === "1");
+```
+
+Les automatisations utilisent ensuite les IDs stables du profil, notamment
+`st_project_brainstorming` pour une capture à clarifier. Elles ne doivent dépendre ni du libellé
+français/anglais, ni de l’ordre visuel des statuts.
+
 ## Templates
 
 ÉLYSIA utilise le template minimal natif du pipeline. Il doit ajouter uniquement les champs canoniques nécessaires : `operonId`, création, modification, statut et priorité. Les conventions de projet, de création ou de note quotidienne restent la responsabilité des templates ÉLYSIA/Obsidian ; elles ne doivent pas être recopiées dans un template de tâche Kairélys.

--- a/profiles/elysia-tasks/README.fr.md
+++ b/profiles/elysia-tasks/README.fr.md
@@ -41,6 +41,19 @@ français/anglais, ni de l’ordre visuel des statuts.
 
 Cette séparation évite qu’une modification de template Obsidian change silencieusement la sémantique MCP des tâches.
 
+## Bascule Kairélys ↔ Operon
+
+Le format Markdown et les `operonId` restent communs aux deux moteurs. La procédure complète se
+trouve dans [`docs/kairelys-cutover.fr.md`](../../docs/kairelys-cutover.fr.md) avec deux scripts
+symétriques :
+
+- `scripts/migrate-operon-to-kairelys.ps1` pour installer le fork temporaire ;
+- `scripts/migrate-kairelys-to-operon.ps1` pour revenir à Operon officiel après intégration de l’API publique V1.
+
+Les deux chemins commencent par un dry-run, utilisent le hash de `data.json` comme précondition,
+sauvegardent la cible existante et transfèrent uniquement les réglages et états durables. Les tâches
+elles-mêmes ne sont ni copiées ni reconverties.
+
 ## Application
 
 La V1 est un contrat documenté et validable, pas un importeur aveugle. Avant application dans un coffre :

--- a/profiles/elysia-tasks/README.fr.md
+++ b/profiles/elysia-tasks/README.fr.md
@@ -27,13 +27,19 @@ plutôt que figer un seul identifiant de plugin :
 
 ```js
 const plugins = app.plugins?.plugins;
-const taskEngine = [plugins?.kairelys, plugins?.operon]
-  .find((plugin) => plugin?.api?.version === "1");
+const taskEngines = [plugins?.kairelys, plugins?.operon]
+  .filter((plugin) => plugin?.api?.version === "1");
+if (taskEngines.length !== 1) {
+  throw new Error(`Un moteur de tâches V1 doit être actif, trouvé : ${taskEngines.length}.`);
+}
+const [taskEngine] = taskEngines;
 ```
 
 Les automatisations utilisent ensuite les IDs stables du profil, notamment
 `st_project_brainstorming` pour une capture à clarifier. Elles ne doivent dépendre ni du libellé
-français/anglais, ni de l’ordre visuel des statuts.
+français/anglais, ni de l’ordre visuel des statuts. Elles doivent refuser d’agir si Kairélys et
+Operon sont tous les deux chargés, conformément au contrat `singleOwnerRequired` du profil et au
+comportement du Bridge.
 
 ## Templates
 

--- a/profiles/elysia-tasks/README.fr.md
+++ b/profiles/elysia-tasks/README.fr.md
@@ -27,12 +27,14 @@ plutôt que figer un seul identifiant de plugin :
 
 ```js
 const plugins = app.plugins?.plugins;
-const taskEngines = [plugins?.kairelys, plugins?.operon]
-  .filter((plugin) => plugin?.api?.version === "1");
-if (taskEngines.length !== 1) {
-  throw new Error(`Un moteur de tâches V1 doit être actif, trouvé : ${taskEngines.length}.`);
+const loadedTaskEngines = [plugins?.kairelys, plugins?.operon].filter(Boolean);
+if (loadedTaskEngines.length !== 1) {
+  throw new Error(`Un seul moteur de tâches doit être chargé, trouvé : ${loadedTaskEngines.length}.`);
 }
-const [taskEngine] = taskEngines;
+const [taskEngine] = loadedTaskEngines;
+if (taskEngine.api?.version !== "1") {
+  throw new Error("Le moteur chargé n’expose pas la Public API V1.");
+}
 ```
 
 Les automatisations utilisent ensuite les IDs stables du profil, notamment

--- a/scripts/migrate-kairelys-to-operon.ps1
+++ b/scripts/migrate-kairelys-to-operon.ps1
@@ -1,0 +1,140 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string] $VaultPath,
+
+  [Parameter(Mandatory = $true)]
+  [string] $OperonBuildPath,
+
+  [string] $ExpectedSourceDataSha256 = "",
+
+  [switch] $Apply
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-ExistingDirectory([string] $Path, [string] $Label) {
+  $resolved = Resolve-Path -LiteralPath $Path -ErrorAction Stop
+  $item = Get-Item -LiteralPath $resolved.Path
+  if (-not $item.PSIsContainer) {
+    throw "$Label is not a directory: $($resolved.Path)"
+  }
+  return $resolved.Path
+}
+
+function Assert-ChildPath([string] $Parent, [string] $Child, [string] $Label) {
+  $parentFull = [System.IO.Path]::GetFullPath($Parent).TrimEnd('\') + '\'
+  $childFull = [System.IO.Path]::GetFullPath($Child)
+  if (-not $childFull.StartsWith($parentFull, [System.StringComparison]::OrdinalIgnoreCase)) {
+    throw "$Label escapes the intended parent directory: $childFull"
+  }
+}
+
+$vault = Resolve-ExistingDirectory $VaultPath "VaultPath"
+$build = Resolve-ExistingDirectory $OperonBuildPath "OperonBuildPath"
+$pluginsRoot = Join-Path $vault ".obsidian\plugins"
+$sourceRoot = Join-Path $pluginsRoot "kairelys"
+$targetRoot = Join-Path $pluginsRoot "operon"
+$enabledPath = Join-Path $vault ".obsidian\community-plugins.json"
+
+Assert-ChildPath $vault $pluginsRoot "pluginsRoot"
+Assert-ChildPath $pluginsRoot $sourceRoot "sourceRoot"
+Assert-ChildPath $pluginsRoot $targetRoot "targetRoot"
+
+if (-not (Test-Path -LiteralPath $sourceRoot -PathType Container)) {
+  throw "Kairélys source plugin folder not found: $sourceRoot"
+}
+
+$requiredBuildFiles = @("main.js", "manifest.json", "styles.css")
+foreach ($name in $requiredBuildFiles) {
+  $candidate = Join-Path $build $name
+  if (-not (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+    throw "Operon build file missing: $candidate"
+  }
+}
+
+$manifest = Get-Content -Raw -LiteralPath (Join-Path $build "manifest.json") | ConvertFrom-Json
+if ($manifest.id -ne "operon" -or $manifest.name -ne "Operon") {
+  throw "Build manifest must identify Operon (id=operon, name=Operon)."
+}
+
+$sourceDataPath = Join-Path $sourceRoot "data.json"
+if (-not (Test-Path -LiteralPath $sourceDataPath -PathType Leaf)) {
+  throw "Kairélys data.json not found: $sourceDataPath"
+}
+$null = Get-Content -Raw -LiteralPath $sourceDataPath | ConvertFrom-Json
+$sourceDataHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $sourceDataPath).Hash
+if ($ExpectedSourceDataSha256 -and $sourceDataHash -ne $ExpectedSourceDataSha256.ToUpperInvariant()) {
+  throw "Kairélys data.json changed: expected $ExpectedSourceDataSha256, found $sourceDataHash."
+}
+
+$enabled = @()
+if (Test-Path -LiteralPath $enabledPath -PathType Leaf) {
+  $enabled = @(Get-Content -Raw -LiteralPath $enabledPath | ConvertFrom-Json)
+}
+$activeEngines = @($enabled | Where-Object { $_ -in @("operon", "kairelys") })
+
+$durableEntries = @("data.json", "data", "state") | Where-Object {
+  Test-Path -LiteralPath (Join-Path $sourceRoot $_)
+}
+$excludedEntries = @("runtime", "cache")
+
+$plan = [ordered]@{
+  mode = if ($Apply) { "apply" } else { "dry-run" }
+  vault = $vault
+  source = $sourceRoot
+  target = $targetRoot
+  build = $build
+  sourceDataSha256 = $sourceDataHash
+  buildVersion = [string] $manifest.version
+  durableEntries = $durableEntries
+  excludedRebuildableEntries = $excludedEntries
+  activeTaskEngines = $activeEngines
+  targetExists = Test-Path -LiteralPath $targetRoot
+}
+
+if (-not $Apply) {
+  $plan | ConvertTo-Json -Depth 5
+  exit 0
+}
+
+if ($activeEngines.Count -gt 0) {
+  throw "Disable Kairélys and Operon before applying migration. Active: $($activeEngines -join ', ')"
+}
+
+$timestamp = Get-Date -Format "yyyyMMdd-HHmmss"
+$backupRoot = Join-Path $pluginsRoot ".optimike-backups\operon-return-$timestamp"
+Assert-ChildPath $pluginsRoot $backupRoot "backupRoot"
+New-Item -ItemType Directory -Path $backupRoot -Force | Out-Null
+
+if (Test-Path -LiteralPath $targetRoot) {
+  $targetBackup = Join-Path $backupRoot "previous-operon"
+  Move-Item -LiteralPath $targetRoot -Destination $targetBackup
+}
+
+New-Item -ItemType Directory -Path $targetRoot -Force | Out-Null
+foreach ($name in $requiredBuildFiles) {
+  Copy-Item -LiteralPath (Join-Path $build $name) -Destination (Join-Path $targetRoot $name)
+}
+foreach ($name in $durableEntries) {
+  Copy-Item -LiteralPath (Join-Path $sourceRoot $name) -Destination (Join-Path $targetRoot $name) -Recurse
+}
+
+$targetManifest = Get-Content -Raw -LiteralPath (Join-Path $targetRoot "manifest.json") | ConvertFrom-Json
+$targetDataPath = Join-Path $targetRoot "data.json"
+$null = Get-Content -Raw -LiteralPath $targetDataPath | ConvertFrom-Json
+$targetDataHash = (Get-FileHash -Algorithm SHA256 -LiteralPath $targetDataPath).Hash
+if ($targetManifest.id -ne "operon" -or $targetDataHash -ne $sourceDataHash) {
+  throw "Post-copy validation failed. The recoverable backup is at $backupRoot"
+}
+
+[ordered]@{
+  status = "applied"
+  target = $targetRoot
+  backup = $backupRoot
+  sourceDataSha256 = $sourceDataHash
+  targetDataSha256 = $targetDataHash
+  copiedDurableEntries = $durableEntries
+  excludedRebuildableEntries = $excludedEntries
+  nextAction = "Enable operon, reload optimike-operon-bridge, then validate through operon_status and operon_get_configuration."
+} | ConvertTo-Json -Depth 5

--- a/scripts/migrate-kairelys-to-operon.ps1
+++ b/scripts/migrate-kairelys-to-operon.ps1
@@ -41,6 +41,12 @@ Assert-ChildPath $vault $pluginsRoot "pluginsRoot"
 Assert-ChildPath $pluginsRoot $sourceRoot "sourceRoot"
 Assert-ChildPath $pluginsRoot $targetRoot "targetRoot"
 
+$buildFull = [System.IO.Path]::GetFullPath($build).TrimEnd('\')
+$targetFull = [System.IO.Path]::GetFullPath($targetRoot).TrimEnd('\')
+$buildPathSafeForApply =
+  $buildFull -ne $targetFull -and
+  -not $buildFull.StartsWith($targetFull + '\', [System.StringComparison]::OrdinalIgnoreCase)
+
 if (-not (Test-Path -LiteralPath $sourceRoot -PathType Container)) {
   throw "Kairélys source plugin folder not found: $sourceRoot"
 }
@@ -91,6 +97,7 @@ $plan = [ordered]@{
   excludedRebuildableEntries = $excludedEntries
   activeTaskEngines = $activeEngines
   targetExists = Test-Path -LiteralPath $targetRoot
+  buildPathSafeForApply = $buildPathSafeForApply
 }
 
 if (-not $Apply) {
@@ -100,6 +107,9 @@ if (-not $Apply) {
 
 if ($activeEngines.Count -gt 0) {
   throw "Disable Kairélys and Operon before applying migration. Active: $($activeEngines -join ', ')"
+}
+if (-not $buildPathSafeForApply) {
+  throw "OperonBuildPath must be outside the target plugin folder before applying: $targetRoot"
 }
 
 $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"

--- a/scripts/migrate-operon-to-kairelys.ps1
+++ b/scripts/migrate-operon-to-kairelys.ps1
@@ -41,6 +41,12 @@ Assert-ChildPath $vault $pluginsRoot "pluginsRoot"
 Assert-ChildPath $pluginsRoot $sourceRoot "sourceRoot"
 Assert-ChildPath $pluginsRoot $targetRoot "targetRoot"
 
+$buildFull = [System.IO.Path]::GetFullPath($build).TrimEnd('\')
+$targetFull = [System.IO.Path]::GetFullPath($targetRoot).TrimEnd('\')
+$buildPathSafeForApply =
+  $buildFull -ne $targetFull -and
+  -not $buildFull.StartsWith($targetFull + '\', [System.StringComparison]::OrdinalIgnoreCase)
+
 if (-not (Test-Path -LiteralPath $sourceRoot -PathType Container)) {
   throw "Operon source plugin folder not found: $sourceRoot"
 }
@@ -91,6 +97,7 @@ $plan = [ordered]@{
   excludedRebuildableEntries = $excludedEntries
   activeTaskEngines = $activeEngines
   targetExists = Test-Path -LiteralPath $targetRoot
+  buildPathSafeForApply = $buildPathSafeForApply
 }
 
 if (-not $Apply) {
@@ -100,6 +107,9 @@ if (-not $Apply) {
 
 if ($activeEngines.Count -gt 0) {
   throw "Disable Operon and Kairélys before applying migration. Active: $($activeEngines -join ', ')"
+}
+if (-not $buildPathSafeForApply) {
+  throw "KairelysBuildPath must be outside the target plugin folder before applying: $targetRoot"
 }
 
 $timestamp = Get-Date -Format "yyyyMMdd-HHmmss"

--- a/scripts/test-task-engine-migrations.ps1
+++ b/scripts/test-task-engine-migrations.ps1
@@ -1,0 +1,168 @@
+[CmdletBinding()]
+param()
+
+$ErrorActionPreference = "Stop"
+
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$forwardScript = Join-Path $PSScriptRoot "migrate-operon-to-kairelys.ps1"
+$reverseScript = Join-Path $PSScriptRoot "migrate-kairelys-to-operon.ps1"
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) (
+  "optimike-task-engine-migrations-" + [guid]::NewGuid().ToString("N")
+)
+$utf8 = [System.Text.UTF8Encoding]::new($false)
+
+function Assert-True([bool] $Condition, [string] $Message) {
+  if (-not $Condition) { throw $Message }
+}
+
+function Write-Utf8([string] $Path, [string] $Content) {
+  $parent = Split-Path -Parent $Path
+  if ($parent) { New-Item -ItemType Directory -Path $parent -Force | Out-Null }
+  [System.IO.File]::WriteAllText($Path, $Content, $utf8)
+}
+
+function New-PluginBuild(
+  [string] $Path,
+  [string] $Id,
+  [string] $Name,
+  [string] $Version
+) {
+  New-Item -ItemType Directory -Path $Path -Force | Out-Null
+  Write-Utf8 (Join-Path $Path "manifest.json") (
+    [ordered]@{ id = $Id; name = $Name; version = $Version; minAppVersion = "1.6.0" } |
+      ConvertTo-Json -Compress
+  )
+  Write-Utf8 (Join-Path $Path "main.js") "module.exports = {};"
+  Write-Utf8 (Join-Path $Path "styles.css") "/* fixture */"
+}
+
+function New-DurablePlugin(
+  [string] $Path,
+  [string] $Id,
+  [string] $Name,
+  [string] $Version,
+  [string] $Marker
+) {
+  New-PluginBuild $Path $Id $Name $Version
+  Write-Utf8 (Join-Path $Path "data.json") (
+    [ordered]@{ settings = [ordered]@{ language = "fr" }; marker = $Marker } |
+      ConvertTo-Json -Compress
+  )
+  Write-Utf8 (Join-Path $Path "data\fixture.json") "{`"marker`":`"$Marker-data`"}"
+  Write-Utf8 (Join-Path $Path "state\fixture.json") "{`"marker`":`"$Marker-state`"}"
+  Write-Utf8 (Join-Path $Path "runtime\ignored.json") "{`"ignored`":true}"
+  Write-Utf8 (Join-Path $Path "cache\ignored.json") "{`"ignored`":true}"
+}
+
+function Invoke-MigrationJson([string] $Script, [hashtable] $Arguments) {
+  $lines = & $Script @Arguments
+  return (($lines -join [Environment]::NewLine) | ConvertFrom-Json)
+}
+
+function Test-ReverseMigration([string] $Root) {
+  $vault = Join-Path $Root "vault"
+  $plugins = Join-Path $vault ".obsidian\plugins"
+  $source = Join-Path $plugins "kairelys"
+  $target = Join-Path $plugins "operon"
+  $build = Join-Path $Root "official-operon-build"
+
+  New-DurablePlugin $source "kairelys" "Kairélys" "2.5.3" "reverse-source"
+  New-DurablePlugin $target "operon" "Operon" "2.5.0" "previous-operon"
+  New-PluginBuild $build "operon" "Operon" "2.6.0"
+
+  $sourceHash = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $source "data.json")).Hash
+  $result = Invoke-MigrationJson $reverseScript @{
+    VaultPath = $vault
+    OperonBuildPath = $build
+    ExpectedSourceDataSha256 = $sourceHash
+    Apply = $true
+  }
+
+  $targetHash = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $target "data.json")).Hash
+  $manifest = Get-Content -Raw -LiteralPath (Join-Path $target "manifest.json") | ConvertFrom-Json
+  Assert-True ($result.status -eq "applied") "Reverse migration did not report applied."
+  Assert-True ($manifest.id -eq "operon") "Reverse migration installed the wrong plugin ID."
+  Assert-True ($targetHash -eq $sourceHash) "Reverse migration changed data.json."
+  Assert-True (Test-Path -LiteralPath (Join-Path $result.backup "previous-operon")) "Reverse migration backup is missing."
+  Assert-True (Test-Path -LiteralPath (Join-Path $target "data\fixture.json")) "Reverse migration omitted durable data/."
+  Assert-True (Test-Path -LiteralPath (Join-Path $target "state\fixture.json")) "Reverse migration omitted durable state/."
+  Assert-True (-not (Test-Path -LiteralPath (Join-Path $target "runtime\ignored.json"))) "Reverse migration copied runtime/."
+  Assert-True (-not (Test-Path -LiteralPath (Join-Path $target "cache\ignored.json"))) "Reverse migration copied cache/."
+
+  Write-Utf8 (Join-Path $vault ".obsidian\community-plugins.json") '["operon"]'
+  $hashBeforeActiveRefusal = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $target "data.json")).Hash
+  $activeBlocked = $false
+  try {
+    Invoke-MigrationJson $reverseScript @{
+      VaultPath = $vault
+      OperonBuildPath = $build
+      ExpectedSourceDataSha256 = $sourceHash
+      Apply = $true
+    } | Out-Null
+  } catch {
+    $activeBlocked = $_.Exception.Message -like "*Disable Kairélys and Operon*"
+  }
+  $hashAfterActiveRefusal = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $target "data.json")).Hash
+  Assert-True $activeBlocked "Reverse migration did not reject an active engine."
+  Assert-True ($hashBeforeActiveRefusal -eq $hashAfterActiveRefusal) "Active-engine refusal changed the target."
+
+  Write-Utf8 (Join-Path $vault ".obsidian\community-plugins.json") '[]'
+  $unsafeBlocked = $false
+  try {
+    Invoke-MigrationJson $reverseScript @{
+      VaultPath = $vault
+      OperonBuildPath = $target
+      ExpectedSourceDataSha256 = $sourceHash
+      Apply = $true
+    } | Out-Null
+  } catch {
+    $unsafeBlocked = $_.Exception.Message -like "*must be outside the target plugin folder*"
+  }
+  Assert-True $unsafeBlocked "Reverse migration did not reject an in-target build."
+}
+
+function Test-ForwardMigration([string] $Root) {
+  $vault = Join-Path $Root "vault"
+  $plugins = Join-Path $vault ".obsidian\plugins"
+  $source = Join-Path $plugins "operon"
+  $target = Join-Path $plugins "kairelys"
+  $build = Join-Path $Root "kairelys-build"
+
+  New-DurablePlugin $source "operon" "Operon" "2.5.0" "forward-source"
+  New-DurablePlugin $target "kairelys" "Kairélys" "2.5.2" "previous-kairelys"
+  New-PluginBuild $build "kairelys" "Kairélys" "2.5.3"
+
+  $sourceHash = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $source "data.json")).Hash
+  $result = Invoke-MigrationJson $forwardScript @{
+    VaultPath = $vault
+    KairelysBuildPath = $build
+    ExpectedSourceDataSha256 = $sourceHash
+    Apply = $true
+  }
+
+  $targetHash = (Get-FileHash -Algorithm SHA256 -LiteralPath (Join-Path $target "data.json")).Hash
+  $manifest = Get-Content -Raw -LiteralPath (Join-Path $target "manifest.json") | ConvertFrom-Json
+  Assert-True ($result.status -eq "applied") "Forward migration did not report applied."
+  Assert-True ($manifest.id -eq "kairelys") "Forward migration installed the wrong plugin ID."
+  Assert-True ($targetHash -eq $sourceHash) "Forward migration changed data.json."
+  Assert-True (Test-Path -LiteralPath (Join-Path $result.backup "previous-kairelys")) "Forward migration backup is missing."
+  Assert-True (-not (Test-Path -LiteralPath (Join-Path $target "runtime\ignored.json"))) "Forward migration copied runtime/."
+  Assert-True (-not (Test-Path -LiteralPath (Join-Path $target "cache\ignored.json"))) "Forward migration copied cache/."
+}
+
+try {
+  New-Item -ItemType Directory -Path $tempRoot -Force | Out-Null
+  Test-ReverseMigration (Join-Path $tempRoot "reverse")
+  Test-ForwardMigration (Join-Path $tempRoot "forward")
+  Write-Output "PASS: bidirectional task-engine migrations, backups, durable state, active-engine refusal, and build-path safety"
+} finally {
+  $resolvedTemp = [System.IO.Path]::GetFullPath($tempRoot)
+  $tempParent = [System.IO.Path]::GetFullPath([System.IO.Path]::GetTempPath())
+  $leaf = [System.IO.Path]::GetFileName($resolvedTemp)
+  if (
+    $resolvedTemp.StartsWith($tempParent, [System.StringComparison]::OrdinalIgnoreCase) -and
+    $leaf.StartsWith("optimike-task-engine-migrations-")
+  ) {
+    Remove-Item -LiteralPath $resolvedTemp -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}


### PR DESCRIPTION
## What changed

- document the distinct `kairelys` plugin ID and `operon` fallback for QuickAdd, Templater and CustomJS
- require exactly one loaded task-engine plugin before validating Public API V1; mixed-version dual ownership fails explicitly
- add automation reload/capture checks to cutover and rollback
- add a symmetric `migrate-kairelys-to-operon.ps1` return path with dry-run, hash precondition, backup and post-copy validation
- reject migration builds located inside the plugin target before any target move
- add a Windows CI fixture that applies both migration directions and verifies backups, durable state, excluded caches, active-engine refusal and build-path safety
- explain stable status IDs and reversible engine migration for the public ÉLYSIA task profile

## Why

Kairélys uses a distinct Obsidian plugin ID. Local automations that still read `app.plugins.plugins.operon` fail, while resolvers that silently prefer one engine violate the profile's `singleOwnerRequired` contract. The return to Operon official also needs to preserve settings changed after the initial cutover.

## Validation

- `npm run test:profiles` (8 profile assertions, 7 skill modules)
- `npm run test:runtime`
- `npm run test:migrations:windows`
- `npm pack --dry-run` (both migration scripts and their test included)
- live-vault bidirectional dry-runs: PASS; active engine and `buildPathSafeForApply` reported without writes
- isolated reverse apply: PASS (`manifestId=operon`, hashes match, backup created, `data.json,data,state` copied)
- unsafe in-target build apply: blocked before mutation; existing target hash unchanged
- live QuickAdd resolver: syntax PASS and mixed-version dual-engine guard PASS
- workflow YAML, package JSON and `git diff --check`: PASS