### PR TITLE
Align ÉLYSIA task horizons and fix Bases wikilinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- ÉLYSIA Tasks profile 1.1 with global Inbox, This Week, bounded Now, Backlog, periodic-note leakage detection, and a P90-J admission gate.
+- Public task-governor guidance for distinct dry-run/apply idempotency keys and post-mutation visibility proof.
+- Regression coverage for Obsidian wikilink normalization in the Bases Bridge.
+
+### Fixed
+
+- Bases Bridge now evaluates `collection.contains(link(...))` correctly when frontmatter stores Obsidian wikilinks such as `[[Projets]]`.
+
 ## [2.3.0] - 2026-07-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Bases Bridge now evaluates `collection.contains(link(...))` correctly when frontmatter stores Obsidian wikilinks such as `[[Projets]]`.
+- Bases Bridge now treats the Bases literal `null` as a missing value instead of the string `"null"`, restoring missing-property filters and dependent formulas.
+- Bases Bridge now evaluates bare `file.*`, `note.*`, and `formula.*` truthy references used by negated filters such as `!formula.next_action_ok`.
+- Bases Bridge now warns when a requested view does not exist instead of silently returning an unfiltered view result.
 
 ## [2.3.0] - 2026-07-21
 

--- a/plugins/obsidian-bases-bridge/manifest.json
+++ b/plugins/obsidian-bases-bridge/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "obsidian-bases-bridge",
   "name": "Bases Bridge (REST)",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "minAppVersion": "1.6.0",
   "author": "Optimike",
   "authorUrl": "https://github.com/mickahouan",

--- a/plugins/obsidian-bases-bridge/package-lock.json
+++ b/plugins/obsidian-bases-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "obsidian-bases-bridge",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "obsidian-bases-bridge",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "devDependencies": {
         "esbuild": "^0.25.0"
       }

--- a/plugins/obsidian-bases-bridge/package-lock.json
+++ b/plugins/obsidian-bases-bridge/package-lock.json
@@ -1,0 +1,499 @@
+{
+  "name": "obsidian-bases-bridge",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "obsidian-bases-bridge",
+      "version": "1.0.0",
+      "devDependencies": {
+        "esbuild": "^0.25.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    }
+  }
+}

--- a/plugins/obsidian-bases-bridge/package.json
+++ b/plugins/obsidian-bases-bridge/package.json
@@ -5,9 +5,11 @@
   "type": "module",
   "scripts": {
     "build": "node esbuild.config.mjs",
-    "dev": "node esbuild.config.mjs --watch"
+    "dev": "node esbuild.config.mjs --watch",
+    "test": "node --test src/*.test.mjs",
+    "check": "npm run test && npm run build"
   },
   "devDependencies": {
-    "esbuild": "^0.24.0"
+    "esbuild": "^0.25.0"
   }
 }

--- a/plugins/obsidian-bases-bridge/package.json
+++ b/plugins/obsidian-bases-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "obsidian-bases-bridge",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/obsidian-bases-bridge/src/filter-comparison.mjs
+++ b/plugins/obsidian-bases-bridge/src/filter-comparison.mjs
@@ -1,0 +1,63 @@
+export function parseComparisonLiteral(rawValue) {
+  const raw = String(rawValue ?? "").trim();
+  if (raw === "null") return null;
+  if (/^(true|false)$/i.test(raw)) return /^true$/i.test(raw);
+  if (/^-?\d+(?:\.\d+)?$/.test(raw)) return Number(raw);
+  if (
+    (raw.startsWith('"') && raw.endsWith('"')) ||
+    (raw.startsWith("'") && raw.endsWith("'"))
+  ) {
+    return raw.slice(1, -1);
+  }
+  return raw;
+}
+
+export function compareFilterValues(left, operator, right) {
+  if (left == null || right == null) {
+    if (operator === "=" || operator === "==") return left == null && right == null;
+    if (operator === "!=") return !(left == null && right == null);
+    return false;
+  }
+
+  const leftNumber = typeof left === "number" ? left : Number(left);
+  const rightNumber = typeof right === "number" ? right : Number(right);
+  const bothNumeric = Number.isFinite(leftNumber) && Number.isFinite(rightNumber);
+  const leftComparable = bothNumeric ? leftNumber : String(left);
+  const rightComparable = bothNumeric ? rightNumber : String(right);
+
+  switch (operator) {
+    case "=":
+    case "==":
+      return leftComparable === rightComparable;
+    case "!=":
+      return leftComparable !== rightComparable;
+    case ">":
+      return leftComparable > rightComparable;
+    case "<":
+      return leftComparable < rightComparable;
+    case ">=":
+      return leftComparable >= rightComparable;
+    case "<=":
+      return leftComparable <= rightComparable;
+    default:
+      return false;
+  }
+}
+
+export function isTruthyFilterReference(rawValue) {
+  const raw = String(rawValue ?? "").trim();
+  return (
+    /^[\p{L}\p{N}_-]+$/u.test(raw) ||
+    /^(?:file|note|formula)\.[\p{L}\p{N}_-]+$/u.test(raw)
+  );
+}
+
+export function isTruthyFilterValue(value) {
+  return (
+    value === true ||
+    (typeof value === "string" && value.trim().length > 0) ||
+    (typeof value === "number" && Number.isFinite(value)) ||
+    (Array.isArray(value) && value.length > 0) ||
+    Boolean(value && typeof value === "object" && Object.keys(value).length > 0)
+  );
+}

--- a/plugins/obsidian-bases-bridge/src/filter-comparison.test.mjs
+++ b/plugins/obsidian-bases-bridge/src/filter-comparison.test.mjs
@@ -1,0 +1,38 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  compareFilterValues,
+  isTruthyFilterReference,
+  isTruthyFilterValue,
+  parseComparisonLiteral,
+} from "./filter-comparison.mjs";
+
+test("parses Bases comparison literals", () => {
+  assert.equal(parseComparisonLiteral("null"), null);
+  assert.equal(parseComparisonLiteral("true"), true);
+  assert.equal(parseComparisonLiteral("42"), 42);
+  assert.equal(parseComparisonLiteral('"actif"'), "actif");
+});
+
+test("matches missing frontmatter against null", () => {
+  assert.equal(compareFilterValues(undefined, "==", null), true);
+  assert.equal(compareFilterValues(null, "=", null), true);
+  assert.equal(compareFilterValues(undefined, "!=", null), false);
+  assert.equal(compareFilterValues("actif", "!=", null), true);
+});
+
+test("preserves numeric and string comparisons", () => {
+  assert.equal(compareFilterValues("5", ">=", 4), true);
+  assert.equal(compareFilterValues("actif", "==", "actif"), true);
+  assert.equal(compareFilterValues("sommeil", "!=", "clos"), true);
+});
+
+test("recognizes truthy property and formula references", () => {
+  assert.equal(isTruthyFilterReference("next_action"), true);
+  assert.equal(isTruthyFilterReference("formula.next_action_ok"), true);
+  assert.equal(isTruthyFilterReference("file.path"), true);
+  assert.equal(isTruthyFilterReference("unknown.path"), false);
+  assert.equal(isTruthyFilterValue("Planifier"), true);
+  assert.equal(isTruthyFilterValue(false), false);
+  assert.equal(isTruthyFilterValue(null), false);
+});

--- a/plugins/obsidian-bases-bridge/src/link-normalization.mjs
+++ b/plugins/obsidian-bases-bridge/src/link-normalization.mjs
@@ -1,0 +1,9 @@
+export function normalizeLinkish(value) {
+  let normalized = String(value ?? "").trim();
+  const wikiLink = normalized.match(/^\[\[(.*)\]\]$/);
+  if (wikiLink) normalized = wikiLink[1];
+  normalized = normalized.split("|")[0] ?? normalized;
+  normalized = normalized.split("#")[0] ?? normalized;
+  normalized = normalized.replace(/\.md$/i, "");
+  return normalized.trim();
+}

--- a/plugins/obsidian-bases-bridge/src/link-normalization.test.mjs
+++ b/plugins/obsidian-bases-bridge/src/link-normalization.test.mjs
@@ -1,0 +1,14 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { normalizeLinkish } from "./link-normalization.mjs";
+
+test("normalizes Obsidian wikilinks used by collection.contains(link())", () => {
+  assert.equal(normalizeLinkish("[[Projets]]"), "Projets");
+  assert.equal(normalizeLinkish("[[Projets|Portefeuille]]"), "Projets");
+  assert.equal(normalizeLinkish("[[Projets#Actifs]]"), "Projets");
+});
+
+test("normalizes Markdown paths without damaging plain values", () => {
+  assert.equal(normalizeLinkish("Atlas/Maps/Projets.md"), "Atlas/Maps/Projets");
+  assert.equal(normalizeLinkish("Projets"), "Projets");
+});

--- a/plugins/obsidian-bases-bridge/src/main.ts
+++ b/plugins/obsidian-bases-bridge/src/main.ts
@@ -6,6 +6,7 @@ import {
   parseYaml,
   stringifyYaml,
 } from "obsidian";
+import { normalizeLinkish } from "./link-normalization.mjs";
 
 /** -------- Engine V2 (flag + cache) -------- */
 type EngineRow = Record<string, any>;
@@ -213,16 +214,6 @@ function parseStringListLiteral(inner: string): string[] {
     if (v) values.push(v);
   }
   return values;
-}
-
-function normalizeLinkish(value: string): string {
-  let v = String(value ?? "").trim();
-  const wiki = v.match(/^\\[\\[(.*)\\]\\]$/);
-  if (wiki) v = wiki[1];
-  v = v.split("|")[0] ?? v;
-  v = v.split("#")[0] ?? v;
-  v = v.replace(/\\.md$/i, "");
-  return v.trim();
 }
 
 function splitTopLevelCommas(input: string): string[] {

--- a/plugins/obsidian-bases-bridge/src/main.ts
+++ b/plugins/obsidian-bases-bridge/src/main.ts
@@ -6,6 +6,12 @@ import {
   parseYaml,
   stringifyYaml,
 } from "obsidian";
+import {
+  compareFilterValues,
+  isTruthyFilterReference,
+  isTruthyFilterValue,
+  parseComparisonLiteral,
+} from "./filter-comparison.mjs";
 import { normalizeLinkish } from "./link-normalization.mjs";
 
 /** -------- Engine V2 (flag + cache) -------- */
@@ -879,46 +885,15 @@ export default class BasesBridgePlugin extends Plugin {
       const rightRaw = opMatch[3].trim();
 
       const left = this.getValueForRef(file, leftRef, schema);
-      let right: any = stripQuotes(rightRaw);
-      if (/^(true|false)$/i.test(rightRaw)) right = /^true$/i.test(rightRaw);
-      else if (/^-?\d+(\.\d+)?$/.test(rightRaw)) right = Number(rightRaw);
-
-      const leftNum = typeof left === "number" ? left : Number(left);
-      const rightNum = typeof right === "number" ? right : Number(right);
-      const bothNumeric = Number.isFinite(leftNum) && Number.isFinite(rightNum);
-      const numericOp = op === ">" || op === "<" || op === ">=" || op === "<=";
-      if (numericOp && typeof right === "number" && !Number.isFinite(leftNum)) {
-        return { ok: false, warnings };
-      }
-
-      switch (op) {
-        case "==":
-        case "=":
-          return { ok: bothNumeric ? leftNum === rightNum : String(left) === String(right), warnings };
-        case "!=":
-          return { ok: bothNumeric ? leftNum !== rightNum : String(left) !== String(right), warnings };
-        case ">":
-          return { ok: bothNumeric ? leftNum > rightNum : String(left) > String(right), warnings };
-        case "<":
-          return { ok: bothNumeric ? leftNum < rightNum : String(left) < String(right), warnings };
-        case ">=":
-          return { ok: bothNumeric ? leftNum >= rightNum : String(left) >= String(right), warnings };
-        case "<=":
-          return { ok: bothNumeric ? leftNum <= rightNum : String(left) <= String(right), warnings };
-      }
+      const right = parseComparisonLiteral(rightRaw);
+      return { ok: compareFilterValues(left, op, right), warnings };
     }
 
     // Bare identifier: treat as "truthy" frontmatter key (used a lot in Bases configs)
     // Ex: `- groupe_réunion` or `- sas_statut`
-    if (/^[\p{L}\p{N}_-]+$/u.test(raw)) {
+    if (isTruthyFilterReference(raw)) {
       const v = this.getValueForRef(file, raw, schema);
-      const ok =
-        v === true ||
-        (typeof v === "string" && v.trim().length > 0) ||
-        (typeof v === "number" && Number.isFinite(v)) ||
-        (Array.isArray(v) && v.length > 0) ||
-        (v && typeof v === "object" && Object.keys(v).length > 0);
-      return { ok, warnings };
+      return { ok: isTruthyFilterValue(v), warnings };
     }
 
     warnings.push(`Filter non reconnu: ${raw}`);
@@ -1164,11 +1139,14 @@ export default class BasesBridgePlugin extends Plugin {
 
           const viewName = typeof body?.view === "string" ? body.view : undefined;
           const view = viewName ? schema.views.find((v) => v.name === viewName) : schema.views[0];
+          const viewLookupWarning =
+            viewName && !view ? `Vue introuvable: ${JSON.stringify(viewName)}.` : undefined;
 
           const limit = clampInt(body?.limit ?? view?.limit ?? 20, 20, 1, 500);
           const page = clampInt(body?.page ?? 1, 1, 1, 1_000_000);
 
           const warningsSet = new Set<string>();
+          if (viewLookupWarning) warningsSet.add(viewLookupWarning);
           let warningsTruncated = false;
           const addWarnings = (ws: string[]) => {
             for (const w of ws) {

--- a/profiles/elysia-tasks/README.fr.md
+++ b/profiles/elysia-tasks/README.fr.md
@@ -8,7 +8,7 @@ Le profil décrit :
 - les libellés français et anglais ;
 - les racines autorisées pour les tâches actives et les captures ;
 - la politique de création et de template ;
-- les cinq filtres canoniques ;
+- les huit filtres canoniques : Inbox, Cette semaine, Maintenant, Backlog, Étoile du Nord, Audit, Fuite périodique et tâches du dossier ;
 - le contrat de mutation pour les agents.
 
 Il ne contient ni tâche, ni `operonId` réel, ni chemin absolu, ni layout personnel, ni cache, ni réglage privé.
@@ -33,7 +33,7 @@ La V1 est un contrat documenté et validable, pas un importeur aveugle. Avant ap
 2. comparer les IDs, chemins et sémantiques ;
 3. produire un dry-run des changements ;
 4. appliquer par petits lots via l’API publique du moteur ;
-5. valider avec `operon_validate` et les cinq filtres canoniques.
+5. valider avec `operon_validate`, les huit filtres canoniques et les invariants `open_without_surface = 0`, `now_not_in_week = 0`, `periodic_non_inbox = 0`.
 
 Le fichier de référence est [`v1/profile.json`](v1/profile.json).
 
@@ -48,6 +48,7 @@ Elle couvre :
 - cycle de vie des backlogs de projet ;
 - diagnostic du runtime et du cache ;
 - dry-run, révisions optimistes, idempotence et preuve après application.
+- admission P90-J avant création/adoption et clés d’idempotence distinctes pour le plan et l’application.
 
 La skill ne contient aucun chemin absolu, aucune tâche réelle, aucun identifiant privé et aucune copie de configuration `data.json`. Les règles propres à un coffre doivent être fournies comme politique locale au moment de l’exécution.
 

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/SKILL.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/SKILL.md
@@ -2,7 +2,7 @@
 name: elysia-task-gouverneur
 description: 'Orchestre les tâches d’un coffre compatible avec le profil public ÉLYSIA Tasks : opérations ponctuelles, audits, triage, cycle de vie et santé du runtime Kairélys/Operon via les outils operon_*, avec IDs stables, dry-run et validation humaine.'
 metadata:
-  version: '1.0.0'
+  version: '1.1.0'
   skill_structure: graph
   portability_class: profile-bound-portable
   profile_id: elysia.tasks
@@ -31,19 +31,22 @@ Utilise le profil public `elysia.tasks` et la configuration live du moteur pour 
 - Toute mutation d’une tâche existante passe par `expectedRevision`, `idempotencyKey`, dry-run, validation humaine, apply, relecture et `operon_validate`.
 - Runtime stale/non-live, capacité absente ou référence critique inaccessible : lecture seulement.
 - Une tâche appartient à un seul moteur. Ne jamais écrire en miroir dans Operon, Tasks et TaskNotes.
+- Toute création ou adoption passe par [admission-p90-j.md](references/admission-p90-j.md). Un plan ou une liste n’autorise pas automatiquement la création de tâches.
 
 ## Reference Gate Map
 
 | Intention | `module_route` | Modules obligatoires |
 |---|---|---|
-| Créer, adopter, modifier, terminer, convertir, déplacer | `operation-ponctuelle` | [operations-ponctuelles.md](references/operations-ponctuelles.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
+| Créer ou adopter | `operation-ponctuelle` | [admission-p90-j.md](references/admission-p90-j.md) + [operations-ponctuelles.md](references/operations-ponctuelles.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
+| Modifier, terminer, convertir, déplacer | `operation-ponctuelle` | [operations-ponctuelles.md](references/operations-ponctuelles.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
 | Audit, triage, conformité ou saved filters | `audit-triage` | [audits-et-triage.md](references/audits-et-triage.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
 | Changement de phase d’un projet ou nettoyage de backlog | `cycle-vie-projet` | [cycle-de-vie-projet.md](references/cycle-de-vie-projet.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
 | Cache stale, incident, incompatibilité ou lenteur | `sante-performance` | [sante-et-performance.md](references/sante-et-performance.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
 
 ## Routage rapide
 
-- Opération sur une tâche -> ouvrir `operations-ponctuelles` puis `runtime-et-mutations`.
+- Création ou adoption -> ouvrir `admission-p90-j`, `operations-ponctuelles`, puis `runtime-et-mutations`.
+- Autre opération sur une tâche -> ouvrir `operations-ponctuelles` puis `runtime-et-mutations`.
 - Audit ou cockpit -> ouvrir `audits-et-triage` puis `runtime-et-mutations`.
 - Projet qui change de phase -> ouvrir `cycle-de-vie-projet` puis `runtime-et-mutations`.
 - Runtime stale ou incident -> ouvrir `sante-et-performance` puis `runtime-et-mutations`.
@@ -86,6 +89,7 @@ Appliquer [contrat-de-sortie.md](references/contrat-de-sortie.md) et renseigner 
 ## Navigation
 
 - Runtime et mutations : [runtime-et-mutations.md](references/runtime-et-mutations.md)
+- Admission P90-J : [admission-p90-j.md](references/admission-p90-j.md)
 - Opérations ponctuelles : [operations-ponctuelles.md](references/operations-ponctuelles.md)
 - Audits et triage : [audits-et-triage.md](references/audits-et-triage.md)
 - Cycle de vie projet : [cycle-de-vie-projet.md](references/cycle-de-vie-projet.md)

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/admission-p90-j.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/admission-p90-j.md
@@ -1,0 +1,38 @@
+# Admission P90-J d’une tâche
+
+## But
+
+Décider si un item mérite un cycle de vie de tâche avant toute création ou adoption. Le profil est portable : la politique locale du coffre fournit les projets pivots, obligations et budgets précis.
+
+## Trois portes
+
+1. **Stratégique** — projet pivot, création autorisée, obligation externe, maintenance admise ou mission agentique bornée.
+2. **Exécutable** — verbe et objet observables, contexte explicite, définition de fini et preuve compréhensibles.
+3. **Capacité** — pas de doublon, horizon explicite et WIP local respecté ou dépassement documenté.
+
+## Verdict
+
+- `CREATE_INLINE`
+- `CREATE_FILE`
+- `ADOPT`
+- `KEEP_AS_BULLET`
+- `KEEP_AS_CHECKLIST`
+- `KEEP_AS_NOTE`
+- `REJECT_DUPLICATE`
+- `DEFER_CAPACITY`
+
+## Sortie minimale
+
+```yaml
+admission:
+  verdict: ...
+  justification_strategique: ...
+  definition_de_fini: ...
+  contexte_cible: ...
+  wip_avant: ...
+  wip_apres: ...
+  depassement_justifie: false | raison
+  preuve_attendue: ...
+```
+
+Ne jamais créer une tâche par outcome, idée, étape de SOP ou ligne de checklist. Une échéance ne sert jamais à forcer la visibilité.

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/audits-et-triage.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/audits-et-triage.md
@@ -15,8 +15,11 @@ Pour un audit de conformité ÉLYSIA, ouvrir `profiles/elysia-tasks/v1/profile.j
 
 - `fs_elysia_now`
 - `fs_elysia_inbox`
+- `fs_elysia_week`
+- `fs_elysia_backlog`
 - `fs_elysia_north`
 - `fs_elysia_audit`
+- `fs_elysia_periodic_leakage`
 - `fs_elysia_folder_open` avec un `scopePath` explicite
 
 Appeler `operon_query_saved_filter` ; ne pas reconstruire la logique du filtre côté agent.
@@ -28,5 +31,6 @@ Appeler `operon_query_saved_filter` ; ne pas reconstruire la logique du filtre c
 3. Interroger le saved filter ou les tâches concernées.
 4. Séparer faits, écarts au profil, politique locale et interprétation.
 5. Proposer uniquement les mutations nécessaires.
+6. Pour un audit complet, comparer toutes les tâches ouvertes à l’union des surfaces et exiger `open_without_surface = 0`, `now_not_in_week = 0` et `periodic_non_inbox = 0`.
 
 `apply_propose: aucun` est une conclusion valide. Les comptages avant/après ne sont rapportés que s’ils ont été réellement mesurés.

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/contrat-de-sortie.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/contrat-de-sortie.md
@@ -35,6 +35,8 @@ preuve_application:
   operation_id: identifiant retourné
   relecture_effectuee: true | false
   resultat_attendu_obtenu: true | false | incertain
+  filtre_attendu_verifie: true | false | non_applicable
+  invisible: false | true | non_applicable
   operon_validate: résultat réel
   divergence: aucune | description
 ```

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/runtime-et-mutations.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/runtime-et-mutations.md
@@ -47,12 +47,17 @@ Mutation :
 Pour une tâche existante :
 
 1. Lire la tâche et sa `revision`.
-2. Construire une `idempotencyKey` liée à l’intention.
-3. Exécuter le même outil avec `dryRun: true` et `expectedRevision`.
-4. Présenter l’avant, la demande et l’après attendu.
+2. Construire une clé de plan : `<intention>-plan-<nonce>`.
+3. Exécuter l’outil avec `dryRun: true` et `expectedRevision`.
+4. Présenter l’avant, la demande, l’après attendu, le WIP et les avertissements.
 5. Attendre une validation humaine explicite.
-6. Appliquer avec la révision encore valide.
-7. Relire la tâche et appeler `operon_validate`.
+6. Relire la tâche et sa révision ; arrêter ou recalculer si elle a changé.
+7. Construire une clé d’application distincte : `<intention>-apply-<nonce>`.
+8. Appliquer avec `dryRun: false` et la révision actuelle.
+9. Relire la tâche, vérifier le filtre attendu et appeler `operon_validate`.
+10. Si la tâche apparaît dans `fs_elysia_now`, prouver sa présence dans `fs_elysia_week` et rapporter `invisible: false`.
+
+Ne jamais réutiliser la clé du dry-run pour l’apply : `dryRun` fait partie de la requête canonique.
 
 Pour une création, aucune révision antérieure n’existe : destination, pipeline, statut initial et clé d’idempotence doivent être explicites. Pour une adoption, verrouiller le chemin, la ligne et le contenu attendu de la checkbox.
 

--- a/profiles/elysia-tasks/v1/profile.json
+++ b/profiles/elysia-tasks/v1/profile.json
@@ -2,7 +2,7 @@
   "$schema": "./schema.json",
   "schemaVersion": 1,
   "profileId": "elysia.tasks",
-  "profileVersion": "1.0.0",
+  "profileVersion": "1.1.0",
   "defaultLocale": "fr",
   "supportedLocales": ["fr", "en"],
   "engine": {
@@ -89,54 +89,123 @@
   },
   "filters": [
     {
-      "id": "fs_elysia_now",
-      "names": { "fr": "ÉLYSIA — Maintenant", "en": "ÉLYSIA — Now" },
-      "icon": "circle-play",
-      "all": [
-        { "field": "checkbox", "operator": "isOpen" },
-        { "field": "folders", "operator": "isInAnyFolderTree", "values": ["Efforts/Projets", "Efforts/Créations"] },
-        { "field": "statusId", "operator": "isNot", "value": "st_project_brainstorming" },
-        { "field": "tags", "operator": "noneContain", "value": "north-star" }
-      ],
-      "sort": ["priority:asc", "dateDue:asc", "dateScheduled:asc"]
-    },
-    {
       "id": "fs_elysia_inbox",
       "names": { "fr": "ÉLYSIA — Boîte de réception", "en": "ÉLYSIA — Inbox" },
       "icon": "inbox",
-      "all": [
+      "where": { "logic": "all", "children": [
         { "field": "checkbox", "operator": "isOpen" },
-        { "field": "folders", "operator": "isInFolderTree", "value": "Calendrier/NOTES PÉRIODIQUES" },
         { "field": "statusId", "operator": "is", "value": "st_project_brainstorming" }
-      ],
+      ] },
       "sort": ["dateCreated:asc"]
+    },
+    {
+      "id": "fs_elysia_week",
+      "names": { "fr": "ÉLYSIA — Cette semaine", "en": "ÉLYSIA — This week" },
+      "icon": "calendar-range",
+      "where": { "logic": "all", "children": [
+        { "field": "checkbox", "operator": "isOpen" },
+        { "logic": "any", "children": [
+          { "field": "folders", "operator": "isInFolderTree", "value": "Efforts/Projets" },
+          { "field": "folders", "operator": "isInFolderTree", "value": "Efforts/Créations" }
+        ] },
+        { "field": "statusId", "operator": "isNot", "value": "st_project_brainstorming" },
+        { "field": "statusId", "operator": "isNot", "value": "st_project_paused" },
+        { "logic": "any", "children": [
+          { "field": "statusId", "operator": "is", "value": "st_project_in_progress" },
+          { "field": "dateScheduled", "operator": "beforeToday" },
+          { "field": "dateScheduled", "operator": "thisWeek" },
+          { "field": "dateDue", "operator": "beforeToday" },
+          { "field": "dateDue", "operator": "thisWeek" }
+        ] }
+      ] },
+      "sort": ["dateScheduled:asc", "dateDue:asc", "priority:asc"]
+    },
+    {
+      "id": "fs_elysia_now",
+      "names": { "fr": "ÉLYSIA — Maintenant", "en": "ÉLYSIA — Now" },
+      "icon": "circle-play",
+      "where": { "logic": "all", "children": [
+        { "field": "checkbox", "operator": "isOpen" },
+        { "logic": "any", "children": [
+          { "field": "folders", "operator": "isInFolderTree", "value": "Efforts/Projets" },
+          { "field": "folders", "operator": "isInFolderTree", "value": "Efforts/Créations" }
+        ] },
+        { "field": "statusId", "operator": "isNot", "value": "st_project_brainstorming" },
+        { "field": "statusId", "operator": "isNot", "value": "st_project_paused" },
+        { "logic": "any", "children": [
+          { "field": "statusId", "operator": "is", "value": "st_project_in_progress" },
+          { "field": "dateScheduled", "operator": "beforeToday" },
+          { "field": "dateScheduled", "operator": "isToday" },
+          { "field": "dateDue", "operator": "beforeToday" },
+          { "field": "dateDue", "operator": "isToday" }
+        ] }
+      ] },
+      "sort": ["dateDue:asc", "dateScheduled:asc", "priority:asc"]
     },
     {
       "id": "fs_elysia_north",
       "names": { "fr": "ÉLYSIA — Étoile du Nord", "en": "ÉLYSIA — North Star" },
       "icon": "star",
-      "all": [
+      "where": { "logic": "all", "children": [
         { "field": "checkbox", "operator": "isOpen" },
         { "field": "tags", "operator": "anyContains", "value": "north-star" }
-      ],
+      ] },
       "sort": ["priority:asc", "dateDue:asc"]
+    },
+    {
+      "id": "fs_elysia_backlog",
+      "names": { "fr": "ÉLYSIA — Backlog", "en": "ÉLYSIA — Backlog" },
+      "icon": "archive",
+      "where": { "logic": "all", "children": [
+        { "field": "checkbox", "operator": "isOpen" },
+        { "logic": "any", "children": [
+          { "field": "folders", "operator": "isInFolderTree", "value": "Efforts/Projets" },
+          { "field": "folders", "operator": "isInFolderTree", "value": "Efforts/Créations" }
+        ] },
+        { "logic": "any", "children": [
+          { "field": "statusId", "operator": "is", "value": "st_project_paused" },
+          { "logic": "all", "children": [
+            { "field": "statusId", "operator": "is", "value": "st_project_planned" },
+            { "logic": "none", "children": [
+              { "field": "dateScheduled", "operator": "beforeToday" },
+              { "field": "dateScheduled", "operator": "isToday" },
+              { "field": "dateScheduled", "operator": "thisWeek" },
+              { "field": "dateDue", "operator": "beforeToday" },
+              { "field": "dateDue", "operator": "isToday" },
+              { "field": "dateDue", "operator": "thisWeek" }
+            ] }
+          ] }
+        ] }
+      ] },
+      "sort": ["priority:asc", "dateCreated:desc"]
     },
     {
       "id": "fs_elysia_audit",
       "names": { "fr": "ÉLYSIA — Audit anti-pollution", "en": "ÉLYSIA — Anti-pollution audit" },
       "icon": "shield-alert",
-      "all": [
+      "where": { "logic": "all", "children": [
         { "field": "checkbox", "operator": "isOpen" },
         { "field": "folders", "operator": "isOutsideAllFolderTrees", "values": ["Efforts/Projets", "Efforts/Créations", "Calendrier/NOTES PÉRIODIQUES"] }
-      ],
+      ] },
       "sort": ["folders:asc"]
+    },
+    {
+      "id": "fs_elysia_periodic_leakage",
+      "names": { "fr": "ÉLYSIA — Fuite des notes périodiques", "en": "ÉLYSIA — Periodic-note leakage" },
+      "icon": "shield-x",
+      "where": { "logic": "all", "children": [
+        { "field": "checkbox", "operator": "isOpen" },
+        { "field": "folders", "operator": "isInFolderTree", "value": "Calendrier/NOTES PÉRIODIQUES" },
+        { "field": "statusId", "operator": "isNot", "value": "st_project_brainstorming" }
+      ] },
+      "sort": ["datetimeModified:asc"]
     },
     {
       "id": "fs_elysia_folder_open",
       "names": { "fr": "ÉLYSIA — Tâches ouvertes du dossier", "en": "ÉLYSIA — Open tasks in folder" },
       "icon": "list-todo",
       "scope": "current-folder",
-      "all": [{ "field": "checkbox", "operator": "isOpen" }],
+      "where": { "logic": "all", "children": [{ "field": "checkbox", "operator": "isOpen" }] },
       "sort": ["dateDue:asc", "priority:asc", "dateScheduled:asc"]
     }
   ],
@@ -145,7 +214,10 @@
     "queryAndTransitionByStableIds": true,
     "mutationsRequireExpectedRevision": true,
     "mutationsRequireIdempotencyKey": true,
+    "dryRunAndApplyUseDistinctIdempotencyKeys": true,
     "dryRunBeforeApply": true,
+    "taskAdmissionRequired": true,
+    "postMutationVisibilityProofRequired": true,
     "rawMarkdownMutationAllowed": false
   },
   "excludedFromProfile": [

--- a/profiles/elysia-tasks/v1/schema.json
+++ b/profiles/elysia-tasks/v1/schema.json
@@ -19,14 +19,17 @@
     "automation": { "type": "object" },
     "filters": {
       "type": "array",
-      "minItems": 5,
-      "maxItems": 5,
+      "minItems": 8,
+      "maxItems": 8,
       "items": { "$ref": "#/$defs/filter" },
       "allOf": [
         { "contains": { "type": "object", "properties": { "id": { "const": "fs_elysia_now" } }, "required": ["id"] }, "minContains": 1, "maxContains": 1 },
         { "contains": { "type": "object", "properties": { "id": { "const": "fs_elysia_inbox" } }, "required": ["id"] }, "minContains": 1, "maxContains": 1 },
+        { "contains": { "type": "object", "properties": { "id": { "const": "fs_elysia_week" } }, "required": ["id"] }, "minContains": 1, "maxContains": 1 },
+        { "contains": { "type": "object", "properties": { "id": { "const": "fs_elysia_backlog" } }, "required": ["id"] }, "minContains": 1, "maxContains": 1 },
         { "contains": { "type": "object", "properties": { "id": { "const": "fs_elysia_north" } }, "required": ["id"] }, "minContains": 1, "maxContains": 1 },
         { "contains": { "type": "object", "properties": { "id": { "const": "fs_elysia_audit" } }, "required": ["id"] }, "minContains": 1, "maxContains": 1 },
+        { "contains": { "type": "object", "properties": { "id": { "const": "fs_elysia_periodic_leakage" } }, "required": ["id"] }, "minContains": 1, "maxContains": 1 },
         { "contains": { "type": "object", "properties": { "id": { "const": "fs_elysia_folder_open" } }, "required": ["id"] }, "minContains": 1, "maxContains": 1 }
       ]
     },
@@ -55,31 +58,48 @@
       "anyOf": [
         { "type": "object", "properties": { "value": {} }, "required": ["value"] },
         { "type": "object", "properties": { "values": { "type": "array" } }, "required": ["values"] },
-        { "type": "object", "properties": { "operator": { "const": "isOpen" } } }
+        { "type": "object", "properties": { "operator": { "enum": ["isOpen", "beforeToday", "isToday", "thisWeek"] } } }
       ],
       "additionalProperties": false
     },
+    "filterNode": {
+      "oneOf": [
+        { "$ref": "#/$defs/condition" },
+        {
+          "type": "object",
+          "required": ["logic", "children"],
+          "properties": {
+            "logic": { "enum": ["all", "any", "none"] },
+            "children": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "$ref": "#/$defs/filterNode" }
+            }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
     "filter": {
       "type": "object",
-      "required": ["id", "names", "icon", "all", "sort"],
+      "required": ["id", "names", "icon", "where", "sort"],
       "properties": {
         "id": {
           "enum": [
             "fs_elysia_now",
             "fs_elysia_inbox",
+            "fs_elysia_week",
+            "fs_elysia_backlog",
             "fs_elysia_north",
             "fs_elysia_audit",
+            "fs_elysia_periodic_leakage",
             "fs_elysia_folder_open"
           ]
         },
         "names": { "$ref": "#/$defs/localizedNames" },
         "icon": { "type": "string", "minLength": 1 },
         "scope": { "const": "current-folder" },
-        "all": {
-          "type": "array",
-          "minItems": 1,
-          "items": { "$ref": "#/$defs/condition" }
-        },
+        "where": { "$ref": "#/$defs/filterNode" },
         "sort": {
           "type": "array",
           "minItems": 1,

--- a/scripts/test-elysia-task-profile.mjs
+++ b/scripts/test-elysia-task-profile.mjs
@@ -15,9 +15,9 @@ const rejectedProfiles = [
   { name: "empty filter catalog", mutate: value => { value.filters = []; } },
   { name: "missing canonical filter", mutate: value => { value.filters.pop(); } },
   { name: "duplicate canonical filter id", mutate: value => { value.filters[4].id = value.filters[0].id; } },
-  { name: "filter without conditions", mutate: value => { value.filters[0].all = []; } },
-  { name: "condition without field or operator", mutate: value => { value.filters[0].all[0] = {}; } },
-  { name: "folder filter without current-folder scope", mutate: value => { delete value.filters[4].scope; } },
+  { name: "filter without conditions", mutate: value => { value.filters[0].where.children = []; } },
+  { name: "condition without field or operator", mutate: value => { value.filters[0].where.children[0] = {}; } },
+  { name: "folder filter without current-folder scope", mutate: value => { delete value.filters[7].scope; } },
   { name: "non-folder filter with folder scope", mutate: value => { value.filters[0].scope = "current-folder"; } },
 ];
 
@@ -37,7 +37,7 @@ assert.ok(frontmatterMatch, "public task skill must have YAML frontmatter");
 const frontmatter = parseYaml(frontmatterMatch[1]);
 
 assert.equal(frontmatter.name, "elysia-task-gouverneur");
-assert.equal(frontmatter.metadata.version, "1.0.0");
+assert.equal(frontmatter.metadata.version, "1.1.0");
 assert.equal(frontmatter.metadata.skill_structure, "graph");
 assert.equal(frontmatter.metadata.portability_class, "profile-bound-portable");
 assert.equal(frontmatter.metadata.profile_id, profile.profileId);
@@ -62,7 +62,7 @@ for (const token of requiredSkillTokens) {
 
 const markdownLinks = [...skill.matchAll(/\]\(([^)]+)\)/g)].map(match => match[1]);
 const referenceLinks = markdownLinks.filter(link => link.startsWith("references/"));
-assert.equal(new Set(referenceLinks).size, 6, "public task skill must expose six graph modules");
+assert.equal(new Set(referenceLinks).size, 7, "public task skill must expose seven graph modules");
 for (const link of markdownLinks) {
   await readFile(new URL(link, skillUrl), "utf8");
 }
@@ -90,5 +90,5 @@ for (const marker of forbiddenPrivateMarkers) {
 }
 
 console.log(
-  `ÉLYSIA task profile and public skill tests passed: ${rejectedProfiles.length + 1} profile assertions, 6 skill modules`,
+  `ÉLYSIA task profile and public skill tests passed: ${rejectedProfiles.length + 1} profile assertions, 7 skill modules`,
 );


### PR DESCRIPTION
## Summary

- ships Bases Bridge 1.0.1 and fixes evaluation of Obsidian wikilinks such as `[[Projets]]`
- preserves Bases `null` semantics and evaluates truthy `file.*`, `note.*`, and `formula.*` references
- warns when a requested Base view is missing instead of silently returning unfiltered rows
- publishes ÉLYSIA Tasks profile 1.1 with global Inbox, This Week, bounded Now, Backlog and periodic-note leakage detection
- adds P90-J admission and distinct dry-run/apply idempotency guidance to the public task-governor skill

## Validation

- `npm --prefix plugins/obsidian-bases-bridge run check` (6/6 tests + build)
- `npm run test:profiles` (8 profile assertions, 7 skill modules)
- `npm run test:runtime`
- `npm pack --dry-run`
- live `PROJETS.base`: 10 canonical views queried through the bridge with zero warnings
- live Base hygiene after removing one false project classification: 207 project-collection notes, 185 in the non-closed pipeline, 22 closed, 0 missing-status anomalies
- live Kairélys coverage: 13 open, 13 surfaced, `now_not_in_week=0`, `periodic_non_inbox=0`, validation P0/P1/P2 = `0/0/0`

## Notes

- root `npm audit` still reports pre-existing transitive advisories (8 moderate, 1 high); no forced major dependency upgrade is included in this PR
- no task content or private vault configuration is published