### PR TITLE
fix: preserve Operon idempotency precedence

### DIFF
--- a/docs/operon-rest-contract.md
+++ b/docs/operon-rest-contract.md
@@ -54,7 +54,7 @@ Live validation reports duplicate IDs, missing sources, unknown workflow statuse
 
 ## Mutation controls
 
-All mutation routes require `idempotencyKey`. The key is bound to the canonical request: an identical replay returns the cached result, while reuse for different input returns HTTP 409 with `idempotency_key_reused`. Existing-task routes also require `expectedRevision`. `dryRun` defaults to `true`; apply occurs only with `dryRun: false`.
+All mutation routes require `idempotencyKey`. The key is bound to the canonical request: an identical replay returns the cached result, while reuse for different input returns HTTP 409 with `idempotency_key_reused` before later payload validation. Existing-task routes also require `expectedRevision`. `dryRun` defaults to `true`; apply occurs only with `dryRun: false`.
 
 Every mutation destination is validated without normalization at both the MCP and Bridge boundaries. `targetPath` must be an exact vault-relative Markdown path; `targetFolder` must be an exact vault-relative folder path. Leading or trailing whitespace, backslashes, absolute paths, empty segments, trailing separators, `.` and `..` are rejected before any call to the task engine.
 

--- a/plugins/obsidian-operon-bridge/README.md
+++ b/plugins/obsidian-operon-bridge/README.md
@@ -36,7 +36,7 @@ Prefix: `/extensions/optimike-operon-bridge/v1`
 - `POST /tasks/:operonId/convert`
 - `POST /tasks/:operonId/relocate`
 
-All routes inherit Local REST API authentication and local TLS settings. Saved filters run through Operon's native filter evaluator. Mutations require idempotency; an idempotency key is bound to one canonical request and conflicting reuse is rejected. Existing-task mutations require the live revision; in-place adoption instead requires an exact one-based line plus `expectedLine`. Dry-run is the default.
+All routes inherit Local REST API authentication and local TLS settings. Saved filters run through Operon's native filter evaluator. Mutations require idempotency; an idempotency key is bound to one canonical request and conflicting reuse is rejected before later payload validation. Existing-task mutations require the live revision; in-place adoption instead requires an exact one-based line plus `expectedLine`. Dry-run is the default.
 
 Mutation paths are strict, exact vault-relative paths. The MCP and Bridge reject leading or trailing whitespace, backslashes, absolute paths, empty segments, traversal, and non-Markdown `targetPath` values; they never trim or rewrite an invalid destination into a valid one.
 

--- a/plugins/obsidian-operon-bridge/manifest.json
+++ b/plugins/obsidian-operon-bridge/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "optimike-operon-bridge",
   "name": "Optimike Kairélys / Operon Bridge",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "minAppVersion": "1.7.2",
   "description": "Versioned Local REST API bridge from Kairélys or Operon's live task engine to Optimike Obsidian MCP.",
   "author": "Optimike",

--- a/plugins/obsidian-operon-bridge/package-lock.json
+++ b/plugins/obsidian-operon-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optimike-operon-bridge",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optimike-operon-bridge",
-      "version": "0.4.6",
+      "version": "0.4.7",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "esbuild": "^0.25.0",

--- a/plugins/obsidian-operon-bridge/package.json
+++ b/plugins/obsidian-operon-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optimike-operon-bridge",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/obsidian-operon-bridge/src/contract.test.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.test.ts
@@ -12,7 +12,8 @@ import {
   resolveWorkflow,
 	settingsSignature,
 	shouldAttemptIndexValidation,
-	mutationPathValidationError,
+  mutationPathValidationError,
+  resolveMutationPreflight,
   type OperonBridgeTask,
   type RuntimeIndexedTask,
 } from "./contract";
@@ -188,6 +189,65 @@ test("mutation paths are rejected instead of normalized at the Bridge boundary",
 		}),
 		null,
 	);
+});
+
+test("consumed idempotency keys take precedence over replacement validation", () => {
+	const cached = {
+		signature: "original-signature",
+		payload: { ok: true, status: "planned", operationId: "original-operation" },
+	};
+	let validationCalled = false;
+	const conflict = resolveMutationPreflight({
+		cached,
+		idempotencyKey: "stable-idempotency-key",
+		signature: "different-signature",
+		requested: { targetPath: "Efforts/Projets/Test.md " },
+		validate: () => {
+			validationCalled = true;
+			return "invalid path";
+		},
+		operationId: () => "conflict-operation",
+	});
+	assert.equal(conflict.kind, "response");
+	if (conflict.kind === "response") {
+		assert.equal(conflict.response.httpStatus, 409);
+		assert.equal(
+			(conflict.response.payload.error as { code?: string }).code,
+			"idempotency_key_reused",
+		);
+	}
+	assert.equal(validationCalled, false);
+
+	const replay = resolveMutationPreflight({
+		cached,
+		idempotencyKey: "stable-idempotency-key",
+		signature: "original-signature",
+		requested: { targetPath: "Efforts/Projets/Test.md" },
+		validate: () => {
+			validationCalled = true;
+			return "must not run";
+		},
+		operationId: () => "unused-operation",
+	});
+	assert.equal(replay.kind, "response");
+	if (replay.kind === "response") {
+		assert.equal(replay.response.httpStatus, 200);
+		assert.equal(replay.response.payload.replayed, true);
+	}
+	assert.equal(validationCalled, false);
+
+	const invalidFreshRequest = resolveMutationPreflight({
+		cached: undefined,
+		idempotencyKey: "fresh-idempotency-key",
+		signature: "fresh-signature",
+		requested: { targetPath: "Efforts/Projets/Test.md " },
+		validate: () => "invalid path",
+		operationId: () => "unused-operation",
+	});
+	assert.deepEqual(invalidFreshRequest, {
+		kind: "validation-error",
+		message: "invalid path",
+	});
 });
 
 test("index readiness refuses startup, recovery, sync, and dirty states", () => {

--- a/plugins/obsidian-operon-bridge/src/contract.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.ts
@@ -85,6 +85,69 @@ export function mutationPathValidationError(
 	return null;
 }
 
+export interface CachedMutation {
+	signature: string;
+	payload: Record<string, unknown>;
+}
+
+export type MutationPreflightDecision =
+	| {
+		kind: "response";
+		response: { httpStatus: number; payload: Record<string, unknown> };
+	}
+	| { kind: "validation-error"; message: string }
+	| { kind: "continue" };
+
+export function resolveMutationPreflight(options: {
+	cached: CachedMutation | undefined;
+	idempotencyKey: string;
+	signature: string;
+	requested: Record<string, unknown>;
+	validate: () => string | null;
+	operationId: () => string;
+}): MutationPreflightDecision {
+	const { cached, idempotencyKey, signature, requested } = options;
+	if (cached?.signature === signature) {
+		return {
+			kind: "response",
+			response: {
+				httpStatus: 200,
+				payload: { ...cached.payload, replayed: true },
+			},
+		};
+	}
+	if (cached) {
+		return {
+			kind: "response",
+			response: {
+				httpStatus: 409,
+				payload: {
+					ok: false,
+					contractVersion: OPERON_BRIDGE_CONTRACT_VERSION,
+					operationId: options.operationId(),
+					idempotencyKey,
+					status: "conflict",
+					before: null,
+					requested,
+					after: null,
+					error: {
+						code: "idempotency_key_reused",
+						message:
+							"idempotencyKey was already used for a different mutation request.",
+					},
+					retryable: false,
+					source: "operon-live",
+					stale: false,
+				},
+			},
+		};
+	}
+	const validationError = options.validate();
+	return validationError
+		? { kind: "validation-error", message: validationError }
+		: { kind: "continue" };
+}
+
 export type OperonTaskSource = "inline" | "file";
 export type OperonCheckboxState = "open" | "done" | "cancelled";
 export type OperonTier = "hot" | "warm" | "cold";

--- a/plugins/obsidian-operon-bridge/src/main.ts
+++ b/plugins/obsidian-operon-bridge/src/main.ts
@@ -6,6 +6,7 @@ import {
   isIndexReady,
   isCanonicalVaultMarkdownPath,
   mutationPathValidationError,
+  resolveMutationPreflight,
   isVersionCompatible,
   normalizeTask,
   queryTasks,
@@ -22,6 +23,7 @@ import {
   type OperonBridgeConfiguration,
   type OperonSemanticConfiguration,
   type OperonWorkflowTaxonomy,
+  type CachedMutation,
 } from "./contract";
 import { resolveTaskEnginePlugin } from "./task-engine-runtime";
 
@@ -165,11 +167,6 @@ interface StableTaskRead {
   tasks: OperonBridgeTask[];
   generation: number;
   settingsSignature: string;
-}
-
-interface CachedMutation {
-  signature: string;
-  payload: Record<string, unknown>;
 }
 
 const BASE_LIMITATIONS = [
@@ -979,40 +976,20 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
     if (oldest) this.mutationResults.delete(oldest);
   }
 
-  private cachedMutationResult(
+  private mutationPreflight(
     idempotencyKey: string,
     signature: string,
     requested: Record<string, unknown>,
-  ): { httpStatus: number; payload: Record<string, unknown> } | null {
-    const cached = this.mutationResults.get(idempotencyKey);
-    if (!cached) return null;
-    if (cached.signature === signature) {
-      return {
-        httpStatus: 200,
-        payload: { ...cached.payload, replayed: true },
-      };
-    }
-    return {
-      httpStatus: 409,
-      payload: {
-        ok: false,
-        contractVersion: OPERON_BRIDGE_CONTRACT_VERSION,
-        operationId: this.mutationOperationId(),
-        idempotencyKey,
-        status: "conflict",
-        before: null,
-        requested,
-        after: null,
-        error: {
-          code: "idempotency_key_reused",
-          message:
-            "idempotencyKey was already used for a different mutation request.",
-        },
-        retryable: false,
-        source: "operon-live",
-        stale: false,
-      },
-    };
+    validate: () => string | null,
+  ) {
+    return resolveMutationPreflight({
+      cached: this.mutationResults.get(idempotencyKey),
+      idempotencyKey,
+      signature,
+      requested,
+      validate,
+      operationId: () => this.mutationOperationId(),
+    });
   }
 
   private requireMutationRuntime(
@@ -1058,44 +1035,45 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       !Array.isArray(body.adoption)
         ? (body.adoption as Record<string, unknown>)
         : {};
-    const targetPath = requested.targetPath;
-    const line = Number(requested.line);
-    const expectedLine = String(requested.expectedLine ?? "");
-    if (
-      !isCanonicalVaultMarkdownPath(targetPath) ||
-      !Number.isInteger(line) ||
-      line < 1 ||
-      !expectedLine ||
-      /[\r\n]/u.test(expectedLine)
-    ) {
-      return {
-        httpStatus: 400,
-        payload: errorPayload(
-          new Error(
-            "adoption requires targetPath, a positive one-based line, and one exact expectedLine.",
-          ),
-          "validation_error",
-        ),
-      };
-    }
     const signature = stableJson({
       capability: "adopt",
       dryRun: body.dryRun !== false,
       requested,
     });
-    const cached = this.cachedMutationResult(
+    const targetPath = requested.targetPath;
+    const line = Number(requested.line);
+    const expectedLine = String(requested.expectedLine ?? "");
+    const preflight = this.mutationPreflight(
       idempotencyKey,
       signature,
       requested,
+      () =>
+        !isCanonicalVaultMarkdownPath(targetPath) ||
+        !Number.isInteger(line) ||
+        line < 1 ||
+        !expectedLine ||
+        /[\r\n]/u.test(expectedLine)
+          ? "adoption requires targetPath, a positive one-based line, and one exact expectedLine."
+          : null,
     );
-    if (cached) return cached;
+    if (preflight.kind === "response") return preflight.response;
+    if (preflight.kind === "validation-error") {
+      return {
+        httpStatus: 400,
+        payload: errorPayload(
+          new Error(preflight.message),
+          "validation_error",
+        ),
+      };
+    }
+    const canonicalTargetPath = targetPath as string;
     const runtime = this.requireMutationRuntime("adopt");
-    const file = this.app.vault.getAbstractFileByPath(targetPath);
+    const file = this.app.vault.getAbstractFileByPath(canonicalTargetPath);
     if (!(file instanceof TFile)) {
       return {
         httpStatus: 404,
         payload: errorPayload(
-          new Error(`Markdown source file not found: ${targetPath}`),
+          new Error(`Markdown source file not found: ${canonicalTargetPath}`),
           "not_found",
         ),
       };
@@ -1194,7 +1172,8 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       return { httpStatus: 500, payload };
     }
     const after = afterRead.task;
-    const locationMatches = after?.path === targetPath && after.line === line;
+    const locationMatches =
+      after?.path === canonicalTargetPath && after?.line === line;
     const payload = {
       ok: Boolean(after && locationMatches),
       contractVersion: OPERON_BRIDGE_CONTRACT_VERSION,
@@ -1339,13 +1318,6 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
         ),
       };
     }
-    const pathError = mutationPathValidationError(capability, requested);
-    if (pathError) {
-      return {
-        httpStatus: 400,
-        payload: errorPayload(new Error(pathError), "validation_error"),
-      };
-    }
     const signature = stableJson({
       capability,
       operonId,
@@ -1353,12 +1325,19 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       dryRun: body.dryRun !== false,
       requested,
     });
-    const cached = this.cachedMutationResult(
+    const preflight = this.mutationPreflight(
       idempotencyKey,
       signature,
       requested,
+      () => mutationPathValidationError(capability, requested),
     );
-    if (cached) return cached;
+    if (preflight.kind === "response") return preflight.response;
+    if (preflight.kind === "validation-error") {
+      return {
+        httpStatus: 400,
+        payload: errorPayload(new Error(preflight.message), "validation_error"),
+      };
+    }
 
     const runtime = this.requireMutationRuntime(capability);
     const beforeRead = await this.oneTask(operonId, true);
@@ -1491,24 +1470,24 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       body.task && typeof body.task === "object" && !Array.isArray(body.task)
         ? (body.task as Record<string, unknown>)
         : {};
-    const pathError = mutationPathValidationError("create", requested);
-    if (pathError) {
-      return {
-        httpStatus: 400,
-        payload: errorPayload(new Error(pathError), "validation_error"),
-      };
-    }
     const signature = stableJson({
       capability: "create",
       dryRun: body.dryRun !== false,
       requested,
     });
-    const cached = this.cachedMutationResult(
+    const preflight = this.mutationPreflight(
       idempotencyKey,
       signature,
       requested,
+      () => mutationPathValidationError("create", requested),
     );
-    if (cached) return cached;
+    if (preflight.kind === "response") return preflight.response;
+    if (preflight.kind === "validation-error") {
+      return {
+        httpStatus: 400,
+        payload: errorPayload(new Error(preflight.message), "validation_error"),
+      };
+    }
     const runtime = this.requireMutationRuntime("create");
     const operationId = this.mutationOperationId();
     if (body.dryRun !== false) {


### PR DESCRIPTION
## Summary
- resolve consumed idempotency keys before validating replacement payloads
- apply the same precedence to adopt, create, update, transition, convert, and relocate
- add a lazy preflight contract proving validation is not evaluated for replay/conflict paths
- bump Optimike Operon Bridge to 0.4.7

## Review feedback
Closes the unresolved P3 from #22: https://github.com/optimikelabs/optimike-obsidian-mcp/pull/22#discussion_r3635348606

## Validation
- npm run check:operon
- npm run test:profiles
- npm run test:tool-annotations
- npm run test:package
