### PR TITLE
fix: harden external root confinement

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -238,7 +238,8 @@ est liée au handle vérifié et son dossier temporaire, détenu par le processu
 est supprimé à l’arrêt du MCP. Les copies expirent après une heure, sont
 nettoyées toutes les cinq minutes et restent limitées à 16 fichiers et 512 Mio
 par processus ; les dossiers abandonnés par un processus mort sont récupérés au
-prochain démarrage d’un service de handoff.
+prochain démarrage d’un service configuré. Un heartbeat borné évite qu’un PID
+réutilisé soit confondu durablement avec le processus propriétaire.
 
 Le cœur MCP n’embarque aucun moteur PDF, Office ou OCR. Codex, Claude Code,
 Gemini CLI, OpenClaw ou Hermes Agent peuvent utiliser leurs propres outils

--- a/README.fr.md
+++ b/README.fr.md
@@ -232,8 +232,10 @@ configuration.
 
 La première version expose des outils bornés et read-only pour l’état, la liste,
 les métadonnées, le SHA-256 et la lecture UTF-8. `external_handoff` peut remettre
-le chemin physique vérifié d’un seul fichier uniquement à un client stdio local,
-et seulement si la racine possède `readable` et `handoff`.
+une copie locale temporaire vérifiée d’un seul fichier uniquement à un client
+stdio local, et seulement si la racine possède `readable` et `handoff`. La copie
+est liée au handle vérifié et son dossier temporaire, détenu par le processus,
+est supprimé à l’arrêt du MCP.
 
 Le cœur MCP n’embarque aucun moteur PDF, Office ou OCR. Codex, Claude Code,
 Gemini CLI, OpenClaw ou Hermes Agent peuvent utiliser leurs propres outils

--- a/README.fr.md
+++ b/README.fr.md
@@ -235,7 +235,10 @@ les métadonnées, le SHA-256 et la lecture UTF-8. `external_handoff` peut remet
 une copie locale temporaire vérifiée d’un seul fichier uniquement à un client
 stdio local, et seulement si la racine possède `readable` et `handoff`. La copie
 est liée au handle vérifié et son dossier temporaire, détenu par le processus,
-est supprimé à l’arrêt du MCP.
+est supprimé à l’arrêt du MCP. Les copies expirent après une heure, sont
+nettoyées toutes les cinq minutes et restent limitées à 16 fichiers et 512 Mio
+par processus ; les dossiers abandonnés par un processus mort sont récupérés au
+prochain démarrage d’un service de handoff.
 
 Le cœur MCP n’embarque aucun moteur PDF, Office ou OCR. Codex, Claude Code,
 Gemini CLI, OpenClaw ou Hermes Agent peuvent utiliser leurs propres outils

--- a/README.md
+++ b/README.md
@@ -227,8 +227,10 @@ machine-local path, adapt the roots and limits, then set the absolute path in
 
 The first release exposes bounded read-only tools for root status, listing,
 metadata, SHA-256, and UTF-8 text reads. `external_handoff` can return one
-verified physical file path only to a local stdio client and only when the root
-has both `readable` and `handoff`.
+verified temporary local copy only to a local stdio client and only when the
+root has both `readable` and `handoff`. The copy is tied to the verified file
+handle and its process-owned temporary directory is removed when the MCP
+process exits.
 
 The MCP core does not embed PDF, Office, or OCR engines. Agent clients such as
 Codex, Claude Code, Gemini CLI, OpenClaw, or Hermes Agent can use their own

--- a/README.md
+++ b/README.md
@@ -230,7 +230,9 @@ metadata, SHA-256, and UTF-8 text reads. `external_handoff` can return one
 verified temporary local copy only to a local stdio client and only when the
 root has both `readable` and `handoff`. The copy is tied to the verified file
 handle and its process-owned temporary directory is removed when the MCP
-process exits.
+process exits. Copies expire after one hour, are swept every five minutes, and
+are capped at 16 files and 512 MiB per process; abandoned directories from dead
+processes are scavenged on the next handoff service startup.
 
 The MCP core does not embed PDF, Office, or OCR engines. Agent clients such as
 Codex, Claude Code, Gemini CLI, OpenClaw, or Hermes Agent can use their own

--- a/README.md
+++ b/README.md
@@ -232,7 +232,8 @@ root has both `readable` and `handoff`. The copy is tied to the verified file
 handle and its process-owned temporary directory is removed when the MCP
 process exits. Copies expire after one hour, are swept every five minutes, and
 are capped at 16 files and 512 MiB per process; abandoned directories from dead
-processes are scavenged on the next handoff service startup.
+processes or stale ownership heartbeats are scavenged when the next configured
+service starts.
 
 The MCP core does not embed PDF, Office, or OCR engines. Agent clients such as
 Codex, Claude Code, Gemini CLI, OpenClaw, or Hermes Agent can use their own

--- a/docs/adr/ADR-External-Document-Roots.md
+++ b/docs/adr/ADR-External-Document-Roots.md
@@ -65,8 +65,8 @@ Initial capability vocabulary:
 
 - `visible`: disclose root metadata and bounded directory entries;
 - `readable`: hash or read an explicitly requested UTF-8 text file;
-- `handoff`: reveal one verified local file path to an explicitly requesting
-  local stdio client so that the client can use its own document tools.
+- `handoff`: create one verified temporary local copy for an explicitly
+  requesting local stdio client so that it can use its own document tools.
 
 `extractable` and `indexable` are reserved for optional future adapters. They
 are not implemented by the core service.
@@ -103,9 +103,12 @@ PPTX, ODF, RTF, OCR, and active rendering remain the responsibility of the
 calling agent harness or an optional future adapter.
 
 `external_handoff` is the only operation that returns a physical local path.
-It requires both `readable` and `handoff`, verifies confinement and size first,
-and is available only over stdio. Lists, status, stat, and text reads remain
-portable and never expose the machine path.
+It requires both `readable` and `handoff`, reads through a handle whose
+filesystem identity is revalidated after open, writes a process-owned temporary
+copy, and is available only over stdio. Returning a verified copy avoids
+re-opening a source path whose ancestors could be swapped after validation. The
+temporary directory is removed when the MCP process exits. Lists, status, stat,
+and text reads remain portable and never expose the machine path.
 
 This preserves a clean responsibility boundary:
 
@@ -170,7 +173,7 @@ carry read-only MCP annotations.
 2. Traversal, absolute-path, include/exclude, capability, and size-limit tests.
 3. Windows junction escape rejection.
 4. Public status/list/stat/read outputs without physical paths.
-5. Explicit handoff as the only physical-path disclosure.
+5. Explicit handoff copy as the only physical-path disclosure.
 6. Stdio-only handoff policy.
 7. Read-only annotations on every MCP tool.
 8. Disposable-root tests plus a limited AMEX pilot.

--- a/docs/adr/ADR-External-Document-Roots.md
+++ b/docs/adr/ADR-External-Document-Roots.md
@@ -108,7 +108,10 @@ filesystem identity is revalidated after open, writes a process-owned temporary
 copy, and is available only over stdio. Returning a verified copy avoids
 re-opening a source path whose ancestors could be swapped after validation. The
 temporary directory is removed when the MCP process exits. Lists, status, stat,
-and text reads remain portable and never expose the machine path.
+and text reads remain portable and never expose the machine path. The handoff
+cache expires copies after one hour, sweeps every five minutes, evicts the
+oldest entries above 16 files or 512 MiB, and scavenges directories owned by
+dead processes on the next service startup.
 
 This preserves a clean responsibility boundary:
 

--- a/docs/adr/ADR-External-Document-Roots.md
+++ b/docs/adr/ADR-External-Document-Roots.md
@@ -111,7 +111,9 @@ temporary directory is removed when the MCP process exits. Lists, status, stat,
 and text reads remain portable and never expose the machine path. The handoff
 cache expires copies after one hour, sweeps every five minutes, evicts the
 oldest entries above 16 files or 512 MiB, and scavenges directories owned by
-dead processes on the next service startup.
+dead processes or stale ownership heartbeats on the next configured service
+startup. The heartbeat prevents PID reuse from preserving abandoned copies
+indefinitely.
 
 This preserves a clean responsibility boundary:
 

--- a/docs/obsidian_mcp_tools_spec.md
+++ b/docs/obsidian_mcp_tools_spec.md
@@ -135,8 +135,8 @@ machine-local JSON configuration.
   are visible but never followed.
 - `external_stat`: bounded metadata and optional SHA-256.
 - `external_read`: bounded UTF-8 text read.
-- `external_handoff`: explicit verified physical-path handoff to a local stdio
-  client that has its own PDF or Office tooling.
+- `external_handoff`: explicit handoff of a verified temporary local copy to a
+  local stdio client that has its own PDF or Office tooling.
 
 The core MCP does not parse PDF or Office files. Handoff requires both
 `readable` and `handoff`; it is denied on HTTP. See

--- a/scripts/test-external-roots.mjs
+++ b/scripts/test-external-roots.mjs
@@ -40,6 +40,8 @@ try {
   await mkdir(outsidePath, { recursive: true });
   await writeFile(path.join(rootPath, "hello.txt"), "Bonjour ÉLYSIA", "utf8");
   await writeFile(path.join(rootPath, "empty.txt"), "", "utf8");
+  const longSourceName = `${"a".repeat(230)}.txt`;
+  await writeFile(path.join(rootPath, longSourceName), "long name", "utf8");
   await writeFile(path.join(rootPath, "LICENSE"), "private license", "utf8");
   await writeFile(
     path.join(rootPath, "docs", "note.md"),
@@ -120,6 +122,13 @@ try {
   assert.notEqual(handoff.localPath, path.join(rootPath, "hello.txt"));
   assert.equal(await readFile(handoff.localPath, "utf8"), "Bonjour ÉLYSIA");
   assert.equal(handoff.sha256, read.sha256);
+  const longNameHandoff = await service.handoff(
+    "pilot.docs",
+    longSourceName,
+    false,
+  );
+  assert.match(path.basename(longNameHandoff.localPath), /^[0-9a-f-]{36}\.txt$/);
+  assert.equal(await readFile(longNameHandoff.localPath, "utf8"), "long name");
 
   for (let index = 0; index < 16; index += 1) {
     await service.handoff("pilot.docs", "hello.txt", false);

--- a/scripts/test-external-roots.mjs
+++ b/scripts/test-external-roots.mjs
@@ -34,6 +34,7 @@ async function expectCode(operation, expectedCode) {
 
 try {
   await mkdir(path.join(rootPath, "docs"), { recursive: true });
+  await mkdir(path.join(rootPath, "blocking.txt"), { recursive: true });
   await mkdir(path.join(rootPath, "secret"), { recursive: true });
   await mkdir(outsidePath, { recursive: true });
   await writeFile(path.join(rootPath, "hello.txt"), "Bonjour ÉLYSIA", "utf8");
@@ -200,6 +201,10 @@ try {
   await expectCode(
     () => service.handoff("pilot.docs", "LICENSE", true),
     "path_not_allowed",
+  );
+  await expectCode(
+    () => service.readText("pilot.docs", "blocking.txt"),
+    "not_a_file",
   );
   if (linkCreated) {
     await expectCode(

--- a/scripts/test-external-roots.mjs
+++ b/scripts/test-external-roots.mjs
@@ -8,6 +8,7 @@ import {
   readdir,
   rm,
   symlink,
+  utimes,
   writeFile,
 } from "node:fs/promises";
 import os from "node:os";
@@ -131,11 +132,10 @@ try {
   const abandonedHandoffDirectory = await mkdtemp(
     path.join(os.tmpdir(), "optimike-external-handoff-"),
   );
-  await writeFile(
-    path.join(abandonedHandoffDirectory, ".owner.json"),
-    JSON.stringify({ pid: 2_147_483_647 }),
-    "utf8",
-  );
+  const abandonedOwner = path.join(abandonedHandoffDirectory, ".owner.json");
+  await writeFile(abandonedOwner, JSON.stringify({ pid: process.pid }), "utf8");
+  const staleHeartbeat = new Date(Date.now() - 21 * 60 * 1000);
+  await utimes(abandonedOwner, staleHeartbeat, staleHeartbeat);
   await writeFile(
     path.join(abandonedHandoffDirectory, "sensitive.txt"),
     "stale",
@@ -153,7 +153,7 @@ try {
       },
     ],
   });
-  await scavengingService.handoff("scavenger", "hello.txt", false);
+  await scavengingService.listRoots();
   await assert.rejects(() => access(abandonedHandoffDirectory));
 
   const handlers = new Map();

--- a/scripts/test-external-roots.mjs
+++ b/scripts/test-external-roots.mjs
@@ -1,9 +1,11 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import {
+  access,
   mkdtemp,
   mkdir,
   readFile,
+  readdir,
   rm,
   symlink,
   writeFile,
@@ -115,6 +117,43 @@ try {
   assert.notEqual(handoff.localPath, path.join(rootPath, "hello.txt"));
   assert.equal(await readFile(handoff.localPath, "utf8"), "Bonjour ÉLYSIA");
   assert.equal(handoff.sha256, read.sha256);
+
+  for (let index = 0; index < 16; index += 1) {
+    await service.handoff("pilot.docs", "hello.txt", false);
+  }
+  await assert.rejects(() => access(handoff.localPath));
+  const retainedCopies = (
+    await readdir(path.dirname(handoff.localPath))
+  ).filter((name) => name !== ".owner.json");
+  assert.equal(retainedCopies.length, 16);
+
+  const abandonedHandoffDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "optimike-external-handoff-"),
+  );
+  await writeFile(
+    path.join(abandonedHandoffDirectory, ".owner.json"),
+    JSON.stringify({ pid: 2_147_483_647 }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(abandonedHandoffDirectory, "sensitive.txt"),
+    "stale",
+    "utf8",
+  );
+  const scavengingService = ExternalRootsService.fromConfig({
+    version: 1,
+    roots: [
+      {
+        id: "scavenger",
+        path: rootPath,
+        capabilities: ["visible", "readable", "handoff"],
+        include: ["**/*.txt"],
+        limits: { maxFileBytes: 1024 },
+      },
+    ],
+  });
+  await scavengingService.handoff("scavenger", "hello.txt", false);
+  await assert.rejects(() => access(abandonedHandoffDirectory));
 
   const handlers = new Map();
   const annotations = new Map();
@@ -297,7 +336,7 @@ try {
   assert.equal(JSON.stringify(redacted).includes(rootPath), false);
 
   console.log(
-    `PASS: external roots confinement, strict allowlists, handle identity, redaction, limits, hashing and explicit local handoff${linkCreated ? ", including junction rejection" : ""}`,
+    `PASS: external roots confinement, strict allowlists, handle identity, redaction, limits, bounded handoff copies, stale-directory scavenging and explicit local handoff${linkCreated ? ", including junction rejection" : ""}`,
   );
 } finally {
   await rm(sandbox, { recursive: true, force: true });

--- a/scripts/test-external-roots.mjs
+++ b/scripts/test-external-roots.mjs
@@ -39,6 +39,7 @@ try {
   await mkdir(path.join(rootPath, "secret"), { recursive: true });
   await mkdir(outsidePath, { recursive: true });
   await writeFile(path.join(rootPath, "hello.txt"), "Bonjour ÉLYSIA", "utf8");
+  await writeFile(path.join(rootPath, "empty.txt"), "", "utf8");
   await writeFile(path.join(rootPath, "LICENSE"), "private license", "utf8");
   await writeFile(
     path.join(rootPath, "docs", "note.md"),
@@ -128,11 +129,21 @@ try {
     await readdir(path.dirname(handoff.localPath))
   ).filter((name) => name !== ".owner.json");
   assert.equal(retainedCopies.length, 16);
-  await service.pruneHandoffDirectory(path.dirname(handoff.localPath), 0);
+  await service.pruneHandoffDirectory(
+    path.dirname(handoff.localPath),
+    0,
+    false,
+  );
   const retainedAfterSweep = (await readdir(path.dirname(handoff.localPath)))
     .filter((name) => name !== ".owner.json")
     .sort();
   assert.deepEqual(retainedAfterSweep, retainedCopies.sort());
+  const emptyHandoff = await service.handoff("pilot.docs", "empty.txt", false);
+  assert.equal((await readFile(emptyHandoff.localPath)).length, 0);
+  const retainedAfterEmptyHandoff = (
+    await readdir(path.dirname(emptyHandoff.localPath))
+  ).filter((name) => name !== ".owner.json");
+  assert.equal(retainedAfterEmptyHandoff.length, 16);
 
   const abandonedHandoffDirectory = await mkdtemp(
     path.join(os.tmpdir(), "optimike-external-handoff-"),

--- a/scripts/test-external-roots.mjs
+++ b/scripts/test-external-roots.mjs
@@ -161,6 +161,21 @@ try {
   ]);
   service.readVerifiedBuffer = originalReadVerifiedBuffer;
   assert.equal(maxConcurrentHandoffReads, 1);
+  const originalReadOpenedFile = service.readOpenedFile.bind(service);
+  service.readOpenedFile = async (...args) => {
+    const buffer = await originalReadOpenedFile(...args);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const changed = Buffer.from(buffer);
+    changed[0] ^= 1;
+    await writeFile(path.join(rootPath, "hello.txt"), changed);
+    return buffer;
+  };
+  await expectCode(
+    () => service.handoff("pilot.docs", "hello.txt", false),
+    "non_verifiable",
+  );
+  service.readOpenedFile = originalReadOpenedFile;
+  await writeFile(path.join(rootPath, "hello.txt"), "Bonjour ÉLYSIA", "utf8");
 
   for (let index = 0; index < 16; index += 1) {
     await service.handoff("pilot.docs", "hello.txt", false);

--- a/scripts/test-external-roots.mjs
+++ b/scripts/test-external-roots.mjs
@@ -8,7 +8,6 @@ import {
   readdir,
   rm,
   symlink,
-  utimes,
   writeFile,
 } from "node:fs/promises";
 import os from "node:os";
@@ -127,8 +126,41 @@ try {
     longSourceName,
     false,
   );
-  assert.match(path.basename(longNameHandoff.localPath), /^[0-9a-f-]{36}\.txt$/);
+  assert.match(
+    path.basename(longNameHandoff.localPath),
+    /^[0-9a-f-]{36}\.txt$/,
+  );
   assert.equal(await readFile(longNameHandoff.localPath, "utf8"), "long name");
+  const longExtensionCopy = await service.withHandoffLock(() =>
+    service.createHandoffCopy(
+      `source.${"x".repeat(220)}`,
+      Buffer.from("long extension"),
+    ),
+  );
+  assert.match(path.basename(longExtensionCopy), /^[0-9a-f-]{36}$/);
+  assert.equal(await readFile(longExtensionCopy, "utf8"), "long extension");
+  const originalReadVerifiedBuffer = service.readVerifiedBuffer.bind(service);
+  let activeHandoffReads = 0;
+  let maxConcurrentHandoffReads = 0;
+  service.readVerifiedBuffer = async (...args) => {
+    activeHandoffReads += 1;
+    maxConcurrentHandoffReads = Math.max(
+      maxConcurrentHandoffReads,
+      activeHandoffReads,
+    );
+    try {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      return await originalReadVerifiedBuffer(...args);
+    } finally {
+      activeHandoffReads -= 1;
+    }
+  };
+  await Promise.all([
+    service.handoff("pilot.docs", "hello.txt", false),
+    service.handoff("pilot.docs", "hello.txt", false),
+  ]);
+  service.readVerifiedBuffer = originalReadVerifiedBuffer;
+  assert.equal(maxConcurrentHandoffReads, 1);
 
   for (let index = 0; index < 16; index += 1) {
     await service.handoff("pilot.docs", "hello.txt", false);
@@ -158,9 +190,17 @@ try {
     path.join(os.tmpdir(), "optimike-external-handoff-"),
   );
   const abandonedOwner = path.join(abandonedHandoffDirectory, ".owner.json");
-  await writeFile(abandonedOwner, JSON.stringify({ pid: process.pid }), "utf8");
-  const staleHeartbeat = new Date(Date.now() - 21 * 60 * 1000);
-  await utimes(abandonedOwner, staleHeartbeat, staleHeartbeat);
+  await writeFile(
+    abandonedOwner,
+    JSON.stringify({
+      kind: "optimike-external-handoff",
+      version: 1,
+      pid: process.pid,
+      startedAt: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      heartbeatAt: new Date(Date.now() - 21 * 60 * 1000).toISOString(),
+    }),
+    "utf8",
+  );
   await writeFile(
     path.join(abandonedHandoffDirectory, "sensitive.txt"),
     "stale",
@@ -180,6 +220,17 @@ try {
   });
   await scavengingService.listRoots();
   await assert.rejects(() => access(abandonedHandoffDirectory));
+  const unownedDirectory = await mkdtemp(
+    path.join(os.tmpdir(), "optimike-external-handoff-"),
+  );
+  await writeFile(path.join(unownedDirectory, "unrelated.txt"), "keep", "utf8");
+  const nonDeletingService = ExternalRootsService.fromConfig({
+    version: 1,
+    roots: [],
+  });
+  await nonDeletingService.listRoots();
+  await access(path.join(unownedDirectory, "unrelated.txt"));
+  await rm(unownedDirectory, { recursive: true, force: true });
 
   const handlers = new Map();
   const annotations = new Map();

--- a/scripts/test-external-roots.mjs
+++ b/scripts/test-external-roots.mjs
@@ -128,6 +128,11 @@ try {
     await readdir(path.dirname(handoff.localPath))
   ).filter((name) => name !== ".owner.json");
   assert.equal(retainedCopies.length, 16);
+  await service.pruneHandoffDirectory(path.dirname(handoff.localPath), 0);
+  const retainedAfterSweep = (await readdir(path.dirname(handoff.localPath)))
+    .filter((name) => name !== ".owner.json")
+    .sort();
+  assert.deepEqual(retainedAfterSweep, retainedCopies.sort());
 
   const abandonedHandoffDirectory = await mkdtemp(
     path.join(os.tmpdir(), "optimike-external-handoff-"),

--- a/scripts/test-external-roots.mjs
+++ b/scripts/test-external-roots.mjs
@@ -1,6 +1,13 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtemp, mkdir, rm, symlink, writeFile } from "node:fs/promises";
+import {
+  mkdtemp,
+  mkdir,
+  readFile,
+  rm,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -28,6 +35,7 @@ try {
   await mkdir(path.join(rootPath, "secret"), { recursive: true });
   await mkdir(outsidePath, { recursive: true });
   await writeFile(path.join(rootPath, "hello.txt"), "Bonjour ÉLYSIA", "utf8");
+  await writeFile(path.join(rootPath, "LICENSE"), "private license", "utf8");
   await writeFile(
     path.join(rootPath, "docs", "note.md"),
     "# Note\nContenu",
@@ -103,7 +111,9 @@ try {
   assert.equal("localPath" in metadata, false);
 
   const handoff = await service.handoff("pilot.docs", "hello.txt", true);
-  assert.equal(handoff.localPath, path.join(rootPath, "hello.txt"));
+  assert.equal(path.isAbsolute(handoff.localPath), true);
+  assert.notEqual(handoff.localPath, path.join(rootPath, "hello.txt"));
+  assert.equal(await readFile(handoff.localPath, "utf8"), "Bonjour ÉLYSIA");
   assert.equal(handoff.sha256, read.sha256);
 
   const handlers = new Map();
@@ -144,11 +154,37 @@ try {
     () => service.readText("pilot.docs", "secret/hidden.txt"),
     "path_not_allowed",
   );
+  await expectCode(
+    () => service.getStat("pilot.docs", "LICENSE", true),
+    "path_not_allowed",
+  );
+  await expectCode(
+    () => service.handoff("pilot.docs", "LICENSE", true),
+    "path_not_allowed",
+  );
   if (linkCreated) {
     await expectCode(
       () => service.readText("pilot.docs", "escape-link/outside.txt"),
       "path_link_unsupported",
     );
+  }
+
+  const originalResolvePath = service.resolvePath.bind(service);
+  let resolveCount = 0;
+  service.resolvePath = async (...args) => {
+    resolveCount += 1;
+    if (resolveCount === 2) {
+      return path.join(outsidePath, "outside.txt");
+    }
+    return originalResolvePath(...args);
+  };
+  try {
+    await expectCode(
+      () => service.readText("pilot.docs", "hello.txt"),
+      "non_verifiable",
+    );
+  } finally {
+    service.resolvePath = originalResolvePath;
   }
 
   const limitedService = ExternalRootsService.fromConfig({
@@ -236,8 +272,32 @@ try {
       error.code === "configuration_invalid",
   );
 
+  const redactionHandlers = new Map();
+  await registerExternalRootsTools(
+    {
+      tool(name, _description, _schema, _annotations, handler) {
+        redactionHandlers.set(name, handler);
+      },
+    },
+    {
+      async listRoots() {
+        throw new Error(`native failure at ${rootPath}`);
+      },
+    },
+    false,
+  );
+  const redacted = await redactionHandlers.get("external_roots_list")();
+  const redactedPayload = JSON.parse(redacted.content[0].text);
+  assert.equal(redacted.isError, true);
+  assert.equal(redactedPayload.error, "non_verifiable");
+  assert.equal(
+    redactedPayload.message,
+    "The external path could not be verified.",
+  );
+  assert.equal(JSON.stringify(redacted).includes(rootPath), false);
+
   console.log(
-    `PASS: external roots confinement, capabilities, redaction, limits, hashing and explicit local handoff${linkCreated ? ", including junction rejection" : ""}`,
+    `PASS: external roots confinement, strict allowlists, handle identity, redaction, limits, hashing and explicit local handoff${linkCreated ? ", including junction rejection" : ""}`,
   );
 } finally {
   await rm(sandbox, { recursive: true, force: true });

--- a/scripts/test-stdio-proxy-external-roots.mjs
+++ b/scripts/test-stdio-proxy-external-roots.mjs
@@ -3,7 +3,7 @@
 import assert from "node:assert/strict";
 import { spawn } from "node:child_process";
 import { createServer } from "node:net";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -53,17 +53,25 @@ const sandbox = await mkdtemp(
 );
 const vaultPath = path.join(sandbox, "vault");
 const externalPath = path.join(sandbox, "external");
+const backendExternalPath = path.join(sandbox, "backend-external");
 const configPath = path.join(sandbox, "external-roots.json");
+const backendConfigPath = path.join(sandbox, "backend-external-roots.json");
 const port = await unusedPort();
 const httpUrl = new URL(`http://127.0.0.1:${port}/mcp`);
 const healthUrl = new URL(`http://127.0.0.1:${port}/healthz`);
 
 await mkdir(path.join(vaultPath, ".obsidian"), { recursive: true });
 await mkdir(externalPath, { recursive: true });
+await mkdir(backendExternalPath, { recursive: true });
 await writeFile(path.join(vaultPath, "Smoke.md"), "# Smoke\n", "utf8");
 await writeFile(
   path.join(externalPath, "hello.txt"),
   "Bonjour depuis le proxy",
+  "utf8",
+);
+await writeFile(
+  path.join(backendExternalPath, "backend.txt"),
+  "Ancienne configuration backend",
   "utf8",
 );
 await writeFile(
@@ -87,6 +95,21 @@ await writeFile(
   }),
   "utf8",
 );
+await writeFile(
+  backendConfigPath,
+  JSON.stringify({
+    version: 1,
+    roots: [
+      {
+        id: "backend.pilot",
+        path: backendExternalPath,
+        capabilities: ["visible", "readable"],
+        include: ["**/*.txt"],
+      },
+    ],
+  }),
+  "utf8",
+);
 
 const commonEnv = {
   ...process.env,
@@ -100,7 +123,7 @@ const commonEnv = {
   MCP_HTTP_HOST: "127.0.0.1",
   MCP_HTTP_PORT: String(port),
   MCP_LOG_LEVEL: "error",
-  MCP_EXTERNAL_ROOTS_FILE: configPath,
+  MCP_EXTERNAL_ROOTS_FILE: backendConfigPath,
 };
 
 const backend = spawn(process.execPath, ["dist/index.js"], {
@@ -115,6 +138,7 @@ const proxyTransport = new StdioClientTransport({
   cwd: process.cwd(),
   env: {
     ...commonEnv,
+    MCP_EXTERNAL_ROOTS_FILE: configPath,
     MCP_PROXY_START_TIMEOUT_MS: "20000",
   },
 });
@@ -140,6 +164,17 @@ try {
   assert.equal(status.enabled, true);
   assert.equal(status.localHandoffAllowed, true);
   assert.equal(JSON.stringify(status).includes(externalPath), false);
+
+  const roots = jsonOf(
+    await proxyClient.callTool({
+      name: "external_roots_list",
+      arguments: {},
+    }),
+  );
+  assert.deepEqual(
+    roots.roots.map((root) => root.id),
+    ["proxy.pilot"],
+  );
 
   const listing = jsonOf(
     await proxyClient.callTool({
@@ -190,7 +225,12 @@ try {
       },
     }),
   );
-  assert.equal(handoff.localPath, path.join(externalPath, "hello.txt"));
+  assert.equal(path.isAbsolute(handoff.localPath), true);
+  assert.notEqual(handoff.localPath, path.join(externalPath, "hello.txt"));
+  assert.equal(
+    await readFile(handoff.localPath, "utf8"),
+    "Bonjour depuis le proxy",
+  );
   assert.equal(handoff.sha256, read.sha256);
 
   const invalidHandoff = await proxyClient.callTool({
@@ -226,7 +266,7 @@ try {
   }
 
   console.log(
-    "PASS: stdio proxy owns explicit handoff, HTTP denies it, and delegated external list/stat/read remain path-redacted",
+    "PASS: stdio proxy owns one external-roots configuration for status/list/stat/read/handoff, HTTP denies handoff, and responses remain path-redacted",
   );
 } finally {
   await proxyClient.close().catch(() => undefined);

--- a/src/mcp-server/tools/externalRootsTools/registration.ts
+++ b/src/mcp-server/tools/externalRootsTools/registration.ts
@@ -6,7 +6,7 @@ import {
 } from "../../../services/externalRootsService.js";
 import { READ_ONLY_TOOL_ANNOTATIONS } from "../../toolAnnotations.js";
 
-const RootPathSchema = z
+export const ExternalRootPathSchema = z
   .object({
     rootId: z
       .string()
@@ -21,20 +21,20 @@ const RootPathSchema = z
   })
   .strict();
 
-const ListSchema = RootPathSchema.extend({
+export const ExternalListSchema = ExternalRootPathSchema.extend({
   depth: z.number().int().min(0).max(20).default(1),
   maxEntries: z.number().int().positive().max(5000).optional(),
 });
 
-const StatSchema = RootPathSchema.extend({
+export const ExternalStatSchema = ExternalRootPathSchema.extend({
   includeHash: z.boolean().default(false),
 });
 
-const ReadSchema = RootPathSchema.extend({
+export const ExternalReadSchema = ExternalRootPathSchema.extend({
   maxChars: z.number().int().positive().max(2_000_000).optional(),
 });
 
-export const ExternalHandoffSchema = RootPathSchema.extend({
+export const ExternalHandoffSchema = ExternalRootPathSchema.extend({
   includeHash: z.boolean().default(true),
 });
 
@@ -58,12 +58,17 @@ export function externalRootsResult(operation: () => Promise<unknown>) {
         isError: false,
       };
     } catch (error) {
+      if (!(error instanceof ExternalRootError)) {
+        console.error(
+          "[external-roots] Unexpected filesystem error; details redacted.",
+        );
+      }
       const externalError =
         error instanceof ExternalRootError
           ? error
           : new ExternalRootError(
               "non_verifiable",
-              error instanceof Error ? error.message : String(error),
+              "The external path could not be verified.",
             );
       return {
         content: [
@@ -113,9 +118,9 @@ export async function registerExternalRootsTools(
   server.tool(
     "external_list",
     "Lists bounded directory entries inside one configured external root. Paths are root-relative and links are never followed.",
-    ListSchema.shape,
+    ExternalListSchema.shape,
     READ_ONLY_TOOL_ANNOTATIONS,
-    async (params: z.infer<typeof ListSchema>) =>
+    async (params: z.infer<typeof ExternalListSchema>) =>
       externalRootsResult(() =>
         service
           ? service.list(
@@ -131,9 +136,9 @@ export async function registerExternalRootsTools(
   server.tool(
     "external_stat",
     "Returns bounded metadata and optionally a SHA-256 hash for one root-relative external file.",
-    StatSchema.shape,
+    ExternalStatSchema.shape,
     READ_ONLY_TOOL_ANNOTATIONS,
-    async (params: z.infer<typeof StatSchema>) =>
+    async (params: z.infer<typeof ExternalStatSchema>) =>
       externalRootsResult(() =>
         service
           ? service.getStat(
@@ -148,9 +153,9 @@ export async function registerExternalRootsTools(
   server.tool(
     "external_read",
     "Reads bounded UTF-8 text from one explicitly allowed root-relative file. For binary and Office documents, a local stdio client can explicitly request external_handoff and use its own document tools.",
-    ReadSchema.shape,
+    ExternalReadSchema.shape,
     READ_ONLY_TOOL_ANNOTATIONS,
-    async (params: z.infer<typeof ReadSchema>) =>
+    async (params: z.infer<typeof ExternalReadSchema>) =>
       externalRootsResult(() =>
         service
           ? service.readText(
@@ -164,7 +169,7 @@ export async function registerExternalRootsTools(
 
   server.tool(
     "external_handoff",
-    "Returns a verified local file path for an explicitly allowed stdio client so that its own document tools can process the file. Physical paths are disclosed only by this explicit handoff.",
+    "Returns a verified temporary local copy for an explicitly allowed stdio client so that its own document tools can process the file. A physical path is disclosed only by this explicit handoff.",
     ExternalHandoffSchema.shape,
     READ_ONLY_TOOL_ANNOTATIONS,
     async (params: z.infer<typeof ExternalHandoffSchema>) =>

--- a/src/services/externalRootsService.ts
+++ b/src/services/externalRootsService.ts
@@ -623,7 +623,7 @@ export class ExternalRootsService {
     files.sort((a, b) => a.modifiedAt - b.modifiedAt);
     let totalBytes = files.reduce((total, file) => total + file.size, 0);
     while (
-      files.length >= HANDOFF_MAX_FILES ||
+      files.length + (incomingBytes > 0 ? 1 : 0) > HANDOFF_MAX_FILES ||
       totalBytes + incomingBytes > HANDOFF_MAX_TOTAL_BYTES
     ) {
       const oldest = files.shift();

--- a/src/services/externalRootsService.ts
+++ b/src/services/externalRootsService.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from "node:crypto";
 import { rmSync } from "node:fs";
 import {
+  type FileHandle,
   lstat,
   mkdtemp,
   open,
@@ -858,6 +859,21 @@ export class ExternalRootsService {
     return (await this.readVerifiedBuffer(runtime, relativePath)).buffer;
   }
 
+  private async readOpenedFile(
+    handle: FileHandle,
+    size: number,
+  ): Promise<Buffer> {
+    const buffer = Buffer.alloc(size);
+    const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
+    if (bytesRead !== buffer.length) {
+      throw new ExternalRootError(
+        "non_verifiable",
+        "The file could not be read completely.",
+      );
+    }
+    return buffer;
+  }
+
   private async readVerifiedBuffer(
     runtime: RootRuntime,
     relativePath: string,
@@ -912,12 +928,24 @@ export class ExternalRootsService {
         );
       }
 
-      const buffer = Buffer.alloc(Number(openedStat.size));
-      const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
-      if (bytesRead !== buffer.length) {
+      const buffer = await this.readOpenedFile(handle, Number(openedStat.size));
+      const postReadStat = await handle.stat({ bigint: true });
+      const finalPath = await this.resolvePath(runtime, relativePath);
+      const finalPathStat = await stat(finalPath, { bigint: true });
+      if (
+        !postReadStat.isFile() ||
+        !finalPathStat.isFile() ||
+        postReadStat.dev !== openedStat.dev ||
+        postReadStat.ino !== openedStat.ino ||
+        postReadStat.size !== openedStat.size ||
+        postReadStat.mtimeNs !== openedStat.mtimeNs ||
+        postReadStat.ctimeNs !== openedStat.ctimeNs ||
+        finalPathStat.dev !== postReadStat.dev ||
+        finalPathStat.ino !== postReadStat.ino
+      ) {
         throw new ExternalRootError(
           "non_verifiable",
-          "The file could not be read completely.",
+          "The file changed while it was being read.",
         );
       }
       return {

--- a/src/services/externalRootsService.ts
+++ b/src/services/externalRootsService.ts
@@ -1,12 +1,16 @@
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
+import { rmSync } from "node:fs";
 import {
   lstat,
+  mkdtemp,
   open,
   readdir,
   readFile,
   realpath,
   stat,
+  writeFile,
 } from "node:fs/promises";
+import os from "node:os";
 import path from "node:path";
 import { z } from "zod";
 
@@ -211,6 +215,7 @@ function decodeUtf8(buffer: Buffer): string {
 
 export class ExternalRootsService {
   private readonly roots: Map<string, RootRuntime>;
+  private handoffDirectory?: Promise<string>;
 
   private constructor(config: ExternalRootsConfig) {
     this.roots = new Map(
@@ -461,20 +466,16 @@ export class ExternalRootsService {
     const runtime = this.requireCapability(rootId, "handoff");
     this.assertCapability(runtime, "readable");
     const relativePath = normalizeRelativePath(requestedPath);
-    const localPath = await this.resolvePath(runtime, relativePath);
-    const fileStat = await stat(localPath);
-    if (!fileStat.isFile()) {
-      throw new ExternalRootError(
-        "not_a_file",
-        "Only files can be handed off to a local client.",
-      );
-    }
-    if (fileStat.size > runtime.config.limits.maxFileBytes) {
-      throw new ExternalRootError(
-        "too_large",
-        `The file exceeds the configured ${runtime.config.limits.maxFileBytes}-byte limit.`,
-      );
-    }
+    const verified = await this.readVerifiedBuffer(runtime, relativePath);
+    const handoffRoot = await this.getHandoffDirectory();
+    const localPath = path.join(
+      handoffRoot,
+      `${randomUUID()}-${path.basename(relativePath)}`,
+    );
+    await writeFile(localPath, verified.buffer, {
+      flag: "wx",
+      mode: 0o600,
+    });
     const response: {
       rootId: string;
       path: string;
@@ -486,13 +487,27 @@ export class ExternalRootsService {
       rootId,
       path: relativePath,
       localPath,
-      size: fileStat.size,
-      modifiedAt: fileStat.mtime.toISOString(),
+      size: verified.buffer.length,
+      modifiedAt: verified.modifiedAt,
     };
     if (includeHash) {
-      response.sha256 = sha256(await this.readBuffer(runtime, relativePath));
+      response.sha256 = sha256(verified.buffer);
     }
     return response;
+  }
+
+  private async getHandoffDirectory(): Promise<string> {
+    if (!this.handoffDirectory) {
+      this.handoffDirectory = mkdtemp(
+        path.join(os.tmpdir(), "optimike-external-handoff-"),
+      ).then((directory) => {
+        process.once("exit", () => {
+          rmSync(directory, { recursive: true, force: true });
+        });
+        return directory;
+      });
+    }
+    return this.handoffDirectory;
   }
 
   private getRoot(rootId: string): RootRuntime {
@@ -605,8 +620,7 @@ export class ExternalRootsService {
   private assertAllowed(runtime: RootRuntime, relativePath: string): void {
     if (
       matchesAny(relativePath, runtime.config.exclude) ||
-      (!matchesAny(relativePath, runtime.config.include) &&
-        path.extname(relativePath))
+      !matchesAny(relativePath, runtime.config.include)
     ) {
       throw new ExternalRootError(
         "path_not_allowed",
@@ -619,33 +633,51 @@ export class ExternalRootsService {
     runtime: RootRuntime,
     relativePath: string,
   ): Promise<Buffer> {
+    return (await this.readVerifiedBuffer(runtime, relativePath)).buffer;
+  }
+
+  private async readVerifiedBuffer(
+    runtime: RootRuntime,
+    relativePath: string,
+  ): Promise<{ buffer: Buffer; modifiedAt: string }> {
     const absolutePath = await this.resolvePath(runtime, relativePath);
-    const fileStat = await stat(absolutePath);
-    if (!fileStat.isFile()) {
-      throw new ExternalRootError(
-        "not_a_file",
-        "The requested external path is not a file.",
-      );
-    }
-    if (fileStat.size > runtime.config.limits.maxFileBytes) {
-      throw new ExternalRootError(
-        "too_large",
-        `The file exceeds the configured ${runtime.config.limits.maxFileBytes}-byte limit.`,
-      );
-    }
     const handle = await open(absolutePath, "r");
     try {
-      const openedStat = await handle.stat();
+      const openedStat = await handle.stat({ bigint: true });
+      if (!openedStat.isFile()) {
+        throw new ExternalRootError(
+          "not_a_file",
+          "The requested external path is not a file.",
+        );
+      }
       if (
-        openedStat.size !== fileStat.size ||
-        openedStat.mtimeMs !== fileStat.mtimeMs
+        openedStat.size > BigInt(runtime.config.limits.maxFileBytes) ||
+        openedStat.size > BigInt(Number.MAX_SAFE_INTEGER)
+      ) {
+        throw new ExternalRootError(
+          "too_large",
+          `The file exceeds the configured ${runtime.config.limits.maxFileBytes}-byte limit.`,
+        );
+      }
+
+      // Re-resolve every path component after opening, then bind the opened
+      // handle to the currently confined object by filesystem identity. If an
+      // ancestor was swapped between validation and open, the identities differ
+      // even if size and timestamps happen to match.
+      const revalidatedPath = await this.resolvePath(runtime, relativePath);
+      const revalidatedStat = await stat(revalidatedPath, { bigint: true });
+      if (
+        !revalidatedStat.isFile() ||
+        openedStat.dev !== revalidatedStat.dev ||
+        openedStat.ino !== revalidatedStat.ino
       ) {
         throw new ExternalRootError(
           "non_verifiable",
-          "The file changed while it was being verified.",
+          "The file identity changed while it was being verified.",
         );
       }
-      const buffer = Buffer.alloc(openedStat.size);
+
+      const buffer = Buffer.alloc(Number(openedStat.size));
       const { bytesRead } = await handle.read(buffer, 0, buffer.length, 0);
       if (bytesRead !== buffer.length) {
         throw new ExternalRootError(
@@ -653,7 +685,10 @@ export class ExternalRootsService {
           "The file could not be read completely.",
         );
       }
-      return buffer;
+      return {
+        buffer,
+        modifiedAt: new Date(Number(openedStat.mtimeMs)).toISOString(),
+      };
     } finally {
       await handle.close();
     }

--- a/src/services/externalRootsService.ts
+++ b/src/services/externalRootsService.ts
@@ -164,6 +164,7 @@ const HANDOFF_MAX_FILES = 16;
 const HANDOFF_MAX_TOTAL_BYTES = 512 * 1024 * 1024;
 const HANDOFF_TTL_MS = 60 * 60 * 1000;
 const HANDOFF_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+const HANDOFF_OWNER_HEARTBEAT_GRACE_MS = 20 * 60 * 1000;
 const UNOWNED_STALE_DIRECTORY_MS = 24 * 60 * 60 * 1000;
 
 function normalizeRelativePath(value: string): string {
@@ -227,10 +228,14 @@ export class ExternalRootsService {
   private handoffDirectory?: string;
   private handoffLock: Promise<void> = Promise.resolve();
   private handoffSweepTimer?: ReturnType<typeof setInterval>;
+  private readonly startupScavenge: Promise<void>;
 
   private constructor(config: ExternalRootsConfig) {
     this.roots = new Map(
       config.roots.map((root) => [root.id, { config: root }]),
+    );
+    this.startupScavenge = this.scavengeStaleHandoffDirectories().catch(
+      () => undefined,
     );
   }
 
@@ -274,6 +279,7 @@ export class ExternalRootsService {
       limits: ExternalRootConfig["limits"];
     }>
   > {
+    await this.startupScavenge;
     const result = [];
     for (const runtime of this.roots.values()) {
       let available = false;
@@ -542,24 +548,26 @@ export class ExternalRootsService {
   }
 
   private async getHandoffDirectory(): Promise<string> {
-    if (this.handoffDirectory) return this.handoffDirectory;
+    await this.startupScavenge;
+    if (this.handoffDirectory) {
+      try {
+        if ((await stat(this.handoffDirectory)).isDirectory()) {
+          return this.handoffDirectory;
+        }
+      } catch {
+        this.handoffDirectory = undefined;
+      }
+    }
 
-    await this.scavengeStaleHandoffDirectories();
     const directory = await mkdtemp(
       path.join(os.tmpdir(), HANDOFF_DIRECTORY_PREFIX),
     );
-    await writeFile(
-      path.join(directory, HANDOFF_OWNER_FILE),
-      JSON.stringify({
-        pid: process.pid,
-        createdAt: new Date().toISOString(),
-      }),
-      { encoding: "utf8", flag: "wx", mode: 0o600 },
-    );
+    await this.writeHandoffOwner(directory, "wx");
     this.handoffDirectory = directory;
     this.handoffSweepTimer = setInterval(() => {
       void this.withHandoffLock(async () => {
         if (this.handoffDirectory) {
+          await this.writeHandoffOwner(this.handoffDirectory, "w");
           await this.pruneHandoffDirectory(this.handoffDirectory, 0);
         }
       }).catch(() => undefined);
@@ -570,6 +578,21 @@ export class ExternalRootsService {
       rmSync(directory, { recursive: true, force: true });
     });
     return directory;
+  }
+
+  private async writeHandoffOwner(
+    directory: string,
+    flag: "w" | "wx",
+  ): Promise<void> {
+    await writeFile(
+      path.join(directory, HANDOFF_OWNER_FILE),
+      JSON.stringify({
+        pid: process.pid,
+        startedAt: new Date(Date.now() - process.uptime() * 1000).toISOString(),
+        heartbeatAt: new Date().toISOString(),
+      }),
+      { encoding: "utf8", flag, mode: 0o600 },
+    );
   }
 
   private async pruneHandoffDirectory(
@@ -628,7 +651,18 @@ export class ExternalRootsService {
       }
       const directory = path.join(temporaryRoot, entry.name);
       const owner = await this.readHandoffOwner(directory);
-      if (owner && this.isProcessAlive(owner.pid)) continue;
+      if (owner && this.isProcessAlive(owner.pid)) {
+        try {
+          const ownerStat = await stat(
+            path.join(directory, HANDOFF_OWNER_FILE),
+          );
+          if (now - ownerStat.mtimeMs < HANDOFF_OWNER_HEARTBEAT_GRACE_MS) {
+            continue;
+          }
+        } catch {
+          // Missing or unreadable owner markers are treated as abandoned.
+        }
+      }
       if (!owner) {
         try {
           const directoryStat = await stat(directory);

--- a/src/services/externalRootsService.ts
+++ b/src/services/externalRootsService.ts
@@ -7,6 +7,7 @@ import {
   readdir,
   readFile,
   realpath,
+  rm,
   stat,
   writeFile,
 } from "node:fs/promises";
@@ -157,6 +158,14 @@ const textExtensions = new Set([
   ".log",
 ]);
 
+const HANDOFF_DIRECTORY_PREFIX = "optimike-external-handoff-";
+const HANDOFF_OWNER_FILE = ".owner.json";
+const HANDOFF_MAX_FILES = 16;
+const HANDOFF_MAX_TOTAL_BYTES = 512 * 1024 * 1024;
+const HANDOFF_TTL_MS = 60 * 60 * 1000;
+const HANDOFF_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+const UNOWNED_STALE_DIRECTORY_MS = 24 * 60 * 60 * 1000;
+
 function normalizeRelativePath(value: string): string {
   const trimmed = value.trim().replace(/\\/gu, "/").replace(/^\.\//u, "");
   if (!trimmed || trimmed === ".") return "";
@@ -215,7 +224,9 @@ function decodeUtf8(buffer: Buffer): string {
 
 export class ExternalRootsService {
   private readonly roots: Map<string, RootRuntime>;
-  private handoffDirectory?: Promise<string>;
+  private handoffDirectory?: string;
+  private handoffLock: Promise<void> = Promise.resolve();
+  private handoffSweepTimer?: ReturnType<typeof setInterval>;
 
   private constructor(config: ExternalRootsConfig) {
     this.roots = new Map(
@@ -467,15 +478,10 @@ export class ExternalRootsService {
     this.assertCapability(runtime, "readable");
     const relativePath = normalizeRelativePath(requestedPath);
     const verified = await this.readVerifiedBuffer(runtime, relativePath);
-    const handoffRoot = await this.getHandoffDirectory();
-    const localPath = path.join(
-      handoffRoot,
-      `${randomUUID()}-${path.basename(relativePath)}`,
+    const localPath = await this.createHandoffCopy(
+      relativePath,
+      verified.buffer,
     );
-    await writeFile(localPath, verified.buffer, {
-      flag: "wx",
-      mode: 0o600,
-    });
     const response: {
       rootId: string;
       path: string;
@@ -496,18 +502,177 @@ export class ExternalRootsService {
     return response;
   }
 
+  private async withHandoffLock<T>(operation: () => Promise<T>): Promise<T> {
+    const previous = this.handoffLock;
+    let release: () => void = () => undefined;
+    this.handoffLock = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+
+  private async createHandoffCopy(
+    relativePath: string,
+    buffer: Buffer,
+  ): Promise<string> {
+    if (buffer.length > HANDOFF_MAX_TOTAL_BYTES) {
+      throw new ExternalRootError(
+        "too_large",
+        "The verified handoff copy exceeds the aggregate handoff budget.",
+      );
+    }
+    return this.withHandoffLock(async () => {
+      const directory = await this.getHandoffDirectory();
+      await this.pruneHandoffDirectory(directory, buffer.length);
+      const localPath = path.join(
+        directory,
+        `${randomUUID()}-${path.basename(relativePath)}`,
+      );
+      await writeFile(localPath, buffer, {
+        flag: "wx",
+        mode: 0o600,
+      });
+      return localPath;
+    });
+  }
+
   private async getHandoffDirectory(): Promise<string> {
-    if (!this.handoffDirectory) {
-      this.handoffDirectory = mkdtemp(
-        path.join(os.tmpdir(), "optimike-external-handoff-"),
-      ).then((directory) => {
-        process.once("exit", () => {
-          rmSync(directory, { recursive: true, force: true });
-        });
-        return directory;
+    if (this.handoffDirectory) return this.handoffDirectory;
+
+    await this.scavengeStaleHandoffDirectories();
+    const directory = await mkdtemp(
+      path.join(os.tmpdir(), HANDOFF_DIRECTORY_PREFIX),
+    );
+    await writeFile(
+      path.join(directory, HANDOFF_OWNER_FILE),
+      JSON.stringify({
+        pid: process.pid,
+        createdAt: new Date().toISOString(),
+      }),
+      { encoding: "utf8", flag: "wx", mode: 0o600 },
+    );
+    this.handoffDirectory = directory;
+    this.handoffSweepTimer = setInterval(() => {
+      void this.withHandoffLock(async () => {
+        if (this.handoffDirectory) {
+          await this.pruneHandoffDirectory(this.handoffDirectory, 0);
+        }
+      }).catch(() => undefined);
+    }, HANDOFF_SWEEP_INTERVAL_MS);
+    this.handoffSweepTimer.unref();
+    process.once("exit", () => {
+      if (this.handoffSweepTimer) clearInterval(this.handoffSweepTimer);
+      rmSync(directory, { recursive: true, force: true });
+    });
+    return directory;
+  }
+
+  private async pruneHandoffDirectory(
+    directory: string,
+    incomingBytes: number,
+  ): Promise<void> {
+    const now = Date.now();
+    const files: Array<{
+      path: string;
+      size: number;
+      modifiedAt: number;
+    }> = [];
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      if (!entry.isFile() || entry.name === HANDOFF_OWNER_FILE) continue;
+      const filePath = path.join(directory, entry.name);
+      const fileStat = await stat(filePath);
+      if (now - fileStat.mtimeMs >= HANDOFF_TTL_MS) {
+        await rm(filePath, { force: true });
+        continue;
+      }
+      files.push({
+        path: filePath,
+        size: fileStat.size,
+        modifiedAt: fileStat.mtimeMs,
       });
     }
-    return this.handoffDirectory;
+
+    files.sort((a, b) => a.modifiedAt - b.modifiedAt);
+    let totalBytes = files.reduce((total, file) => total + file.size, 0);
+    while (
+      files.length >= HANDOFF_MAX_FILES ||
+      totalBytes + incomingBytes > HANDOFF_MAX_TOTAL_BYTES
+    ) {
+      const oldest = files.shift();
+      if (!oldest) break;
+      await rm(oldest.path, { force: true });
+      totalBytes -= oldest.size;
+    }
+  }
+
+  private async scavengeStaleHandoffDirectories(): Promise<void> {
+    const temporaryRoot = os.tmpdir();
+    const now = Date.now();
+    let entries;
+    try {
+      entries = await readdir(temporaryRoot, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (
+        !entry.isDirectory() ||
+        !entry.name.startsWith(HANDOFF_DIRECTORY_PREFIX)
+      ) {
+        continue;
+      }
+      const directory = path.join(temporaryRoot, entry.name);
+      const owner = await this.readHandoffOwner(directory);
+      if (owner && this.isProcessAlive(owner.pid)) continue;
+      if (!owner) {
+        try {
+          const directoryStat = await stat(directory);
+          if (now - directoryStat.mtimeMs < UNOWNED_STALE_DIRECTORY_MS) {
+            continue;
+          }
+        } catch {
+          continue;
+        }
+      }
+      await rm(directory, { recursive: true, force: true }).catch(
+        () => undefined,
+      );
+    }
+  }
+
+  private async readHandoffOwner(
+    directory: string,
+  ): Promise<{ pid: number } | undefined> {
+    try {
+      const value = JSON.parse(
+        await readFile(path.join(directory, HANDOFF_OWNER_FILE), "utf8"),
+      ) as { pid?: unknown };
+      return typeof value.pid === "number" && Number.isInteger(value.pid)
+        ? { pid: value.pid }
+        : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+
+  private isProcessAlive(pid: number): boolean {
+    if (pid <= 0) return false;
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (error) {
+      return (
+        typeof error === "object" &&
+        error !== null &&
+        "code" in error &&
+        error.code === "EPERM"
+      );
+    }
   }
 
   private getRoot(rootId: string): RootRuntime {

--- a/src/services/externalRootsService.ts
+++ b/src/services/externalRootsService.ts
@@ -7,6 +7,7 @@ import {
   readdir,
   readFile,
   realpath,
+  rename,
   rm,
   stat,
   writeFile,
@@ -160,12 +161,12 @@ const textExtensions = new Set([
 
 const HANDOFF_DIRECTORY_PREFIX = "optimike-external-handoff-";
 const HANDOFF_OWNER_FILE = ".owner.json";
+const HANDOFF_OWNER_KIND = "optimike-external-handoff";
 const HANDOFF_MAX_FILES = 16;
 const HANDOFF_MAX_TOTAL_BYTES = 512 * 1024 * 1024;
 const HANDOFF_TTL_MS = 60 * 60 * 1000;
 const HANDOFF_SWEEP_INTERVAL_MS = 5 * 60 * 1000;
 const HANDOFF_OWNER_HEARTBEAT_GRACE_MS = 20 * 60 * 1000;
-const UNOWNED_STALE_DIRECTORY_MS = 24 * 60 * 60 * 1000;
 
 function normalizeRelativePath(value: string): string {
   const trimmed = value.trim().replace(/\\/gu, "/").replace(/^\.\//u, "");
@@ -483,29 +484,33 @@ export class ExternalRootsService {
     const runtime = this.requireCapability(rootId, "handoff");
     this.assertCapability(runtime, "readable");
     const relativePath = normalizeRelativePath(requestedPath);
-    const verified = await this.readVerifiedBuffer(runtime, relativePath);
-    const localPath = await this.createHandoffCopy(
-      relativePath,
-      verified.buffer,
-    );
-    const response: {
-      rootId: string;
-      path: string;
-      localPath: string;
-      size: number;
-      modifiedAt: string;
-      sha256?: string;
-    } = {
-      rootId,
-      path: relativePath,
-      localPath,
-      size: verified.buffer.length,
-      modifiedAt: verified.modifiedAt,
-    };
-    if (includeHash) {
-      response.sha256 = sha256(verified.buffer);
-    }
-    return response;
+    return this.withHandoffLock(async () => {
+      // Keep the verified read inside the same lock as allocation and copy so
+      // concurrent handoffs cannot accumulate multiple max-sized buffers.
+      const verified = await this.readVerifiedBuffer(runtime, relativePath);
+      const localPath = await this.createHandoffCopy(
+        relativePath,
+        verified.buffer,
+      );
+      const response: {
+        rootId: string;
+        path: string;
+        localPath: string;
+        size: number;
+        modifiedAt: string;
+        sha256?: string;
+      } = {
+        rootId,
+        path: relativePath,
+        localPath,
+        size: verified.buffer.length,
+        modifiedAt: verified.modifiedAt,
+      };
+      if (includeHash) {
+        response.sha256 = sha256(verified.buffer);
+      }
+      return response;
+    });
   }
 
   private async withHandoffLock<T>(operation: () => Promise<T>): Promise<T> {
@@ -532,20 +537,20 @@ export class ExternalRootsService {
         "The verified handoff copy exceeds the aggregate handoff budget.",
       );
     }
-    return this.withHandoffLock(async () => {
-      const directory = await this.getHandoffDirectory();
-      await this.pruneHandoffDirectory(directory, buffer.length, true);
-      const sourceExtension = path.extname(relativePath);
-      const localPath = path.join(
-        directory,
-        `${randomUUID()}${sourceExtension}`,
-      );
-      await writeFile(localPath, buffer, {
-        flag: "wx",
-        mode: 0o600,
-      });
-      return localPath;
+    const directory = await this.getHandoffDirectory();
+    await this.pruneHandoffDirectory(directory, buffer.length, true);
+    const sourceExtension = path.extname(relativePath);
+    const boundedExtension =
+      Buffer.byteLength(sourceExtension, "utf8") <= 32 ? sourceExtension : "";
+    const localPath = path.join(
+      directory,
+      `${randomUUID()}${boundedExtension}`,
+    );
+    await writeFile(localPath, buffer, {
+      flag: "wx",
+      mode: 0o600,
     });
+    return localPath;
   }
 
   private async getHandoffDirectory(): Promise<string> {
@@ -563,12 +568,12 @@ export class ExternalRootsService {
     const directory = await mkdtemp(
       path.join(os.tmpdir(), HANDOFF_DIRECTORY_PREFIX),
     );
-    await this.writeHandoffOwner(directory, "wx");
+    await this.writeHandoffOwner(directory);
     this.handoffDirectory = directory;
     this.handoffSweepTimer = setInterval(() => {
       void this.withHandoffLock(async () => {
         if (this.handoffDirectory) {
-          await this.writeHandoffOwner(this.handoffDirectory, "w");
+          await this.writeHandoffOwner(this.handoffDirectory);
           await this.pruneHandoffDirectory(this.handoffDirectory, 0, false);
         }
       }).catch(() => undefined);
@@ -581,19 +586,30 @@ export class ExternalRootsService {
     return directory;
   }
 
-  private async writeHandoffOwner(
-    directory: string,
-    flag: "w" | "wx",
-  ): Promise<void> {
-    await writeFile(
-      path.join(directory, HANDOFF_OWNER_FILE),
-      JSON.stringify({
-        pid: process.pid,
-        startedAt: new Date(Date.now() - process.uptime() * 1000).toISOString(),
-        heartbeatAt: new Date().toISOString(),
-      }),
-      { encoding: "utf8", flag, mode: 0o600 },
+  private async writeHandoffOwner(directory: string): Promise<void> {
+    const ownerPath = path.join(directory, HANDOFF_OWNER_FILE);
+    const temporaryOwnerPath = path.join(
+      directory,
+      `.owner-${randomUUID()}.tmp`,
     );
+    try {
+      await writeFile(
+        temporaryOwnerPath,
+        JSON.stringify({
+          kind: HANDOFF_OWNER_KIND,
+          version: 1,
+          pid: process.pid,
+          startedAt: new Date(
+            Date.now() - process.uptime() * 1000,
+          ).toISOString(),
+          heartbeatAt: new Date().toISOString(),
+        }),
+        { encoding: "utf8", flag: "wx", mode: 0o600 },
+      );
+      await rename(temporaryOwnerPath, ownerPath);
+    } finally {
+      await rm(temporaryOwnerPath, { force: true }).catch(() => undefined);
+    }
   }
 
   private async pruneHandoffDirectory(
@@ -653,27 +669,16 @@ export class ExternalRootsService {
       }
       const directory = path.join(temporaryRoot, entry.name);
       const owner = await this.readHandoffOwner(directory);
-      if (owner && this.isProcessAlive(owner.pid)) {
-        try {
-          const ownerStat = await stat(
-            path.join(directory, HANDOFF_OWNER_FILE),
-          );
-          if (now - ownerStat.mtimeMs < HANDOFF_OWNER_HEARTBEAT_GRACE_MS) {
-            continue;
-          }
-        } catch {
-          // Missing or unreadable owner markers are treated as abandoned.
-        }
-      }
       if (!owner) {
-        try {
-          const directoryStat = await stat(directory);
-          if (now - directoryStat.mtimeMs < UNOWNED_STALE_DIRECTORY_MS) {
-            continue;
-          }
-        } catch {
-          continue;
-        }
+        // A matching prefix alone is not proof that this process owns the
+        // directory. Leave unowned or partially written directories untouched.
+        continue;
+      }
+      if (
+        this.isProcessAlive(owner.pid) &&
+        now - Date.parse(owner.heartbeatAt) < HANDOFF_OWNER_HEARTBEAT_GRACE_MS
+      ) {
+        continue;
       }
       await rm(directory, { recursive: true, force: true }).catch(
         () => undefined,
@@ -683,14 +688,30 @@ export class ExternalRootsService {
 
   private async readHandoffOwner(
     directory: string,
-  ): Promise<{ pid: number } | undefined> {
+  ): Promise<{ pid: number; heartbeatAt: string } | undefined> {
     try {
       const value = JSON.parse(
         await readFile(path.join(directory, HANDOFF_OWNER_FILE), "utf8"),
-      ) as { pid?: unknown };
-      return typeof value.pid === "number" && Number.isInteger(value.pid)
-        ? { pid: value.pid }
-        : undefined;
+      ) as {
+        kind?: unknown;
+        version?: unknown;
+        pid?: unknown;
+        startedAt?: unknown;
+        heartbeatAt?: unknown;
+      };
+      if (
+        value.kind !== HANDOFF_OWNER_KIND ||
+        value.version !== 1 ||
+        typeof value.pid !== "number" ||
+        !Number.isInteger(value.pid) ||
+        typeof value.startedAt !== "string" ||
+        !Number.isFinite(Date.parse(value.startedAt)) ||
+        typeof value.heartbeatAt !== "string" ||
+        !Number.isFinite(Date.parse(value.heartbeatAt))
+      ) {
+        return undefined;
+      }
+      return { pid: value.pid, heartbeatAt: value.heartbeatAt };
     } catch {
       return undefined;
     }

--- a/src/services/externalRootsService.ts
+++ b/src/services/externalRootsService.ts
@@ -534,7 +534,7 @@ export class ExternalRootsService {
     }
     return this.withHandoffLock(async () => {
       const directory = await this.getHandoffDirectory();
-      await this.pruneHandoffDirectory(directory, buffer.length);
+      await this.pruneHandoffDirectory(directory, buffer.length, true);
       const localPath = path.join(
         directory,
         `${randomUUID()}-${path.basename(relativePath)}`,
@@ -568,7 +568,7 @@ export class ExternalRootsService {
       void this.withHandoffLock(async () => {
         if (this.handoffDirectory) {
           await this.writeHandoffOwner(this.handoffDirectory, "w");
-          await this.pruneHandoffDirectory(this.handoffDirectory, 0);
+          await this.pruneHandoffDirectory(this.handoffDirectory, 0, false);
         }
       }).catch(() => undefined);
     }, HANDOFF_SWEEP_INTERVAL_MS);
@@ -598,6 +598,7 @@ export class ExternalRootsService {
   private async pruneHandoffDirectory(
     directory: string,
     incomingBytes: number,
+    reserveIncomingFile: boolean,
   ): Promise<void> {
     const now = Date.now();
     const files: Array<{
@@ -623,7 +624,7 @@ export class ExternalRootsService {
     files.sort((a, b) => a.modifiedAt - b.modifiedAt);
     let totalBytes = files.reduce((total, file) => total + file.size, 0);
     while (
-      files.length + (incomingBytes > 0 ? 1 : 0) > HANDOFF_MAX_FILES ||
+      files.length + (reserveIncomingFile ? 1 : 0) > HANDOFF_MAX_FILES ||
       totalBytes + incomingBytes > HANDOFF_MAX_TOTAL_BYTES
     ) {
       const oldest = files.shift();

--- a/src/services/externalRootsService.ts
+++ b/src/services/externalRootsService.ts
@@ -535,9 +535,10 @@ export class ExternalRootsService {
     return this.withHandoffLock(async () => {
       const directory = await this.getHandoffDirectory();
       await this.pruneHandoffDirectory(directory, buffer.length, true);
+      const sourceExtension = path.extname(relativePath);
       const localPath = path.join(
         directory,
-        `${randomUUID()}-${path.basename(relativePath)}`,
+        `${randomUUID()}${sourceExtension}`,
       );
       await writeFile(localPath, buffer, {
         flag: "wx",

--- a/src/services/externalRootsService.ts
+++ b/src/services/externalRootsService.ts
@@ -806,6 +806,19 @@ export class ExternalRootsService {
     relativePath: string,
   ): Promise<{ buffer: Buffer; modifiedAt: string }> {
     const absolutePath = await this.resolvePath(runtime, relativePath);
+    const preOpenStat = await stat(absolutePath);
+    if (!preOpenStat.isFile()) {
+      throw new ExternalRootError(
+        "not_a_file",
+        "The requested external path is not a regular file.",
+      );
+    }
+    if (preOpenStat.size > runtime.config.limits.maxFileBytes) {
+      throw new ExternalRootError(
+        "too_large",
+        `The file exceeds the configured ${runtime.config.limits.maxFileBytes}-byte limit.`,
+      );
+    }
     const handle = await open(absolutePath, "r");
     try {
       const openedStat = await handle.stat({ bigint: true });

--- a/src/stdio-proxy.ts
+++ b/src/stdio-proxy.ts
@@ -14,6 +14,9 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import {
   ExternalHandoffSchema,
+  ExternalListSchema,
+  ExternalReadSchema,
+  ExternalStatSchema,
   externalRootsResult,
 } from "./mcp-server/tools/externalRootsTools/registration.js";
 import { ensureLocalBackendRunning } from "./runtime/localBackend.js";
@@ -50,6 +53,40 @@ const proxyServer = new Server(
 
 let backend: BackendClient | undefined;
 let externalRootsService: ExternalRootsService | undefined;
+
+function disabledExternalRoots(): Promise<never> {
+  return Promise.reject(
+    new ExternalRootError(
+      "configuration_invalid",
+      "External roots are disabled. Configure MCP_EXTERNAL_ROOTS_FILE to enable them.",
+    ),
+  );
+}
+
+function invalidExternalArguments(
+  toolName: string,
+  message: string,
+): {
+  content: Array<{ type: "text"; text: string }>;
+  isError: true;
+} {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify(
+          {
+            error: "path_invalid",
+            message: `Invalid ${toolName} arguments: ${message}`,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+    isError: true,
+  };
+}
 
 function isReconnectableBackendError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
@@ -162,27 +199,87 @@ async function start() {
       }))();
     }
 
+    if (request.params.name === "external_roots_list") {
+      return externalRootsResult(async () => ({
+        roots: externalRootsService
+          ? await externalRootsService.listRoots()
+          : [],
+      }))();
+    }
+
+    if (request.params.name === "external_list") {
+      const parsed = ExternalListSchema.safeParse(
+        request.params.arguments ?? {},
+      );
+      if (!parsed.success) {
+        return invalidExternalArguments(
+          request.params.name,
+          parsed.error.message,
+        );
+      }
+      return externalRootsResult(() =>
+        externalRootsService
+          ? externalRootsService.list(
+              parsed.data.rootId,
+              parsed.data.relativePath,
+              parsed.data.depth,
+              parsed.data.maxEntries,
+            )
+          : disabledExternalRoots(),
+      )();
+    }
+
+    if (request.params.name === "external_stat") {
+      const parsed = ExternalStatSchema.safeParse(
+        request.params.arguments ?? {},
+      );
+      if (!parsed.success) {
+        return invalidExternalArguments(
+          request.params.name,
+          parsed.error.message,
+        );
+      }
+      return externalRootsResult(() =>
+        externalRootsService
+          ? externalRootsService.getStat(
+              parsed.data.rootId,
+              parsed.data.relativePath,
+              parsed.data.includeHash,
+            )
+          : disabledExternalRoots(),
+      )();
+    }
+
+    if (request.params.name === "external_read") {
+      const parsed = ExternalReadSchema.safeParse(
+        request.params.arguments ?? {},
+      );
+      if (!parsed.success) {
+        return invalidExternalArguments(
+          request.params.name,
+          parsed.error.message,
+        );
+      }
+      return externalRootsResult(() =>
+        externalRootsService
+          ? externalRootsService.readText(
+              parsed.data.rootId,
+              parsed.data.relativePath,
+              parsed.data.maxChars,
+            )
+          : disabledExternalRoots(),
+      )();
+    }
+
     if (request.params.name === "external_handoff") {
       const parsed = ExternalHandoffSchema.safeParse(
         request.params.arguments ?? {},
       );
       if (!parsed.success) {
-        return {
-          content: [
-            {
-              type: "text" as const,
-              text: JSON.stringify(
-                {
-                  error: "path_invalid",
-                  message: `Invalid external_handoff arguments: ${parsed.error.message}`,
-                },
-                null,
-                2,
-              ),
-            },
-          ],
-          isError: true,
-        };
+        return invalidExternalArguments(
+          request.params.name,
+          parsed.error.message,
+        );
       }
 
       return externalRootsResult(() =>
@@ -192,12 +289,7 @@ async function start() {
               parsed.data.relativePath,
               parsed.data.includeHash,
             )
-          : Promise.reject(
-              new ExternalRootError(
-                "configuration_invalid",
-                "External roots are disabled. Configure MCP_EXTERNAL_ROOTS_FILE to enable them.",
-              ),
-            ),
+          : disabledExternalRoots(),
       )();
     }
 


### PR DESCRIPTION
## Summary

Addresses every actionable Codex finding from PR #24.

- enforce include globs for extensionless files
- bind reads to the revalidated opened filesystem identity
- hand off a verified process-owned temporary copy instead of the mutable source path
- make the stdio proxy authoritative for all external-root operations
- redact unexpected filesystem errors from MCP responses and logs
- add regression coverage and update the ADR/docs

## Validation

- `npm run build`
- `npm run test:external-roots`
- `npm run test:runtime`
- `npm run test:profiles`
- `npm run test:tool-annotations`
- `npm run test:package`
- `npm run audit:production` — 0 vulnerabilities
- `npm pack --dry-run`

Closes the review findings in #24.