### PR TITLE
fix: mark semantic search open-world

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Semantic-search tools now declare `openWorldHint: true` because OpenAI can be selected as the query embedder.
 - Bases Bridge now evaluates `collection.contains(link(...))` correctly when frontmatter stores Obsidian wikilinks such as `[[Projets]]`.
 - Bases Bridge now treats the Bases literal `null` as a missing value instead of the string `"null"`, restoring missing-property filters and dependent formulas.
 - Bases Bridge now evaluates bare `file.*`, `note.*`, and `formula.*` truthy references used by negated filters such as `!formula.next_action_ok`.

--- a/scripts/smoke-headless-readonly.mjs
+++ b/scripts/smoke-headless-readonly.mjs
@@ -382,6 +382,23 @@ async function main() {
           .join(", ")}`,
       );
     }
+    const semanticSearchAliases = new Set([
+      "smart-search",
+      "smart_search",
+      "smart_semantic_search",
+    ]);
+    const closedWorldSemanticSearchTools = tools.tools.filter(
+      (tool) =>
+        semanticSearchAliases.has(tool.name) &&
+        tool.annotations?.openWorldHint !== true,
+    );
+    if (closedWorldSemanticSearchTools.length > 0) {
+      throw new Error(
+        `Semantic search tools not marked open-world: ${closedWorldSemanticSearchTools
+          .map((tool) => tool.name)
+          .join(", ")}`,
+      );
+    }
     const expected = [
       "obsidian_list_notes",
       "obsidian_read_note",

--- a/src/mcp-server/toolAnnotations.ts
+++ b/src/mcp-server/toolAnnotations.ts
@@ -5,6 +5,13 @@ export const READ_ONLY_TOOL_ANNOTATIONS = {
   openWorldHint: false,
 } as const;
 
+export const READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS = {
+  readOnlyHint: true,
+  destructiveHint: false,
+  idempotentHint: true,
+  openWorldHint: true,
+} as const;
+
 export const DESTRUCTIVE_TOOL_ANNOTATIONS = {
   readOnlyHint: false,
   destructiveHint: true,

--- a/src/mcp-server/tools/semanticSearchTool/registration.ts
+++ b/src/mcp-server/tools/semanticSearchTool/registration.ts
@@ -17,7 +17,7 @@ import { getQueryEmbedder } from "../../../adapters/embed/index.js";
 import { resolveNoteAbsolutePath } from "./resolvePath.js";
 import type { ObsidianRestApiService } from "../../../services/obsidianRestAPI/index.js";
 import type { VaultCacheService } from "../../../services/obsidianRestAPI/vaultCache/index.js";
-import { READ_ONLY_TOOL_ANNOTATIONS } from "../../toolAnnotations.js";
+import { READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS } from "../../toolAnnotations.js";
 
 const In = z.object({
   query: z.string().min(2, "query too short"),
@@ -556,7 +556,7 @@ export const registerSemanticSearchTool = async (
       name,
       description,
       In.shape,
-      READ_ONLY_TOOL_ANNOTATIONS,
+      READ_ONLY_OPEN_WORLD_TOOL_ANNOTATIONS,
       async (params: InType, _extra: unknown) => {
         try {
           const payload = await handleSearchRequest(params);


### PR DESCRIPTION
## Pourquoi

La recherche sémantique est en lecture seule, mais son embedder de requête est configurable. Avec `QUERY_EMBEDDER=openai`, ou lorsque `auto` résout un modèle OpenAI, le texte de la requête est envoyé à une API externe. Les trois alias annonçaient pourtant `openWorldHint: false` aux clients MCP.

## Ce qui change

- ajoute une annotation partagée en lecture seule avec `openWorldHint: true` ;
- l'applique à `smart-search`, `smart_search` et `smart_semantic_search` ;
- ajoute un smoke test qui refuse toute régression sur ces trois alias ;
- documente la correction dans le changelog.

Aucun comportement de recherche, choix d'embedder, contenu du coffre, Bridge ou moteur de tâches n'est modifié.

## Validation

- `npm run build` — PASS
- `npm run test:tool-annotations` — PASS, 45 registrations
- `npm run test:runtime` — PASS dans les six profils runtime
- `git diff --check` — PASS

Correctif du second passage Codex sur la PR #17, reçu après sa fusion.
