### PR TITLE
fix: reject non-canonical Operon mutation paths

### DIFF
--- a/docs/operon-rest-contract.md
+++ b/docs/operon-rest-contract.md
@@ -56,6 +56,8 @@ Live validation reports duplicate IDs, missing sources, unknown workflow statuse
 
 All mutation routes require `idempotencyKey`. The key is bound to the canonical request: an identical replay returns the cached result, while reuse for different input returns HTTP 409 with `idempotency_key_reused`. Existing-task routes also require `expectedRevision`. `dryRun` defaults to `true`; apply occurs only with `dryRun: false`.
 
+Every mutation destination is validated without normalization at both the MCP and Bridge boundaries. `targetPath` must be an exact vault-relative Markdown path; `targetFolder` must be an exact vault-relative folder path. Leading or trailing whitespace, backslashes, absolute paths, empty segments, trailing separators, `.` and `..` are rejected before any call to the task engine.
+
 Mutation capabilities remain false until **Allow task mutations** is explicitly enabled in Bridge settings. The MCP has a separate `OPERON_MUTATIONS_ENABLED` apply opt-in.
 
 Responses use:

--- a/plugins/obsidian-operon-bridge/README.md
+++ b/plugins/obsidian-operon-bridge/README.md
@@ -38,6 +38,8 @@ Prefix: `/extensions/optimike-operon-bridge/v1`
 
 All routes inherit Local REST API authentication and local TLS settings. Saved filters run through Operon's native filter evaluator. Mutations require idempotency; an idempotency key is bound to one canonical request and conflicting reuse is rejected. Existing-task mutations require the live revision; in-place adoption instead requires an exact one-based line plus `expectedLine`. Dry-run is the default.
 
+Mutation paths are strict, exact vault-relative paths. The MCP and Bridge reject leading or trailing whitespace, backslashes, absolute paths, empty segments, traversal, and non-Markdown `targetPath` values; they never trim or rewrite an invalid destination into a valid one.
+
 Mutation apply is disabled by default. Enable **Allow task mutations** in the plugin settings only after the live validation recipe passes. The MCP runtime has a separate `OPERON_MUTATIONS_ENABLED` opt-in.
 
 ## Build

--- a/plugins/obsidian-operon-bridge/manifest.json
+++ b/plugins/obsidian-operon-bridge/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "optimike-operon-bridge",
   "name": "Optimike Kairélys / Operon Bridge",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "minAppVersion": "1.7.2",
   "description": "Versioned Local REST API bridge from Kairélys or Operon's live task engine to Optimike Obsidian MCP.",
   "author": "Optimike",

--- a/plugins/obsidian-operon-bridge/package-lock.json
+++ b/plugins/obsidian-operon-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optimike-operon-bridge",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optimike-operon-bridge",
-      "version": "0.4.5",
+      "version": "0.4.6",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "esbuild": "^0.25.0",

--- a/plugins/obsidian-operon-bridge/package.json
+++ b/plugins/obsidian-operon-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optimike-operon-bridge",
-  "version": "0.4.5",
+  "version": "0.4.6",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/obsidian-operon-bridge/src/contract.test.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.test.ts
@@ -1,15 +1,18 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
-  filterTasks,
-  isIndexReady,
+	filterTasks,
+	isCanonicalVaultMarkdownPath,
+	isCanonicalVaultRelativePath,
+	isIndexReady,
   isVersionCompatible,
   normalizeTask,
   paginateTasks,
   queryTasks,
   resolveWorkflow,
-  settingsSignature,
-  shouldAttemptIndexValidation,
+	settingsSignature,
+	shouldAttemptIndexValidation,
+	mutationPathValidationError,
   type OperonBridgeTask,
   type RuntimeIndexedTask,
 } from "./contract";
@@ -116,6 +119,75 @@ test("version compatibility is an explicit tested-version allowlist", () => {
   assert.equal(isVersionCompatible("kairelys", "2.6.2"), true);
   assert.equal(isVersionCompatible("kairelys", "2.6.3"), true);
   assert.equal(isVersionCompatible("kairelys", "2.6.4"), false);
+});
+
+test("mutation paths are rejected instead of normalized at the Bridge boundary", () => {
+	assert.equal(isCanonicalVaultRelativePath("Efforts/Projets"), true);
+	assert.equal(isCanonicalVaultMarkdownPath("Efforts/Projets/Test.md"), true);
+	for (const invalidPath of [
+		" Efforts/Projets/Test.md",
+		"Efforts/Projets/Test.md ",
+		"Efforts\\Projets\\Test.md",
+		"/Efforts/Projets/Test.md",
+		"C:/Efforts/Projets/Test.md",
+		"Efforts//Projets/Test.md",
+		"Efforts/./Projets/Test.md",
+		"Efforts/Projets/../Atlas/Test.md",
+	]) {
+		assert.equal(isCanonicalVaultMarkdownPath(invalidPath), false);
+	}
+	assert.match(
+		mutationPathValidationError("create", {
+			source: "inline",
+			targetPath: "Efforts/Projets/Test.md ",
+		}) ?? "",
+		/targetPath/u,
+	);
+	assert.match(
+		mutationPathValidationError("convert", {
+			target: "file",
+			targetFolder: "Efforts/Projets/ ",
+		}) ?? "",
+		/targetFolder/u,
+	);
+	assert.match(
+		mutationPathValidationError("convert", { target: "inline" }) ?? "",
+		/required/u,
+	);
+	assert.match(
+		mutationPathValidationError("create", {
+			source: "file",
+			targetPath: "Efforts/Projets/Test.md",
+		}) ?? "",
+		/only for inline/u,
+	);
+	assert.match(
+		mutationPathValidationError("convert", {
+			target: "file",
+			targetPath: "Efforts/Projets/Test.md",
+		}) ?? "",
+		/only for file-to-inline/u,
+	);
+	assert.match(
+		mutationPathValidationError("relocate", {
+			targetPath: "Efforts/Projets/Test.md ",
+		}) ?? "",
+		/targetPath/u,
+	);
+	assert.equal(
+		mutationPathValidationError("create", {
+			source: "inline",
+			targetPath: "Efforts/Projets/Test.md",
+		}),
+		null,
+	);
+	assert.equal(
+		mutationPathValidationError("convert", {
+			target: "inline",
+			targetPath: "Efforts/Projets/Test.md",
+		}),
+		null,
+	);
 });
 
 test("index readiness refuses startup, recovery, sync, and dirty states", () => {

--- a/plugins/obsidian-operon-bridge/src/contract.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.ts
@@ -5,6 +5,86 @@ export const OPERON_BRIDGE_SUPPORTED_VERSIONS = {
   kairelys: ["2.5.1", "2.5.2", "2.5.3", "2.6.1", "2.6.2", OPERON_BRIDGE_TESTED_VERSION],
 } as const;
 
+export function isCanonicalVaultRelativePath(value: unknown): value is string {
+	if (
+		typeof value !== "string" ||
+		value.length === 0 ||
+		value !== value.trim() ||
+		/[\\\r\n\0]/u.test(value) ||
+		/^(?:\/|[a-z]:\/)/iu.test(value) ||
+		value.endsWith("/")
+	) {
+		return false;
+	}
+	const segments = value.split("/");
+	return segments.every(
+		(segment) =>
+			segment.length > 0 &&
+			segment === segment.trim() &&
+			segment !== "." &&
+			segment !== "..",
+	);
+}
+
+export function isCanonicalVaultMarkdownPath(value: unknown): value is string {
+	return (
+		isCanonicalVaultRelativePath(value) &&
+		value.toLocaleLowerCase().endsWith(".md")
+	);
+}
+
+export function mutationPathValidationError(
+	capability: "create" | "update" | "transition" | "convert" | "relocate",
+	requested: Record<string, unknown>,
+): string | null {
+	const has = (key: string): boolean =>
+		Object.prototype.hasOwnProperty.call(requested, key);
+	if (capability === "create") {
+		if (requested.source !== "inline" && requested.source !== "file") {
+			return "source must be either inline or file.";
+		}
+		if (has("targetPath") && !isCanonicalVaultMarkdownPath(requested.targetPath)) {
+			return "targetPath must be an exact canonical vault-relative Markdown path.";
+		}
+		if (has("targetFolder") && !isCanonicalVaultRelativePath(requested.targetFolder)) {
+			return "targetFolder must be an exact canonical vault-relative folder path.";
+		}
+		if (requested.source === "file" && has("targetPath")) {
+			return "targetPath is supported only for inline task creation.";
+		}
+		if (requested.source === "inline" && has("targetFolder")) {
+			return "targetFolder is supported only for file task creation.";
+		}
+	}
+	if (capability === "convert") {
+		if (requested.target !== "inline" && requested.target !== "file") {
+			return "target must be either inline or file.";
+		}
+		if (has("targetPath") && !isCanonicalVaultMarkdownPath(requested.targetPath)) {
+			return "targetPath must be an exact canonical vault-relative Markdown path.";
+		}
+		if (has("targetFolder") && !isCanonicalVaultRelativePath(requested.targetFolder)) {
+			return "targetFolder must be an exact canonical vault-relative folder path.";
+		}
+		if (requested.target === "inline" && !has("targetPath")) {
+			return "targetPath is required for file-to-inline conversion.";
+		}
+		if (requested.target === "inline" && has("targetFolder")) {
+			return "targetFolder is supported only for inline-to-file conversion.";
+		}
+		if (requested.target === "file" && has("targetPath")) {
+			return "targetPath is supported only for file-to-inline conversion.";
+		}
+	}
+	if (
+		capability === "relocate" &&
+		!isCanonicalVaultMarkdownPath(requested.targetPath)
+	) {
+		return "targetPath must be an exact canonical vault-relative Markdown path.";
+	}
+	return null;
+}
+
 export type OperonTaskSource = "inline" | "file";
 export type OperonCheckboxState = "open" | "done" | "cancelled";
 export type OperonTier = "hot" | "warm" | "cold";

--- a/plugins/obsidian-operon-bridge/src/main.ts
+++ b/plugins/obsidian-operon-bridge/src/main.ts
@@ -4,6 +4,8 @@ import {
   OPERON_BRIDGE_SUPPORTED_VERSIONS,
   OPERON_BRIDGE_TESTED_VERSION,
   isIndexReady,
+  isCanonicalVaultMarkdownPath,
+  mutationPathValidationError,
   isVersionCompatible,
   normalizeTask,
   queryTasks,
@@ -1056,11 +1058,11 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       !Array.isArray(body.adoption)
         ? (body.adoption as Record<string, unknown>)
         : {};
-    const targetPath = String(requested.targetPath ?? "").trim();
+    const targetPath = requested.targetPath;
     const line = Number(requested.line);
     const expectedLine = String(requested.expectedLine ?? "");
     if (
-      !targetPath ||
+      !isCanonicalVaultMarkdownPath(targetPath) ||
       !Number.isInteger(line) ||
       line < 1 ||
       !expectedLine ||
@@ -1303,7 +1305,7 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       if (
         requested.target === "inline" &&
         typeof requested.targetPath === "string" &&
-        after.path !== requested.targetPath.trim()
+        after.path !== requested.targetPath
       ) {
         return "Converted inline task path does not match targetPath.";
       }
@@ -1312,7 +1314,7 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       if (
         after.source !== "inline" ||
         typeof requested.targetPath !== "string" ||
-        after.path !== requested.targetPath.trim()
+        after.path !== requested.targetPath
       ) {
         return "Relocated task was not found at targetPath.";
       }
@@ -1335,6 +1337,13 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
           new Error("idempotencyKey is required."),
           "validation_error",
         ),
+      };
+    }
+    const pathError = mutationPathValidationError(capability, requested);
+    if (pathError) {
+      return {
+        httpStatus: 400,
+        payload: errorPayload(new Error(pathError), "validation_error"),
       };
     }
     const signature = stableJson({
@@ -1482,6 +1491,13 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       body.task && typeof body.task === "object" && !Array.isArray(body.task)
         ? (body.task as Record<string, unknown>)
         : {};
+    const pathError = mutationPathValidationError("create", requested);
+    if (pathError) {
+      return {
+        httpStatus: 400,
+        payload: errorPayload(new Error(pathError), "validation_error"),
+      };
+    }
     const signature = stableJson({
       capability: "create",
       dryRun: body.dryRun !== false,
@@ -1920,7 +1936,7 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
           ).trim();
           const body = this.bodyRecord(req);
           const requested = {
-            targetPath: String(body.targetPath ?? "").trim(),
+            targetPath: body.targetPath,
           };
           const result = await this.executeExistingMutation(
             "relocate",

--- a/scripts/test-operon-contract.mjs
+++ b/scripts/test-operon-contract.mjs
@@ -486,9 +486,10 @@ for (const schemaAndValue of [
 }
 const filterQuery = OperonFilterQuerySchema.parse({
   filterSetId: "fs_elysia_now",
-  scopePath: "Efforts/Projets",
+  scopePath: " Efforts/Projets ",
 });
 assert.equal(filterQuery.limit, 100);
+assert.equal(filterQuery.scopePath, "Efforts/Projets");
 assert.equal(
   OperonFilterQuerySchema.safeParse({
     filterSetId: "fs_elysia_now",

--- a/scripts/test-operon-contract.mjs
+++ b/scripts/test-operon-contract.mjs
@@ -13,6 +13,8 @@ import {
   OperonTaskSchema,
   OperonTransitionTaskSchema,
   OperonUpdateTaskSchema,
+  OperonVaultMarkdownPathSchema,
+  OperonVaultRelativePathSchema,
   queryOperonSnapshot,
 } from "../dist/services/operon/contract.js";
 
@@ -404,6 +406,84 @@ assert.equal(
   }).success,
   false,
 );
+for (const invalidPath of [
+  " Efforts/Projets/Test.md",
+  "Efforts/Projets/Test.md ",
+  "Efforts\\Projets\\Test.md",
+  "/Efforts/Projets/Test.md",
+  "C:/Efforts/Projets/Test.md",
+  "Efforts//Projets/Test.md",
+  "Efforts/./Projets/Test.md",
+  "Efforts/Projets/../Atlas/Test.md",
+  "Efforts/Projets/Test",
+]) {
+  assert.equal(
+    OperonVaultMarkdownPathSchema.safeParse(invalidPath).success,
+    false,
+    `must reject non-canonical Markdown path: ${JSON.stringify(invalidPath)}`,
+  );
+}
+for (const invalidPath of [
+  " Efforts/Projets",
+  "Efforts/Projets ",
+  "Efforts\\Projets",
+  "Efforts//Projets",
+  "Efforts/Projets/",
+]) {
+  assert.equal(
+    OperonVaultRelativePathSchema.safeParse(invalidPath).success,
+    false,
+    `must reject non-canonical vault path: ${JSON.stringify(invalidPath)}`,
+  );
+}
+for (const schemaAndValue of [
+  [
+    OperonAdoptTaskSchema,
+    {
+      ...adopt,
+      adoption: {
+        ...adopt.adoption,
+        targetPath: `${adopt.adoption.targetPath} `,
+      },
+    },
+  ],
+  [
+    OperonCreateTaskSchema,
+    {
+      idempotencyKey: "contract-create-path-space",
+      task: {
+        source: "inline",
+        description: "Do not normalize",
+        targetPath: "Efforts/Projets/Test.md ",
+      },
+    },
+  ],
+  [
+    OperonConvertTaskSchema,
+    {
+      operonId: task.operonId,
+      expectedRevision: task.revision,
+      idempotencyKey: "contract-convert-path-space",
+      target: "inline",
+      targetPath: "Efforts/Projets/Test.md ",
+    },
+  ],
+  [
+    OperonRelocateTaskSchema,
+    {
+      operonId: task.operonId,
+      expectedRevision: task.revision,
+      idempotencyKey: "contract-relocate-path-space",
+      targetPath: "Efforts/Projets/Cible.md ",
+    },
+  ],
+]) {
+  assert.equal(
+    schemaAndValue[0].safeParse(schemaAndValue[1]).success,
+    false,
+    "mutation schemas must reject rather than normalize non-canonical paths",
+  );
+}
 const filterQuery = OperonFilterQuerySchema.parse({
   filterSetId: "fs_elysia_now",
   scopePath: "Efforts/Projets",

--- a/scripts/test-operon-service.mjs
+++ b/scripts/test-operon-service.mjs
@@ -563,6 +563,24 @@ try {
     "scope rejection must happen before the Bridge call",
   );
 
+  await assert.rejects(
+    service.createTask({
+      idempotencyKey: "test-canonical-path-preservation",
+      dryRun: false,
+      task: {
+        source: "inline",
+        description: "Must never be normalized into a valid destination",
+        targetPath: "Efforts/Projets/Internes/Operon Pilot/Pilot.md ",
+      },
+    }),
+    (error) => error?.name === "ZodError",
+  );
+  assert.equal(
+    state.mutationCalls,
+    2,
+    "non-canonical paths must be rejected before any Bridge request",
+  );
+
   const scopedInline = await service.createTask({
     idempotencyKey: "test-scope-inline-target",
     dryRun: true,

--- a/src/services/operon/contract.ts
+++ b/src/services/operon/contract.ts
@@ -376,13 +376,32 @@ export const OperonVaultRelativePathSchema = z
       "Path must be an exact canonical vault-relative path without whitespace normalization, backslashes, empty, '.' or '..' segments.",
   });
 
+const OperonVaultRelativeReadPathSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .superRefine((value, context) => {
+    const normalized = value.replace(/\\/gu, "/");
+    if (
+      /^(?:\/|[a-z]:\/)/iu.test(normalized) ||
+      normalized
+        .split("/")
+        .some((segment) => segment === "." || segment === "..")
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Path must be vault-relative without '.' or '..' segments.",
+      });
+    }
+  });
+
 export const OperonVaultMarkdownPathSchema =
   OperonVaultRelativePathSchema.refine(isCanonicalOperonVaultMarkdownPath, {
     message: "Path must identify a canonical vault-relative Markdown file.",
   });
 export const OperonFilterQuerySchema = z.object({
   filterSetId: z.string().trim().min(1),
-  scopePath: OperonVaultRelativePathSchema.optional(),
+  scopePath: OperonVaultRelativeReadPathSchema.optional(),
   includeProperties: z.boolean().optional().default(false),
   cursor: z.string().optional(),
   limit: z.number().int().positive().max(500).optional().default(100),

--- a/src/services/operon/contract.ts
+++ b/src/services/operon/contract.ts
@@ -336,23 +336,49 @@ const MutationControlSchema = z.object({
   dryRun: z.boolean().optional().default(true),
 });
 
+export function isCanonicalOperonVaultRelativePath(
+  value: unknown,
+): value is string {
+  if (
+    typeof value !== "string" ||
+    value.length === 0 ||
+    value !== value.trim() ||
+    /[\\\r\n\0]/u.test(value) ||
+    /^(?:\/|[a-z]:\/)/iu.test(value) ||
+    value.endsWith("/")
+  ) {
+    return false;
+  }
+  const segments = value.split("/");
+  return segments.every(
+    (segment) =>
+      segment.length > 0 &&
+      segment === segment.trim() &&
+      segment !== "." &&
+      segment !== "..",
+  );
+}
+
+export function isCanonicalOperonVaultMarkdownPath(
+  value: unknown,
+): value is string {
+  return (
+    isCanonicalOperonVaultRelativePath(value) &&
+    value.toLocaleLowerCase().endsWith(".md")
+  );
+}
+
 export const OperonVaultRelativePathSchema = z
   .string()
-  .trim()
   .min(1)
-  .superRefine((value, context) => {
-    const normalized = value.replace(/\\/gu, "/");
-    if (
-      /^(?:\/|[a-z]:\/)/iu.test(normalized) ||
-      normalized
-        .split("/")
-        .some((segment) => segment === "." || segment === "..")
-    ) {
-      context.addIssue({
-        code: z.ZodIssueCode.custom,
-        message: "Path must be vault-relative without '.' or '..' segments.",
-      });
-    }
+  .refine(isCanonicalOperonVaultRelativePath, {
+    message:
+      "Path must be an exact canonical vault-relative path without whitespace normalization, backslashes, empty, '.' or '..' segments.",
+  });
+
+export const OperonVaultMarkdownPathSchema =
+  OperonVaultRelativePathSchema.refine(isCanonicalOperonVaultMarkdownPath, {
+    message: "Path must identify a canonical vault-relative Markdown file.",
   });
 export const OperonFilterQuerySchema = z.object({
   filterSetId: z.string().trim().min(1),
@@ -364,7 +390,7 @@ export const OperonFilterQuerySchema = z.object({
 
 export const OperonAdoptTaskSchema = MutationControlSchema.extend({
   adoption: z.object({
-    targetPath: OperonVaultRelativePathSchema,
+    targetPath: OperonVaultMarkdownPathSchema,
     line: z.number().int().positive(),
     expectedLine: z
       .string()
@@ -390,17 +416,17 @@ export const OperonCreateTaskSchema = MutationControlSchema.extend({
       fileTemplateId: z.string().optional(),
       targetDateKey: z.string().optional(),
       targetFolder: OperonVaultRelativePathSchema.optional(),
-      targetPath: OperonVaultRelativePathSchema.optional(),
+      targetPath: OperonVaultMarkdownPathSchema.optional(),
     })
     .superRefine((value, context) => {
-      if (value.source === "file" && value.targetPath?.trim()) {
+      if (value.source === "file" && value.targetPath) {
         context.addIssue({
           code: z.ZodIssueCode.custom,
           path: ["targetPath"],
           message: "targetPath is supported only for inline tasks.",
         });
       }
-      if (value.source === "inline" && value.targetFolder?.trim()) {
+      if (value.source === "inline" && value.targetFolder) {
         context.addIssue({
           code: z.ZodIssueCode.custom,
           path: ["targetFolder"],
@@ -473,20 +499,20 @@ export const OperonConvertTaskInputSchema = MutationControlSchema.extend({
   expectedRevision: z.string().min(1),
   target: OperonTaskSourceSchema,
   fileTemplateId: z.string().optional(),
-  targetPath: OperonVaultRelativePathSchema.optional(),
+  targetPath: OperonVaultMarkdownPathSchema.optional(),
   targetFolder: OperonVaultRelativePathSchema.optional(),
 });
 
 export const OperonConvertTaskSchema = OperonConvertTaskInputSchema.superRefine(
   (value, context) => {
-    if (value.target === "inline" && !value.targetPath?.trim()) {
+    if (value.target === "inline" && !value.targetPath) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["targetPath"],
         message: "targetPath is required for file-to-inline conversion.",
       });
     }
-    if (value.target === "inline" && value.targetFolder?.trim()) {
+    if (value.target === "inline" && value.targetFolder) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["targetFolder"],
@@ -494,7 +520,7 @@ export const OperonConvertTaskSchema = OperonConvertTaskInputSchema.superRefine(
           "targetFolder is supported only for inline-to-file conversion.",
       });
     }
-    if (value.target === "file" && value.targetPath?.trim()) {
+    if (value.target === "file" && value.targetPath) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         path: ["targetPath"],
@@ -507,7 +533,7 @@ export const OperonConvertTaskSchema = OperonConvertTaskInputSchema.superRefine(
 export const OperonRelocateTaskSchema = MutationControlSchema.extend({
   operonId: z.string().min(1),
   expectedRevision: z.string().min(1),
-  targetPath: OperonVaultRelativePathSchema,
+  targetPath: OperonVaultMarkdownPathSchema,
 });
 
 export const OperonMutationResultSchema = z.object({

--- a/src/services/operon/service.ts
+++ b/src/services/operon/service.ts
@@ -26,6 +26,7 @@ import {
   OperonMutationResultSchema,
   OperonTransitionTaskSchema,
   OperonUpdateTaskSchema,
+  isCanonicalOperonVaultRelativePath,
   type OperonBridgePage,
   type OperonConfiguration,
   type OperonQuery,
@@ -48,13 +49,8 @@ import type { z } from "zod";
 const BRIDGE_PREFIX = "/extensions/optimike-operon-bridge/v1";
 const PAGE_SIZE = 500;
 const MAX_PAGES = 10_000;
-const normalizeVaultRelativePath = (value: string): string | null => {
-  const normalized = value.trim().replace(/\\/gu, "/").replace(/\/+$/u, "");
-  if (!normalized || /^(?:\/|[a-z]:\/)/iu.test(normalized)) return null;
-  const segments = normalized.split("/");
-  if (segments.some((segment) => segment === "." || segment === ".."))
-    return null;
-  return segments.join("/");
+const canonicalVaultRelativePathOrNull = (value: string): string | null => {
+  return isCanonicalOperonVaultRelativePath(value) ? value : null;
 };
 const SNAPSHOT_TABLE_SQL = `
 CREATE TABLE IF NOT EXISTS operon_task_snapshot (
@@ -466,7 +462,7 @@ export class OperonService {
     if (action === "adopt") {
       if (
         typeof request.targetPath !== "string" ||
-        after.path !== request.targetPath.trim()
+        after.path !== request.targetPath
       )
         return "Adopted task path does not match targetPath.";
       if (typeof request.line !== "number" || after.line !== request.line)
@@ -541,7 +537,7 @@ export class OperonService {
       if (
         request.target === "inline" &&
         typeof request.targetPath === "string" &&
-        after.path !== request.targetPath.trim()
+        after.path !== request.targetPath
       )
         return "Converted task path does not match targetPath.";
     }
@@ -549,7 +545,7 @@ export class OperonService {
       action === "relocate" &&
       (after.source !== "inline" ||
         typeof request.targetPath !== "string" ||
-        after.path !== request.targetPath.trim())
+        after.path !== request.targetPath)
     ) {
       return "Relocated task was not found at targetPath.";
     }
@@ -712,7 +708,7 @@ export class OperonService {
   }
 
   private isAllowedMutationPath(candidate: string): boolean {
-    const normalized = normalizeVaultRelativePath(candidate);
+    const normalized = canonicalVaultRelativePathOrNull(candidate);
     if (!normalized) return false;
     return config.operonMutationAllowedPathPrefixes.some(
       (prefix) => normalized === prefix || normalized.startsWith(`${prefix}/`),
@@ -720,7 +716,7 @@ export class OperonService {
   }
 
   private assertAllowedMutationPath(candidate: string, label: string): void {
-    if (!normalizeVaultRelativePath(candidate)) {
+    if (!canonicalVaultRelativePathOrNull(candidate)) {
       throw new McpError(
         BaseErrorCode.VALIDATION_ERROR,
         `Operon ${label} must be a canonical vault-relative path without '.' or '..': ${candidate}`,
@@ -758,7 +754,7 @@ export class OperonService {
       const adoption = payload.adoption as Record<string, unknown> | undefined;
       if (
         typeof adoption?.targetPath === "string" &&
-        adoption.targetPath.trim()
+        adoption.targetPath.length > 0
       ) {
         this.assertAllowedMutationPath(adoption.targetPath, "adopt targetPath");
         return;
@@ -775,7 +771,7 @@ export class OperonService {
       if (
         task?.source === "file" &&
         typeof task.targetFolder === "string" &&
-        task.targetFolder.trim()
+        task.targetFolder.length > 0
       ) {
         this.assertAllowedMutationPath(
           task.targetFolder,
@@ -786,7 +782,7 @@ export class OperonService {
       if (
         task?.source === "inline" &&
         typeof task.targetPath === "string" &&
-        task.targetPath.trim()
+        task.targetPath.length > 0
       ) {
         this.assertAllowedMutationPath(task.targetPath, "create targetPath");
         return;
@@ -820,7 +816,7 @@ export class OperonService {
       if (
         target === "file" &&
         typeof payload.targetFolder === "string" &&
-        payload.targetFolder.trim()
+        payload.targetFolder.length > 0
       ) {
         this.assertAllowedMutationPath(
           payload.targetFolder,
@@ -831,7 +827,7 @@ export class OperonService {
       if (
         target === "inline" &&
         typeof payload.targetPath === "string" &&
-        payload.targetPath.trim()
+        payload.targetPath.length > 0
       ) {
         this.assertAllowedMutationPath(
           payload.targetPath,
@@ -851,7 +847,10 @@ export class OperonService {
     }
 
     if (action === "relocate") {
-      if (typeof payload.targetPath === "string" && payload.targetPath.trim()) {
+      if (
+        typeof payload.targetPath === "string" &&
+        payload.targetPath.length > 0
+      ) {
         this.assertAllowedMutationPath(
           payload.targetPath,
           "relocate targetPath",


### PR DESCRIPTION
## Summary
- reject mutation paths instead of trimming or rewriting them
- validate exact vault-relative Markdown paths at both MCP and Bridge boundaries
- cover create, adopt, convert, and relocate with an adversarial path matrix
- bump Optimike Operon Bridge to 0.4.6

## Why
A live negative test showed that a trailing-space target path was normalized by the MCP/Bridge before Kairélys received it, turning an invalid request into a valid write. This patch makes invalid paths a no-op validation failure.

## Validation
- npm run check:operon
- npm run test:profiles
- npm run test:tool-annotations
- npm run test:package
- npm audit --omit=dev --audit-level=high (2 known moderate transitive Hono findings; no high/critical)
