### PR TITLE
feat: support Kairélys 2.6.1 in Operon Bridge

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -26,7 +26,7 @@ Recommandation Codex : pointer la config MCP vers `dist/stdio-proxy.js`, pas dir
   - Local REST API (obligatoire pour les outils REST live) : https://github.com/coddingtonbear/obsidian-local-rest-api
   - Smart Connections (obligatoire pour la recherche sémantique) : https://github.com/brianpetro/obsidian-smart-connections
   - Bases Bridge (REST) (obligatoire pour les outils `.base` live/plugin-backed, inclus dans ce repo)
-  - Kairélys `2.5.3`, ou une release Operon compatible avec Public API v1, et Optimike Operon Bridge (requis pour les mutations live ; Bridge inclus dans ce repo)
+  - Kairélys `2.6.1`, ou une release Operon compatible avec Public API v1, et Optimike Operon Bridge (requis pour les mutations live ; Bridge inclus dans ce repo)
   - plugin Obsidian Tasks (obligatoire pour un comportement Tasks canonique)
 - Pour la recherche sémantique, assure-toi que ton vault contient un dossier `.smart-env`
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Recommended for Codex: point your MCP config to `dist/stdio-proxy.js`, not direc
   - Local REST API (required for live REST tools): https://github.com/coddingtonbear/obsidian-local-rest-api
   - Smart Connections (required for semantic search): https://github.com/brianpetro/obsidian-smart-connections
   - Bases Bridge (REST) (required for live/plugin-backed `.base` tools, bundled in this repo)
-  - Kairélys `2.5.3`, or a compatible Operon release with Public API v1, plus Optimike Operon Bridge (required for live task mutations; Bridge bundled in this repo)
+  - Kairélys `2.6.1`, or a compatible Operon release with Public API v1, plus Optimike Operon Bridge (required for live task mutations; Bridge bundled in this repo)
   - Obsidian Tasks plugin (required for canonical Tasks behavior)
 - For semantic search, make sure your vault has a `.smart-env` folder
 

--- a/docs/kairelys-cutover.fr.md
+++ b/docs/kairelys-cutover.fr.md
@@ -2,6 +2,11 @@
 
 La première version distribuée est Kairélys `2.5.1`, basée sur Operon `2.5.0`. Kairélys `2.5.2` durcit le cycle de vie de l’API publique et les transitions terminales avec timer actif ; `2.5.3` ajoute une protection contre le remplacement concurrent du timer. Ces versions ne changent pas le format des tâches. Leurs numéros distincts évitent toute collision entre les tags et packs de langue du fork et ceux d’upstream.
 
+Kairélys `2.6.1` reprend le moteur complet d’Operon `2.6.0` tout en conservant la Public API V1.
+Le format Markdown et les `operonId` restent identiques : la mise à niveau ne demande aucune
+migration des tâches. Le Bridge conserve une allowlist exacte et n’assimile pas automatiquement une
+version officielle d’Operon dépourvue de l’API publique.
+
 Kairélys utilise un identifiant Obsidian distinct (`kairelys`). Les tâches restent dans le Markdown
 et conservent leurs `operonId`; seuls le plugin, ses réglages et son état durable changent de dossier.
 

--- a/docs/operon-rest-contract.md
+++ b/docs/operon-rest-contract.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-The Bridge projects the active Operon-compatible engine's live index through Obsidian Local REST API. Reads work with official Operon `2.4.0` and `2.5.0`, and with Kairélys `2.5.1` through `2.5.3` (based on Operon `2.5.0`). Compatibility is decided by plugin ID and version together. Mutations are exposed only when the loaded instance implements `OperonPublicApiV1`; there is no raw Markdown or private-reflection fallback.
+The Bridge projects the active Operon-compatible engine's live index through Obsidian Local REST API. Reads work with official Operon `2.4.0` and `2.5.0`, with Kairélys `2.5.1` through `2.5.3` (based on Operon `2.5.0`), and with Kairélys `2.6.1` (based on Operon `2.6.0`). Compatibility is decided by plugin ID and version together. Mutations are exposed only when the loaded instance implements `OperonPublicApiV1`; there is no raw Markdown or private-reflection fallback.
 
 Prefix:
 
@@ -15,12 +15,12 @@ All routes inherit Local REST API authentication and TLS behavior.
 ## Compatibility and capabilities
 
 - Bridge contract: `1`
-- Latest tested compatible engine version: Kairélys `2.5.3`
+- Latest tested compatible engine version: Kairélys `2.6.1`
 - Official Operon read allowlist: `2.4.0`, `2.5.0`
-- Kairélys read allowlist: `2.5.1`, `2.5.2`, `2.5.3`
+- Kairélys read allowlist: `2.5.1`, `2.5.2`, `2.5.3`, `2.6.1`
 - Mutation contract: Operon Public API `1`
 - Official Operon `2.5.0`: read-only
-- Kairélys `2.5.1` through `2.5.3` with Public API v1: read-write
+- Kairélys `2.5.1` through `2.5.3` and `2.6.1` with Public API v1: read-write
 
 `GET /status` reports `bridge.mode` as `read-only` or `read-write` and exposes each capability independently. A future Operon version is not assumed compatible merely because its Markdown looks similar.
 

--- a/plugins/obsidian-operon-bridge/README.md
+++ b/plugins/obsidian-operon-bridge/README.md
@@ -15,7 +15,8 @@ If both plugins are enabled, the Bridge refuses to choose an owner. Disable one 
 
 - Obsidian Desktop
 - Operon `2.4.0` or `2.5.0` for reads
-- Kairélys `2.5.1` through `2.5.3` (based on Operon `2.5.0`) with Public API v1 for mutations
+- Kairélys `2.5.1` through `2.5.3` (based on Operon `2.5.0`) and Kairélys `2.6.1`
+  (based on Operon `2.6.0`) with Public API v1 for mutations
 - Obsidian Local REST API
 
 ## Routes

--- a/plugins/obsidian-operon-bridge/manifest.json
+++ b/plugins/obsidian-operon-bridge/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "optimike-operon-bridge",
   "name": "Optimike Kairélys / Operon Bridge",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "minAppVersion": "1.7.2",
   "description": "Versioned Local REST API bridge from Kairélys or Operon's live task engine to Optimike Obsidian MCP.",
   "author": "Optimike",

--- a/plugins/obsidian-operon-bridge/package-lock.json
+++ b/plugins/obsidian-operon-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optimike-operon-bridge",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optimike-operon-bridge",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "esbuild": "^0.25.0",

--- a/plugins/obsidian-operon-bridge/package.json
+++ b/plugins/obsidian-operon-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optimike-operon-bridge",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/obsidian-operon-bridge/src/contract.test.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.test.ts
@@ -111,6 +111,9 @@ test("version compatibility is an explicit tested-version allowlist", () => {
   assert.equal(isVersionCompatible("kairelys", "2.5.2"), true);
   assert.equal(isVersionCompatible("kairelys", "2.5.3"), true);
   assert.equal(isVersionCompatible("kairelys", "2.5.4"), false);
+  assert.equal(isVersionCompatible("kairelys", "2.6.0"), false);
+  assert.equal(isVersionCompatible("kairelys", "2.6.1"), true);
+  assert.equal(isVersionCompatible("kairelys", "2.6.2"), false);
 });
 
 test("index readiness refuses startup, recovery, sync, and dirty states", () => {

--- a/plugins/obsidian-operon-bridge/src/contract.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.ts
@@ -1,8 +1,8 @@
 export const OPERON_BRIDGE_CONTRACT_VERSION = "1" as const;
-export const OPERON_BRIDGE_TESTED_VERSION = "2.5.3" as const;
+export const OPERON_BRIDGE_TESTED_VERSION = "2.6.1" as const;
 export const OPERON_BRIDGE_SUPPORTED_VERSIONS = {
   operon: ["2.4.0", "2.5.0"],
-  kairelys: ["2.5.1", "2.5.2", OPERON_BRIDGE_TESTED_VERSION],
+  kairelys: ["2.5.1", "2.5.2", "2.5.3", OPERON_BRIDGE_TESTED_VERSION],
 } as const;
 
 export type OperonTaskSource = "inline" | "file";


### PR DESCRIPTION
## Summary

- allowlist Kairélys 2.6.1 in the bundled Operon Bridge
- keep official Operon 2.6.0 rejected because it does not expose Public API V1
- update English/French prerequisites, REST contract, and cutover documentation
- preserve support for Kairélys 2.5.1–2.5.3

## Validation

- `npm run check:operon` — PASS
- Bridge unit tests — 12/12 PASS
- `npm run test:package` — PASS
- `npm run test:migrations:windows` — PASS
- production audit policy remains unchanged; the full development tree still reports the existing transitive Hono moderate advisory

## Dependency

Merge after Kairélys PR #6 so the allowlisted `2.6.1` release exists.