### PR TITLE
docs: publish external roots operator guide

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -22,6 +22,7 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run test:runtime
+      - run: npm run test:external-roots
       - run: npm run test:profiles
       - run: npm run test:tool-annotations
       - if: runner.os == 'Windows'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Default-deny external document roots with logical root IDs, bounded listing,
+  metadata, hashing, UTF-8 reads, and explicit local stdio handoff for clients
+  with their own PDF or Office tools.
+- Bilingual external-roots setup and operations guides with Windows and Unix
+  examples, schema limits, client compatibility, verification, rollback, and
+  troubleshooting.
 - ÉLYSIA Tasks profile 1.1 with global Inbox, This Week, bounded Now, Backlog, periodic-note leakage detection, and a P90-J admission gate.
 - Public task-governor guidance for distinct dry-run/apply idempotency keys and post-mutation visibility proof.
 - Regression coverage for Obsidian wikilink normalization in the Bases Bridge.
@@ -26,6 +32,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- External-root access uses canonical-path confinement, strict include/exclude
+  policies, link/junction rejection, handle identity revalidation, path-redacted
+  responses, and HTTP handoff denial.
+- Handoff returns a verified process-owned temporary copy instead of the source
+  path, with a one-hour TTL, five-minute sweep, 16-file/512-MiB caps, stale-owner
+  scavenging, and regression coverage on Linux and Windows.
 - Marked every legacy MCP tool as read-only, mutating, maintenance, or destructive for approval-aware clients.
 - Moved MCP Inspector to development dependencies and updated `fast-uri` to a patched release, removing the high-severity production audit finding.
 

--- a/OPERATIONS.fr.md
+++ b/OPERATIONS.fr.md
@@ -336,6 +336,10 @@ Codex doit pointer vers :
 [mcp_servers.optimike-obsidian-mcp-stdio]
 command = "node"
 args = ["/path/to/optimike-obsidian-mcp/dist/stdio-proxy.js"]
+
+[mcp_servers.optimike-obsidian-mcp-stdio.env]
+# Optionnel : chemin absolu vers un JSON external-roots local à la machine
+MCP_EXTERNAL_ROOTS_FILE = "/home/vous/.config/optimike/external-roots.json"
 ```
 
 Variables importantes :
@@ -347,6 +351,7 @@ Variables importantes :
 - `SMART_ENV_DIR`
 - `OBSIDIAN_BASE_URL`
 - `OBSIDIAN_API_KEY`
+- `MCP_EXTERNAL_ROOTS_FILE`
 
 Comportement de démarrage recommandé :
 
@@ -355,6 +360,31 @@ OBSIDIAN_STARTUP_BLOCKING = "false"
 ```
 
 Ça garde le démarrage de Codex réactif pendant que le health check du backend finit en arrière-plan.
+
+## Runbook des racines documentaires externes
+
+Les racines externes forment une frontière optionnelle, default-deny et en
+lecture seule pour des fichiers qui restent légitimement hors du coffre. Elles
+ne sont ni un index externe, ni un moteur de synchronisation, ni une sauvegarde.
+
+1. Copier `docs/external-roots.example.json` vers un chemin local à la machine,
+   hors du dépôt.
+2. Configurer les identifiants logiques, capacités, politiques include/exclude
+   et limites. Ne jamais committer le vrai fichier.
+3. Définir son chemin absolu dans `MCP_EXTERNAL_ROOTS_FILE` sur le processus
+   `dist/stdio-proxy.js`.
+4. Redémarrer le processus MCP. La configuration n’est pas rechargée à chaud.
+5. Vérifier `external_runtime_status`, `external_roots_list`, un listing borné,
+   une lecture UTF-8 et, seulement si nécessaire, un handoff explicite.
+
+Pour le schéma complet, les exemples Windows et Unix, la compatibilité client,
+le cycle de sécurité, le rollback, les niveaux de smoke test et le dépannage,
+voir
+[Racines documentaires externes — configuration et exploitation](docs/external-roots-setup.fr.md).
+
+Pour désactiver la fonction, retirer `MCP_EXTERNAL_ROOTS_FILE`, redémarrer et
+confirmer que `external_runtime_status` indique `enabled: false`. Cette opération
+ne modifie aucun document source.
 
 ## Dépannage
 

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -334,6 +334,10 @@ Codex should point to:
 [mcp_servers.optimike-obsidian-mcp-stdio]
 command = "node"
 args = ["/path/to/optimike-obsidian-mcp/dist/stdio-proxy.js"]
+
+[mcp_servers.optimike-obsidian-mcp-stdio.env]
+# Optional: absolute path to a machine-local external-roots JSON file
+MCP_EXTERNAL_ROOTS_FILE = "/home/you/.config/optimike/external-roots.json"
 ```
 
 Important environment variables:
@@ -345,6 +349,7 @@ Important environment variables:
 - `SMART_ENV_DIR`
 - `OBSIDIAN_BASE_URL`
 - `OBSIDIAN_API_KEY`
+- `MCP_EXTERNAL_ROOTS_FILE`
 
 Recommended startup behavior:
 
@@ -353,6 +358,30 @@ OBSIDIAN_STARTUP_BLOCKING = "false"
 ```
 
 That keeps Codex startup responsive while the backend health check completes in the background.
+
+## External document roots runbook
+
+External roots are an optional, default-deny, read-only boundary for files that
+legitimately remain outside the vault. They are not an external index, a sync
+engine, or a backup system.
+
+1. Copy `docs/external-roots.example.json` to a machine-local path outside the
+   repository.
+2. Configure logical root IDs, capabilities, include/exclude policies, and
+   limits. Never commit the real file.
+3. Set its absolute path in `MCP_EXTERNAL_ROOTS_FILE` on the
+   `dist/stdio-proxy.js` process.
+4. Restart the MCP process. Configuration is not hot-reloaded.
+5. Verify `external_runtime_status`, `external_roots_list`, a bounded listing,
+   one UTF-8 read, and—only when needed—one explicit handoff.
+
+For the complete schema, Windows and Unix examples, client compatibility,
+security lifecycle, rollback, smoke-test levels, and troubleshooting, see
+[External document roots — setup and operations](docs/external-roots-setup.md).
+
+To disable the feature, remove `MCP_EXTERNAL_ROOTS_FILE`, restart, and confirm
+that `external_runtime_status` reports `enabled: false`. This does not mutate
+source documents.
 
 ## Troubleshooting
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -6,7 +6,10 @@ Guide d’exploitation anglais : [OPERATIONS.md](OPERATIONS.md)
 
 ![Hero Optimike Obsidian MCP](docs/assets/hero-optimike-obsidian-mcp.png)
 
-Serveur MCP (Model Context Protocol) pour Obsidian avec cache local partagé, outils Operon sécurisés, compatibilité Tasks historique, Bases et recherche sémantique Smart Connections.
+Serveur MCP (Model Context Protocol) pour Obsidian avec cache local partagé,
+outils Operon sécurisés, compatibilité Tasks historique, Bases, recherche
+sémantique Smart Connections et accès explicite en lecture seule à des racines
+documentaires configurées hors du coffre.
 
 ## TL;DR
 
@@ -53,6 +56,8 @@ node dist/stdio-proxy.js
 - Exposer les outils REST Obsidian (lecture/écriture, frontmatter, tags, recherche)
 - Offrir une recherche vectorielle locale via Smart Connections (`.smart-env`)
 - Garder un backend local durable au lieu de respawner tout l’état lourd à chaque run stdio
+- Donner aux agents locaux un accès borné et default-deny à des documents
+  explicitement configurés hors du coffre sans les transformer en notes Obsidian
 
 ## Ce qu'il sait faire
 
@@ -65,6 +70,7 @@ Optimike Obsidian MCP donne aux agents une façon structurée de travailler avec
 - inspecter et requêter les tâches Obsidian Tasks
 - lancer une recherche sémantique sur un index Smart Connections
 - vérifier la santé du serveur, l'état du cache, le mode dégradé et la politique d'écriture
+- lister, hasher, lire ou remettre explicitement des documents autorisés hors du coffre
 
 En clair : il ne fait pas seulement de la lecture de notes. Il expose le coffre comme une vraie surface MCP opérationnelle, avec outils de lecture/écriture, opérations structurées sur les métadonnées, Tasks, Bases, recherche sémantique et observabilité de l'état du serveur.
 
@@ -83,6 +89,8 @@ Le MCP devient donc une frontière pratique entre les agents et Obsidian : les a
 - Outils Tasks intégrés : `list_all_tasks` et `query_tasks`
 - Recherche sémantique locale `smart_semantic_search`
 - Outils de santé/état du serveur : `obsidian_runtime_status` et `obsidian_runtime_maintenance`
+- Outils documentaires externes en lecture seule avec identifiants logiques et
+  handoff temporaire réservé au stdio
 - Mode dégradé lecture seule pour `obsidian_read_note` et `obsidian_list_notes` si Obsidian REST tombe
 - Store SQLite partagé pour le contenu du vault, le cache Tasks et le manifest sémantique
 - Embedder-agnostic : aligne automatiquement la requête sur le modèle du vault
@@ -91,10 +99,14 @@ Le MCP devient donc une frontière pratique entre les agents et Obsidian : les a
 ## Architecture (vue d'ensemble)
 
 1. **Obsidian** + plugins (Local REST API, Bases Bridge, Smart Connections)
-2. **Optimike Obsidian MCP** (ce serveur)
-3. **Agents MCP** (Codex, IDE, etc.)
+2. Racines documentaires externes locales optionnelles
+3. **Optimike Obsidian MCP** (ce serveur)
+4. **Agents MCP** (Codex, IDE, etc.)
 
-Le serveur agit comme un **pont** entre tes agents et Obsidian, ajoute une couche “Base” pour les fichiers `.base`, et persiste l’état runtime local pour garder Codex rapide et stable au fil des sessions.
+Le serveur agit comme un **pont** entre les agents et Obsidian, et comme un
+courtier en lecture séparé et default-deny pour les racines externes configurées.
+Il ajoute une couche « Base » pour les fichiers `.base` et persiste l’état
+runtime local pour garder Codex rapide et stable au fil des sessions.
 
 ## Bases Bridge (REST) — pourquoi et comment
 
@@ -253,6 +265,9 @@ MCP_EXTERNAL_ROOTS_FILE=/chemin/absolu/external-roots.json npm run smoke:externa
 ```
 
 Voir [ADR — External document roots](docs/adr/ADR-External-Document-Roots.md).
+Pour le schéma complet, les exemples Windows et Unix, la validation, le rollback
+et le dépannage, voir
+[Racines documentaires externes — configuration et exploitation](docs/external-roots-setup.fr.md).
 
 Scripts utiles :
 
@@ -351,6 +366,9 @@ MCP_HTTP_PORT = "3010"
 MCP_PROXY_START_TIMEOUT_MS = "20000"
 OBSIDIAN_VAULT = "/chemin/vers/<vault>"
 
+# Racines documentaires optionnelles en lecture seule hors du coffre
+# MCP_EXTERNAL_ROOTS_FILE = "/chemin/absolu/vers/external-roots.json"
+
 # Smart Connections
 SMART_ENV_DIR = "/chemin/vers/<vault>/.smart-env"
 ENABLE_QUERY_EMBEDDING = "true"
@@ -378,6 +396,9 @@ Notes :
 - Garde cette config en local dans `~/.codex/config.toml` (ne pas commit des chemins machine personnels).
 - Dans la doc, utilise des chemins logiques (`/chemin/vers/...`) et garde les chemins réels uniquement en local.
 - `dist/index.js` reste l’entrypoint backend, mais Codex doit pointer vers `dist/stdio-proxy.js`.
+- La configuration external-roots est chargée au démarrage du processus.
+  Redémarre le client/serveur MCP après toute modification de
+  `MCP_EXTERNAL_ROOTS_FILE` ou de son JSON.
 
 ## Réglage Local REST API (Obsidian)
 
@@ -438,6 +459,9 @@ Le MCP principal inclut maintenant :
 - outils Tasks : `list_all_tasks`, `query_tasks`
 - outils sémantiques : `smart_semantic_search`, `smart_search`, `smart-search`
 - outils santé/état du serveur : `obsidian_runtime_status`, `obsidian_runtime_maintenance`
+- outils documentaires externes : `external_runtime_status`,
+  `external_roots_list`, `external_list`, `external_stat`, `external_read`,
+  `external_handoff`
 
 ## Plugins Obsidian requis ou utiles
 
@@ -517,7 +541,8 @@ Garder le mode auto et laisser chaque utilisateur surcharger par variables d’e
 - Profil serveur headless dédié : [docs/headless-server-profile.fr.md](docs/headless-server-profile.fr.md)
 - Guide de routage agent : [docs/mcp-routing-guide.fr.md](docs/mcp-routing-guide.fr.md)
 - Surface actuelle des tools : [docs/obsidian_mcp_tools_spec.md](docs/obsidian_mcp_tools_spec.md)
-- Frontière proposée pour les racines documentaires externes : [docs/adr/ADR-External-Document-Roots.md](docs/adr/ADR-External-Document-Roots.md)
+- Configuration et exploitation des racines documentaires externes : [docs/external-roots-setup.fr.md](docs/external-roots-setup.fr.md)
+- Architecture des racines documentaires externes : [docs/adr/ADR-External-Document-Roots.md](docs/adr/ADR-External-Document-Roots.md)
 - Profil public de gestion des tâches ÉLYSIA et skill agentique portable : [profiles/elysia-tasks/README.fr.md](profiles/elysia-tasks/README.fr.md)
 - README anglais : [README.md](README.md)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ Guide d’exploitation (FR): [OPERATIONS.fr.md](OPERATIONS.fr.md)
 
 ![Optimike Obsidian MCP hero](docs/assets/hero-optimike-obsidian-mcp.png)
 
-MCP (Model Context Protocol) server for Obsidian with shared local caching, guarded Operon and legacy Tasks tools, Bases support, and semantic search powered by Smart Connections.
+MCP (Model Context Protocol) server for Obsidian with shared local caching,
+guarded Operon and legacy Tasks tools, Bases support, Smart Connections
+semantic search, and explicit read-only access to configured document roots
+outside the vault.
 
 ## TL;DR
 
@@ -53,6 +56,8 @@ node dist/stdio-proxy.js
 - Expose Obsidian REST tools (read/write, frontmatter, tags, search)
 - Provide local vector search via Smart Connections (`.smart-env`)
 - Keep one durable local backend instead of re-spawning heavy state on every stdio run
+- Give local agents bounded, default-deny access to explicitly configured
+  documents outside the vault without turning them into Obsidian notes
 
 ## What it can do
 
@@ -65,6 +70,7 @@ Optimike Obsidian MCP gives agents a structured way to work with an Obsidian vau
 - inspect and query Obsidian Tasks
 - run semantic search against a Smart Connections index
 - check server health, cache state, degraded mode, and write policy
+- list, hash, read, or explicitly hand off allowed documents outside the vault
 
 In short: it does more than read notes. It exposes the vault as an operational MCP surface, with read/write tools, structured metadata operations, Tasks, Bases, semantic search, and server health/status observability.
 
@@ -83,6 +89,8 @@ This makes the MCP a practical boundary between agents and Obsidian: agents call
 - Integrated Tasks tools: `list_all_tasks` and `query_tasks`
 - Local semantic search `smart_semantic_search`
 - Server health/status tools: `obsidian_runtime_status` and `obsidian_runtime_maintenance`
+- Read-only external document tools with logical root IDs and stdio-only
+  temporary handoff
 - Read-only degraded mode for `obsidian_read_note` and `obsidian_list_notes` when Obsidian REST is down
 - Shared SQLite store for vault content, task cache, and semantic manifest data
 - Embedder‑agnostic: query embedding aligned to the vault model
@@ -91,10 +99,14 @@ This makes the MCP a practical boundary between agents and Obsidian: agents call
 ## Architecture (overview)
 
 1. **Obsidian** + plugins (Local REST API, Bases Bridge, Smart Connections)
-2. **Optimike Obsidian MCP** (this server)
-3. **MCP Agents** (Codex, IDEs, etc.)
+2. Optional machine-local **external document roots**
+3. **Optimike Obsidian MCP** (this server)
+4. **MCP Agents** (Codex, IDEs, etc.)
 
-The server acts as a **bridge** between agents and Obsidian, adds a “Base” layer for `.base` files, and persists shared runtime state locally so Codex can stay fast and stable across runs.
+The server acts as a **bridge** between agents and Obsidian, and as a separate
+default-deny read broker for configured external roots. It adds a “Base” layer
+for `.base` files and persists shared runtime state locally so Codex can stay
+fast and stable across runs.
 
 ## Bases Bridge (REST) — why & how
 
@@ -247,6 +259,9 @@ MCP_EXTERNAL_ROOTS_FILE=/absolute/path/external-roots.json npm run smoke:externa
 ```
 
 See [ADR — External document roots](docs/adr/ADR-External-Document-Roots.md).
+For the complete schema, Windows and Unix client examples, verification,
+rollback, and troubleshooting, see
+[External document roots — setup and operations](docs/external-roots-setup.md).
 
 ## Runtime modes
 
@@ -358,6 +373,9 @@ MCP_HTTP_PORT = "3010"
 MCP_PROXY_START_TIMEOUT_MS = "20000"
 OBSIDIAN_VAULT = "/path/to/<vault>"
 
+# Optional read-only document roots outside the vault
+# MCP_EXTERNAL_ROOTS_FILE = "/absolute/path/to/external-roots.json"
+
 # Smart Connections
 SMART_ENV_DIR = "/path/to/<vault>/.smart-env"
 ENABLE_QUERY_EMBEDDING = "true"
@@ -385,6 +403,8 @@ Notes:
 - Keep this config local in `~/.codex/config.toml` (do not commit personal machine paths).
 - Use logical placeholders in documentation (`/path/to/...`) and keep real paths only in local config.
 - `dist/index.js` is still the backend entrypoint, but Codex should point to `dist/stdio-proxy.js`.
+- External-root configuration is loaded at process startup. Restart the MCP
+  client/server after changing `MCP_EXTERNAL_ROOTS_FILE` or its JSON file.
 
 ## Obsidian Local REST API Setup
 
@@ -445,6 +465,8 @@ The main MCP now includes:
 - Tasks tools: `list_all_tasks`, `query_tasks`
 - semantic tools: `smart_semantic_search`, `smart_search`, `smart-search`
 - server health/status tools: `obsidian_runtime_status`, `obsidian_runtime_maintenance`
+- external document tools: `external_runtime_status`, `external_roots_list`,
+  `external_list`, `external_stat`, `external_read`, `external_handoff`
 
 ## Tasks Integration
 
@@ -553,7 +575,8 @@ Keep auto mode and let each user override via env vars.
 - Dedicated headless server profile: [docs/headless-server-profile.md](docs/headless-server-profile.md)
 - Agent routing guide: [docs/mcp-routing-guide.md](docs/mcp-routing-guide.md)
 - Current tool surface: [docs/obsidian_mcp_tools_spec.md](docs/obsidian_mcp_tools_spec.md)
-- Proposed external document roots boundary: [docs/adr/ADR-External-Document-Roots.md](docs/adr/ADR-External-Document-Roots.md)
+- External document roots setup and operations: [docs/external-roots-setup.md](docs/external-roots-setup.md)
+- External document roots architecture: [docs/adr/ADR-External-Document-Roots.md](docs/adr/ADR-External-Document-Roots.md)
 - Public ÉLYSIA task-management profile and portable agent skill (French): [profiles/elysia-tasks/README.fr.md](profiles/elysia-tasks/README.fr.md)
 - French README: [README.fr.md](README.fr.md)
 

--- a/docs/adr/ADR-External-Document-Roots.md
+++ b/docs/adr/ADR-External-Document-Roots.md
@@ -64,7 +64,9 @@ A root configuration must be local and must not be committed:
 
 Initial capability vocabulary:
 
-- `visible`: disclose root metadata and bounded directory entries;
+- root IDs, capabilities, availability, and limits are disclosed by runtime
+  status and root listing independently of `visible`;
+- `visible`: disclose bounded directory entries and file metadata;
 - `readable`: hash or read an explicitly requested UTF-8 text file;
 - `handoff`: create one verified temporary local copy for an explicitly
   requesting local stdio client so that it can use its own document tools.
@@ -76,7 +78,8 @@ are not implemented by the core service.
 it requires a separate ADR, threat model, mutation journal, optimistic
 preconditions, dry-run contract, explicit apply gate, and rollback evidence.
 
-The absence of a capability is a denial.
+The absence of a capability denies the corresponding file operation; root
+discovery remains available as described above.
 
 ## Confinement
 
@@ -87,8 +90,8 @@ Every path request must:
 3. resolve the physical root and candidate to canonical paths;
 4. prove that the candidate remains inside the canonical root;
 5. apply platform-aware case and separator rules;
-6. reject or explicitly govern symlinks, junctions, reparse points and mounted
-   paths;
+6. reject detectable symlink, junction, and reparse-point escapes supported by
+   the current platform;
 7. apply include, exclude, depth, size and entry-count limits;
 8. log the decision without exposing secrets or unnecessary physical paths.
 

--- a/docs/adr/ADR-External-Document-Roots.md
+++ b/docs/adr/ADR-External-Document-Roots.md
@@ -1,8 +1,9 @@
 # ADR — External document roots
 
-- Status: implemented locally, pending product promotion
+- Status: accepted and implemented on `main`
 - Date: 2026-07-28
-- MCP baseline: `optimikelabs/optimike-obsidian-mcp@13969990e5c6b0da455a70a2ed7a40ae0e1ea399`
+- MCP implementation baseline:
+  `optimikelabs/optimike-obsidian-mcp@7c2eaad5bf958fa0315d69a067f9972910f6c39d`
 - Related product contract: ÉLYSIA OS external spaces and artifacts boundary
 
 ## Problem
@@ -22,7 +23,7 @@ portable agent output.
 
 ## Decision
 
-If external document access is implemented, it will use an explicit
+External document access uses an explicit
 `external_roots` subsystem with these invariants:
 
 - default deny;
@@ -157,8 +158,8 @@ Current first-release tool surface:
 - `external_handoff`
 - `external_runtime_status`
 
-These tools are implemented on the local feature branch. All are read-only and
-carry read-only MCP annotations.
+These tools are implemented on `main`. All are read-only and carry read-only
+MCP annotations.
 
 ## Runtime and deployment policy
 
@@ -172,22 +173,26 @@ carry read-only MCP annotations.
 - Runtime status reports root IDs, capabilities and health states without
   returning full physical paths by default.
 
-## Required evidence before product promotion
+## Product-promotion evidence
 
-1. Configuration schema validation with duplicate-ID and network-root rejection.
-2. Traversal, absolute-path, include/exclude, capability, and size-limit tests.
-3. Windows junction escape rejection.
-4. Public status/list/stat/read outputs without physical paths.
-5. Explicit handoff copy as the only physical-path disclosure.
-6. Stdio-only handoff policy.
-7. Read-only annotations on every MCP tool.
-8. Disposable-root tests plus a limited AMEX pilot.
-9. Packaging scan proving that no machine-local root is published.
-10. Cross-platform CI coverage before claiming macOS or Linux support.
+The promoted implementation provides:
+
+1. configuration schema validation with duplicate-ID and network-root rejection;
+2. traversal, absolute-path, strict include/exclude, capability, and size-limit
+   tests;
+3. Windows junction escape rejection;
+4. public status/list/stat/read outputs without physical paths;
+5. a verified temporary copy as the only physical-path disclosure;
+6. stdio-only handoff policy;
+7. read-only annotations on every MCP tool;
+8. disposable-root tests plus a limited AMEX pilot;
+9. packaging checks proving that no machine-local root configuration is
+   published;
+10. Linux and Windows CI coverage for the external-roots regression suite.
 
 ## Phased backlog
 
-### Phase 0 — Contract — complete locally
+### Phase 0 — Contract — complete
 
 - configuration schema;
 - threat model;
@@ -195,14 +200,14 @@ carry read-only MCP annotations.
 - portable output contract;
 - test fixtures with synthetic documents only.
 
-### Phase 1 — Visibility — complete locally
+### Phase 1 — Visibility — complete
 
 - list configured roots;
 - bounded list and stat;
 - no file content;
 - redacted health diagnostics.
 
-### Phase 2 — Read and handoff — complete locally
+### Phase 2 — Read and handoff — complete
 
 - explicit single-file read;
 - SHA-256 and bounded metadata;

--- a/docs/adr/ADR-External-Document-Roots.md
+++ b/docs/adr/ADR-External-Document-Roots.md
@@ -94,8 +94,10 @@ Every path request must:
 
 The server must not infer a new root from a path found in a note.
 
-UNC paths, network mounts and cloud placeholders remain unsupported until
-separate availability, identity and timeout behavior is specified.
+UNC-prefixed paths are rejected. Mapped drives, network filesystems mounted
+behind ordinary local-looking paths, and cloud placeholders cannot be detected
+reliably and remain outside supported identity and consistency guarantees until
+provider-specific connectors exist.
 
 ## Read and client-handoff boundary
 
@@ -177,7 +179,7 @@ MCP annotations.
 
 The promoted implementation provides:
 
-1. configuration schema validation with duplicate-ID and network-root rejection;
+1. configuration schema validation with duplicate-ID and UNC-prefix rejection;
 2. traversal, absolute-path, strict include/exclude, capability, and size-limit
    tests;
 3. Windows junction escape rejection;

--- a/docs/external-roots-setup.fr.md
+++ b/docs/external-roots-setup.fr.md
@@ -1,0 +1,249 @@
+# Racines documentaires externes — configuration et exploitation
+
+Les racines documentaires externes permettent à un client MCP de découvrir et
+lire des fichiers explicitement autorisés qui restent hors du coffre Obsidian :
+PDF, documents Office, jeux de données, dossiers projet ou bibliothèques gérées
+par une autre application.
+
+Cette fonction est un courtier en lecture seule, pas un second coffre :
+
+- le MCP autorise des identifiants logiques et confine chaque requête à une
+  racine ;
+- il sait lister, lire les métadonnées, calculer un hash et lire du texte UTF-8
+  dans des limites explicites ;
+- un client stdio local peut demander une copie temporaire vérifiée avec
+  `external_handoff`, puis employer ses propres outils PDF, Office ou OCR ;
+- il n’indexe, ne synchronise, ne déplace, ne renomme, n’écrit et ne sauvegarde
+  aucun document externe.
+
+## 1. Créer une configuration locale à la machine
+
+Copier [`external-roots.example.json`](external-roots.example.json) hors du
+dépôt. Ne jamais committer le fichier configuré : il contient des chemins
+propres à la machine.
+
+Exemple Unix :
+
+```json
+{
+  "version": 1,
+  "roots": [
+    {
+      "id": "project.documents",
+      "path": "/srv/documents/project",
+      "capabilities": ["visible", "readable", "handoff"],
+      "include": ["**/*.md", "**/*.pdf", "**/*.docx"],
+      "exclude": ["**/.git/**", "**/node_modules/**", "**/~$*"],
+      "limits": {
+        "maxDepth": 6,
+        "maxFileBytes": 52428800,
+        "maxListEntries": 500,
+        "maxTextChars": 200000
+      }
+    }
+  ]
+}
+```
+
+Exemple JSON Windows :
+
+```json
+{
+  "version": 1,
+  "roots": [
+    {
+      "id": "project.documents",
+      "path": "B:\\Documents\\Projet",
+      "capabilities": ["visible", "readable", "handoff"],
+      "include": ["**/*.md", "**/*.pdf", "**/*.docx"],
+      "exclude": ["**/.git/**", "**/node_modules/**", "**/~$*"],
+      "limits": {
+        "maxDepth": 6,
+        "maxFileBytes": 52428800,
+        "maxListEntries": 500,
+        "maxTextChars": 200000
+      }
+    }
+  ]
+}
+```
+
+Les antislashs JSON doivent être doublés. Les racines UNC et réseau ne sont pas
+supportées.
+
+## 2. Contrat de configuration
+
+L’objet racine est strict :
+
+| Champ     | Contrat                                                    |
+| --------- | ---------------------------------------------------------- |
+| `version` | Doit valoir `1`.                                           |
+| `roots`   | De zéro à 32 racines. Chaque identifiant doit être unique. |
+
+Chaque racine est également stricte :
+
+| Champ          | Contrat                                                                                                                         |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `id`           | Identifiant logique stable en minuscules : lettres, chiffres, `.`, `_` et `-`.                                                  |
+| `path`         | Dossier absolu local à la machine. Les chemins UNC/réseau sont refusés.                                                         |
+| `capabilities` | Une ou plusieurs valeurs parmi `visible`, `readable`, `handoff`. `handoff` exige `readable`.                                    |
+| `include`      | Allowlist de globs de style Git. Défaut : `["**"]`. Un fichier qui ne correspond à aucun motif est refusé, même sans extension. |
+| `exclude`      | Denylist de globs. Défaut : `.git` et `node_modules`. `exclude` l’emporte sur `include`.                                        |
+| `limits`       | Limites bornées optionnelles décrites ci-dessous. Les champs inconnus sont refusés.                                             |
+
+Les capacités sont distinctes :
+
+- `visible` autorise l’état, le listing borné et les métadonnées ;
+- `readable` autorise le hash et la lecture UTF-8 directe ;
+- `handoff` autorise une copie temporaire vérifiée, uniquement en stdio local.
+
+Valeurs par défaut et plafonds du schéma :
+
+| Limite           |  Défaut |   Maximum |
+| ---------------- | ------: | --------: |
+| `maxDepth`       |       6 |        20 |
+| `maxFileBytes`   |  50 Mio |   200 Mio |
+| `maxListEntries` |     500 |     5 000 |
+| `maxTextChars`   | 200 000 | 2 000 000 |
+
+`external_read` accepte les fichiers UTF-8 valides portant les extensions
+`.txt`, `.md`, `.markdown`, `.csv`, `.json`, `.yaml`, `.yml`, `.xml`, `.html`,
+`.htm` et `.log`. Pour un document binaire autorisé, employer
+`external_handoff`.
+
+## 3. Configurer un client stdio local
+
+L’entrypoint recommandé est `dist/stdio-proxy.js`. Définir
+`MCP_EXTERNAL_ROOTS_FILE` sur ce processus MCP, jamais dans le coffre.
+
+Codex sous Windows :
+
+```toml
+[mcp_servers.optimike-obsidian-mcp-stdio]
+command = "node"
+args = ['E:\chemin\vers\optimike-obsidian-mcp\dist\stdio-proxy.js']
+
+[mcp_servers.optimike-obsidian-mcp-stdio.env]
+MCP_EXTERNAL_ROOTS_FILE = 'C:\Users\vous\.config\optimike\external-roots.json'
+```
+
+Codex sous Unix :
+
+```toml
+[mcp_servers.optimike-obsidian-mcp-stdio]
+command = "node"
+args = ["/chemin/vers/optimike-obsidian-mcp/dist/stdio-proxy.js"]
+
+[mcp_servers.optimike-obsidian-mcp-stdio.env]
+MCP_EXTERNAL_ROOTS_FILE = "/home/vous/.config/optimike/external-roots.json"
+```
+
+Claude Code, Gemini CLI, OpenClaw, Hermes Agent et les autres clients MCP locaux
+peuvent employer la même commande stdio et la même variable si leur
+implémentation permet de configurer l’environnement du processus. Leur syntaxe,
+leurs approbations et leur accès au chemin local retourné restent propres au
+client. Le dépôt ne promet pas une parité identique entre eux.
+
+| Client              | Intégration visée                                       | Ce que ce dépôt vérifie                                                         |
+| ------------------- | ------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| Codex               | Proxy stdio local avec environnement du processus       | Usage de production configuré et workflow pilote.                               |
+| Claude Code         | Serveur stdio local configuré par le client             | Conception compatible avec le protocole ; setup propre au client non testé ici. |
+| Gemini CLI          | Serveur stdio local configuré par le client             | Conception compatible avec le protocole ; setup propre au client non testé ici. |
+| OpenClaw            | Processus MCP local si son déploiement le supporte      | Conception compatible ; accès au chemin dépendant du déploiement.               |
+| Hermes Agent        | Processus MCP local si son déploiement le supporte      | Conception compatible ; accès au chemin dépendant du déploiement.               |
+| Client HTTP distant | Status/list/stat/read selon la politique de déploiement | Handoff de chemin physique toujours refusé.                                     |
+
+Le cœur MCP n’installe ni ne configure les extracteurs du client. Sans outil PDF
+ou Office local adapté, un client peut toujours lister, lire les métadonnées,
+hasher et lire les documents UTF-8 autorisés, mais pas extraire un binaire.
+
+## 4. Redémarrer et vérifier
+
+Le JSON est chargé une seule fois au démarrage du processus MCP. Après toute
+modification du fichier ou de la variable d’environnement, redémarrer le client
+MCP ou son serveur.
+
+Séquence de vérification recommandée :
+
+1. Appeler `external_runtime_status` ; confirmer `enabled: true`,
+   `localHandoffAllowed: true` et l’identifiant logique attendu.
+2. Appeler `external_roots_list` ; confirmer que la racine est `available`.
+3. Appeler `external_list` avec l’identifiant et une profondeur bornée.
+4. Appeler `external_stat`, puis `external_read` sur un petit fichier pilote
+   UTF-8.
+5. Si nécessaire, appeler `external_handoff` sur un document autorisé et
+   vérifier que le client ouvre bien la copie temporaire retournée.
+
+Vérifications du dépôt sous Unix :
+
+```bash
+npm run test:external-roots
+MCP_EXTERNAL_ROOTS_FILE=/chemin/absolu/external-roots.json npm run smoke:external-roots
+MCP_EXTERNAL_ROOTS_FILE=/chemin/absolu/external-roots.json npm run smoke:external-roots:mcp
+```
+
+Sous PowerShell :
+
+```powershell
+npm run test:external-roots
+$env:MCP_EXTERNAL_ROOTS_FILE = 'C:\Users\vous\.config\optimike\external-roots.json'
+npm run smoke:external-roots
+npm run smoke:external-roots:mcp
+```
+
+Ces contrôles ne testent pas la même frontière :
+
+- `test:external-roots` emploie des fixtures jetables et teste le confinement,
+  les allowlists, l’identité du handle, la redaction, les limites, le cycle des
+  copies temporaires, le vrai proxy stdio et le refus du handoff HTTP ;
+- `smoke:external-roots` valide le service configuré et une vraie racine pilote ;
+- `smoke:external-roots:mcp` valide le contrat MCP via l’entrypoint stdio direct
+  avec la racine configurée ;
+- le client de production doit encore être vérifié via `dist/stdio-proxy.js`
+  avec les cinq appels décrits plus haut.
+
+## 5. Cycle de vie du handoff et sécurité
+
+`external_handoff` ne retourne pas le chemin source. Il lit via un handle vérifié
+et crée une copie détenue par le processus en mode `0600` sur les plateformes
+qui appliquent les permissions de fichiers POSIX.
+
+- le handoff est refusé en HTTP ;
+- les copies expirent après une heure et sont nettoyées toutes les cinq minutes ;
+- un service conserve au maximum 16 fichiers et 512 Mio de copies ;
+- les copies les plus anciennes sont évincées pour libérer de la place ;
+- le processus supprime son dossier lors d’un arrêt normal ;
+- un service configuré ultérieur récupère les dossiers détenus par des processus
+  morts ou des heartbeats périmés.
+
+Le chemin retourné est éphémère. Le client doit l’utiliser pendant l’opération
+courante et ne jamais le conserver comme provenance documentaire.
+
+La provenance portable est l’identifiant logique, le chemin relatif, la taille,
+la date de modification et le SHA-256 lorsqu’il est retourné, pas le chemin
+temporaire.
+
+## 6. Retour arrière et dépannage
+
+Le retour arrière échoue fermé :
+
+1. retirer `MCP_EXTERNAL_ROOTS_FILE` de la configuration du client MCP ;
+2. redémarrer le processus MCP ;
+3. appeler `external_runtime_status` et confirmer `enabled: false`.
+
+Cette opération ne supprime ni ne modifie aucun document source. Les éventuelles
+copies temporaires suivent leur cycle de nettoyage normal.
+
+| Erreur/état             | Vérification                                                                              |
+| ----------------------- | ----------------------------------------------------------------------------------------- |
+| `configuration_invalid` | Chemin de config absolu, JSON valide, version `1`, champs connus et règles d’identifiant. |
+| `root_unavailable`      | Le dossier existe et le processus MCP peut y accéder.                                     |
+| `capability_denied`     | La racine déclare la capacité exigée par l’opération.                                     |
+| `path_not_allowed`      | Le chemin relatif correspond à `include` et pas à `exclude`.                              |
+| `path_link_unsupported` | Retirer les symlinks/jonctions du chemin demandé.                                         |
+| `too_large`             | Vérifier `maxFileBytes` et le budget agrégé du handoff.                                   |
+| `unsupported`           | Employer un texte UTF-8 avec `external_read`, ou le handoff stdio pour un binaire.        |
+| Handoff refusé          | Employer un client stdio local ; HTTP ne divulgue volontairement aucun chemin.            |
+
+Le serveur ne déduit jamais une nouvelle racine à partir d’un chemin trouvé dans
+une note Obsidian.

--- a/docs/external-roots-setup.fr.md
+++ b/docs/external-roots-setup.fr.md
@@ -68,8 +68,9 @@ Exemple JSON Windows :
 }
 ```
 
-Les antislashs JSON doivent être doublés. Les racines UNC et réseau ne sont pas
-supportées.
+Les antislashs JSON doivent être doublés. Les chemins préfixés UNC sont refusés.
+Un lecteur réseau mappé ou un système réseau monté derrière un chemin d’apparence
+locale ne peut pas être détecté de manière fiable et reste hors garanties.
 
 ## 2. Contrat de configuration
 
@@ -82,18 +83,21 @@ L’objet racine est strict :
 
 Chaque racine est également stricte :
 
-| Champ          | Contrat                                                                                                                         |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `id`           | Identifiant logique stable en minuscules : lettres, chiffres, `.`, `_` et `-`.                                                  |
-| `path`         | Dossier absolu local à la machine. Les chemins UNC/réseau sont refusés.                                                         |
-| `capabilities` | Une ou plusieurs valeurs parmi `visible`, `readable`, `handoff`. `handoff` exige `readable`.                                    |
-| `include`      | Allowlist de globs de style Git. Défaut : `["**"]`. Un fichier qui ne correspond à aucun motif est refusé, même sans extension. |
-| `exclude`      | Denylist de globs. Défaut : `.git` et `node_modules`. `exclude` l’emporte sur `include`.                                        |
-| `limits`       | Limites bornées optionnelles décrites ci-dessous. Les champs inconnus sont refusés.                                             |
+| Champ          | Contrat                                                                                                                            |
+| -------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
+| `id`           | Identifiant logique stable en minuscules : lettres, chiffres, `.`, `_` et `-`.                                                     |
+| `path`         | Dossier absolu. Les chemins préfixés UNC sont refusés ; un stockage réseau mappé ou monté n’est pas détecté et reste non supporté. |
+| `capabilities` | Une ou plusieurs valeurs parmi `visible`, `readable`, `handoff`. `handoff` exige `readable`.                                       |
+| `include`      | Allowlist de globs de style Git. Défaut : `["**"]`. Un fichier qui ne correspond à aucun motif est refusé, même sans extension.    |
+| `exclude`      | Denylist de globs. Défaut : `.git` et `node_modules`. `exclude` l’emporte sur `include`.                                           |
+| `limits`       | Limites bornées optionnelles décrites ci-dessous. Les champs inconnus sont refusés.                                                |
 
 Les capacités sont distinctes :
 
-- `visible` autorise l’état, le listing borné et les métadonnées ;
+- les identifiants, capacités, états de disponibilité et limites des racines
+  sont toujours exposés par `external_runtime_status` et
+  `external_roots_list` ;
+- `visible` autorise le listing borné et les métadonnées de fichiers ;
 - `readable` autorise le hash et la lecture UTF-8 directe ;
 - `handoff` autorise une copie temporaire vérifiée, uniquement en stdio local.
 

--- a/docs/external-roots-setup.md
+++ b/docs/external-roots-setup.md
@@ -1,0 +1,244 @@
+# External document roots — setup and operations
+
+External document roots let an MCP client discover and read explicitly allowed
+files that remain outside the Obsidian vault. Typical examples are PDFs, Office
+documents, datasets, project folders, and application-managed libraries.
+
+This feature is a read-only broker, not a second vault:
+
+- the MCP authorizes logical root IDs and confines every request to one root;
+- it can list, stat, hash, and read bounded UTF-8 text;
+- a local stdio client can explicitly request a verified temporary copy with
+  `external_handoff`, then use its own PDF, Office, or OCR tools;
+- it does not index, synchronize, move, rename, write, or back up external
+  documents.
+
+## 1. Create a machine-local configuration
+
+Copy [`external-roots.example.json`](external-roots.example.json) outside the
+repository. Never commit the configured file because it contains machine paths.
+
+Unix example:
+
+```json
+{
+  "version": 1,
+  "roots": [
+    {
+      "id": "project.documents",
+      "path": "/srv/documents/project",
+      "capabilities": ["visible", "readable", "handoff"],
+      "include": ["**/*.md", "**/*.pdf", "**/*.docx"],
+      "exclude": ["**/.git/**", "**/node_modules/**", "**/~$*"],
+      "limits": {
+        "maxDepth": 6,
+        "maxFileBytes": 52428800,
+        "maxListEntries": 500,
+        "maxTextChars": 200000
+      }
+    }
+  ]
+}
+```
+
+Windows JSON example:
+
+```json
+{
+  "version": 1,
+  "roots": [
+    {
+      "id": "project.documents",
+      "path": "B:\\Documents\\Project",
+      "capabilities": ["visible", "readable", "handoff"],
+      "include": ["**/*.md", "**/*.pdf", "**/*.docx"],
+      "exclude": ["**/.git/**", "**/node_modules/**", "**/~$*"],
+      "limits": {
+        "maxDepth": 6,
+        "maxFileBytes": 52428800,
+        "maxListEntries": 500,
+        "maxTextChars": 200000
+      }
+    }
+  ]
+}
+```
+
+JSON backslashes must be escaped. UNC and network roots are not supported.
+
+## 2. Configuration contract
+
+The top-level object is strict:
+
+| Field     | Contract                                          |
+| --------- | ------------------------------------------------- |
+| `version` | Must be `1`.                                      |
+| `roots`   | Zero to 32 root objects. Root IDs must be unique. |
+
+Each root is also strict:
+
+| Field          | Contract                                                                                                                      |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `id`           | Stable lowercase logical ID: letters, digits, `.`, `_`, and `-`.                                                              |
+| `path`         | Absolute machine-local directory. UNC/network paths are rejected.                                                             |
+| `capabilities` | One or more of `visible`, `readable`, `handoff`. `handoff` requires `readable`.                                               |
+| `include`      | Git-style glob allowlist. Default: `["**"]`. A file that matches no include pattern is denied, including extensionless files. |
+| `exclude`      | Git-style glob denylist. Default: `.git` and `node_modules`. Exclude wins over include.                                       |
+| `limits`       | Optional bounded limits described below. Unknown fields are rejected.                                                         |
+
+Capabilities are independent:
+
+- `visible` permits root status, bounded listing, and metadata;
+- `readable` permits hashing and direct UTF-8 reads;
+- `handoff` permits a verified temporary copy over local stdio only.
+
+Limit defaults and schema ceilings:
+
+| Limit            | Default |   Maximum |
+| ---------------- | ------: | --------: |
+| `maxDepth`       |       6 |        20 |
+| `maxFileBytes`   |  50 MiB |   200 MiB |
+| `maxListEntries` |     500 |     5,000 |
+| `maxTextChars`   | 200,000 | 2,000,000 |
+
+`external_read` accepts valid UTF-8 files with these extensions: `.txt`, `.md`,
+`.markdown`, `.csv`, `.json`, `.yaml`, `.yml`, `.xml`, `.html`, `.htm`, and
+`.log`. Use `external_handoff` for an allowed binary document.
+
+## 3. Configure a local stdio client
+
+The recommended entrypoint is `dist/stdio-proxy.js`. Set
+`MCP_EXTERNAL_ROOTS_FILE` on that MCP process, not in the vault.
+
+Codex on Windows:
+
+```toml
+[mcp_servers.optimike-obsidian-mcp-stdio]
+command = "node"
+args = ['E:\path\to\optimike-obsidian-mcp\dist\stdio-proxy.js']
+
+[mcp_servers.optimike-obsidian-mcp-stdio.env]
+MCP_EXTERNAL_ROOTS_FILE = 'C:\Users\you\.config\optimike\external-roots.json'
+```
+
+Codex on Unix:
+
+```toml
+[mcp_servers.optimike-obsidian-mcp-stdio]
+command = "node"
+args = ["/path/to/optimike-obsidian-mcp/dist/stdio-proxy.js"]
+
+[mcp_servers.optimike-obsidian-mcp-stdio.env]
+MCP_EXTERNAL_ROOTS_FILE = "/home/you/.config/optimike/external-roots.json"
+```
+
+Claude Code, Gemini CLI, OpenClaw, Hermes Agent, and other local MCP clients can
+use the same stdio command and environment variable if their MCP implementation
+supports local process environment configuration. Configuration syntax,
+approval behavior, and access to a returned local path are client-specific.
+The repository does not claim identical behavior across those clients.
+
+| Client             | Intended integration                                      | What this repository verifies                                         |
+| ------------------ | --------------------------------------------------------- | --------------------------------------------------------------------- |
+| Codex              | Local stdio proxy with process environment                | Configured production use and pilot workflow.                         |
+| Claude Code        | Local stdio server configured by the client               | Protocol-compatible design; client-specific setup is not tested here. |
+| Gemini CLI         | Local stdio server configured by the client               | Protocol-compatible design; client-specific setup is not tested here. |
+| OpenClaw           | Local MCP process when supported by its deployment        | Protocol-compatible design; path access depends on the deployment.    |
+| Hermes Agent       | Local MCP process when supported by its deployment        | Protocol-compatible design; path access depends on the deployment.    |
+| Remote HTTP client | Status/list/stat/read may be exposed by deployment policy | Physical-path handoff is always denied.                               |
+
+The MCP core does not install or configure the client's document extraction
+tools. A client without a suitable local PDF or Office tool can still list,
+stat, hash, and read allowed UTF-8 documents, but cannot extract binary content.
+
+## 4. Restart and verify
+
+The JSON configuration is loaded once when the MCP process starts. Restart the
+MCP client or its server process after changing the file or environment
+variable.
+
+Recommended verification sequence:
+
+1. Call `external_runtime_status`; confirm `enabled: true`,
+   `localHandoffAllowed: true`, and the expected logical root ID.
+2. Call `external_roots_list`; confirm the root is `available`.
+3. Call `external_list` with the root ID and a bounded depth.
+4. Call `external_stat`, then `external_read` on a small UTF-8 pilot file.
+5. If needed, call `external_handoff` on one allowed document and verify that
+   the client can open the returned temporary copy.
+
+Repository checks:
+
+Unix:
+
+```bash
+npm run test:external-roots
+MCP_EXTERNAL_ROOTS_FILE=/absolute/path/external-roots.json npm run smoke:external-roots
+MCP_EXTERNAL_ROOTS_FILE=/absolute/path/external-roots.json npm run smoke:external-roots:mcp
+```
+
+PowerShell:
+
+```powershell
+npm run test:external-roots
+$env:MCP_EXTERNAL_ROOTS_FILE = 'C:\Users\you\.config\optimike\external-roots.json'
+npm run smoke:external-roots
+npm run smoke:external-roots:mcp
+```
+
+These checks cover different boundaries:
+
+- `test:external-roots` uses disposable fixtures and tests confinement,
+  allowlists, handle identity, redaction, limits, temporary-copy lifecycle, the
+  actual stdio proxy, and HTTP handoff denial;
+- `smoke:external-roots` validates the configured service and a real pilot root;
+- `smoke:external-roots:mcp` validates the MCP tool contract through the direct
+  stdio server entrypoint with the configured root;
+- the production client must still be checked through `dist/stdio-proxy.js`
+  using the five calls above.
+
+## 5. Handoff lifecycle and security
+
+`external_handoff` does not return the source path. It reads through a verified
+file handle and creates a process-owned copy with mode `0600` on platforms that
+enforce POSIX file permissions.
+
+- handoff is denied over HTTP;
+- copies expire after one hour and are swept every five minutes;
+- one service keeps at most 16 files and 512 MiB of handoff copies;
+- oldest copies are evicted to make room;
+- the process removes its directory on normal exit;
+- a later configured service scavenges directories owned by dead processes or
+  stale ownership heartbeats.
+
+Treat the returned path as short-lived. A client should consume it during the
+current operation and must not persist it as document provenance.
+
+Portable provenance is the logical root ID, root-relative path, size,
+modification time, and SHA-256 when returned—not the temporary path.
+
+## 6. Rollback and troubleshooting
+
+Rollback is fail-closed:
+
+1. remove `MCP_EXTERNAL_ROOTS_FILE` from the MCP client configuration;
+2. restart the MCP process;
+3. call `external_runtime_status` and confirm `enabled: false`.
+
+This does not delete or modify any source document. Existing temporary copies
+remain bounded by their normal cleanup lifecycle.
+
+Common failures:
+
+| Error/state             | Check                                                                       |
+| ----------------------- | --------------------------------------------------------------------------- |
+| `configuration_invalid` | Absolute config path, valid JSON, version `1`, known fields, root ID rules. |
+| `root_unavailable`      | The configured directory exists and the MCP process can access it.          |
+| `capability_denied`     | The root declares the capability required by the operation.                 |
+| `path_not_allowed`      | The relative file path matches `include` and does not match `exclude`.      |
+| `path_link_unsupported` | Remove symlinks/junctions from the requested path.                          |
+| `too_large`             | Root `maxFileBytes` and the aggregate handoff budget.                       |
+| `unsupported`           | Use UTF-8 text for `external_read`, or stdio handoff for binary documents.  |
+| Handoff denied          | Use a local stdio client; HTTP intentionally cannot disclose a path.        |
+
+The server never infers a new root from a path found in an Obsidian note.

--- a/docs/external-roots-setup.md
+++ b/docs/external-roots-setup.md
@@ -64,7 +64,9 @@ Windows JSON example:
 }
 ```
 
-JSON backslashes must be escaped. UNC and network roots are not supported.
+JSON backslashes must be escaped. Paths with a UNC prefix are rejected. A
+mapped drive or a network filesystem mounted behind an ordinary local-looking
+path cannot be detected reliably and remains outside the supported guarantees.
 
 ## 2. Configuration contract
 
@@ -77,18 +79,20 @@ The top-level object is strict:
 
 Each root is also strict:
 
-| Field          | Contract                                                                                                                      |
-| -------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| `id`           | Stable lowercase logical ID: letters, digits, `.`, `_`, and `-`.                                                              |
-| `path`         | Absolute machine-local directory. UNC/network paths are rejected.                                                             |
-| `capabilities` | One or more of `visible`, `readable`, `handoff`. `handoff` requires `readable`.                                               |
-| `include`      | Git-style glob allowlist. Default: `["**"]`. A file that matches no include pattern is denied, including extensionless files. |
-| `exclude`      | Git-style glob denylist. Default: `.git` and `node_modules`. Exclude wins over include.                                       |
-| `limits`       | Optional bounded limits described below. Unknown fields are rejected.                                                         |
+| Field          | Contract                                                                                                                        |
+| -------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `id`           | Stable lowercase logical ID: letters, digits, `.`, `_`, and `-`.                                                                |
+| `path`         | Absolute directory. UNC-prefixed paths are rejected; mapped or mounted network storage is not detected and remains unsupported. |
+| `capabilities` | One or more of `visible`, `readable`, `handoff`. `handoff` requires `readable`.                                                 |
+| `include`      | Git-style glob allowlist. Default: `["**"]`. A file that matches no include pattern is denied, including extensionless files.   |
+| `exclude`      | Git-style glob denylist. Default: `.git` and `node_modules`. Exclude wins over include.                                         |
+| `limits`       | Optional bounded limits described below. Unknown fields are rejected.                                                           |
 
 Capabilities are independent:
 
-- `visible` permits root status, bounded listing, and metadata;
+- root IDs, capabilities, availability, and limits are always disclosed by
+  `external_runtime_status` and `external_roots_list`;
+- `visible` permits bounded directory listing and file metadata;
 - `readable` permits hashing and direct UTF-8 reads;
 - `handoff` permits a verified temporary copy over local stdio only.
 

--- a/docs/mcp-routing-guide.fr.md
+++ b/docs/mcp-routing-guide.fr.md
@@ -2,7 +2,11 @@
 
 Version anglaise : [mcp-routing-guide.md](mcp-routing-guide.md)
 
-Docs liées : [README](../README.fr.md), [Guide d’exploitation](../OPERATIONS.fr.md), [Matrice des capacités runtime](runtime-capability-matrix.fr.md), [Profil serveur headless](headless-server-profile.fr.md)
+Docs liées : [README](../README.fr.md),
+[Guide d’exploitation](../OPERATIONS.fr.md),
+[Matrice des capacités runtime](runtime-capability-matrix.fr.md),
+[Profil serveur headless](headless-server-profile.fr.md) et
+[Racines documentaires externes](external-roots-setup.fr.md)
 
 Ce guide aide les agents à choisir la bonne couche pour travailler avec Obsidian.
 
@@ -11,6 +15,7 @@ Ce guide aide les agents à choisir la bonne couche pour travailler avec Obsidia
 | Besoin                                                                     | Utiliser                                                        | Pourquoi                                                                          |
 | -------------------------------------------------------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------- |
 | Lire, lister, rechercher, Tasks, recherche sémantique                      | Optimike MCP                                                    | Surface stable entre live, hybrid et headless.                                    |
+| Lire un document explicitement configuré hors du coffre                    | Outils external-roots du MCP                                    | Confinement default-deny avec chemins logiques portables.                         |
 | Comportement Obsidian complet, commandes, active file, Bases via plugin    | Optimike MCP en `live` ou `hybrid` avec Obsidian Desktop ouvert | C'est le seul mode avec sémantique Desktop/plugin.                                |
 | Serveur backend sûr au-dessus d'un vault synchronisé                       | Optimike MCP en `headless-readonly` d'abord                     | Pas besoin de Desktop et aucun risque d'écriture.                                 |
 | Écritures Markdown/frontmatter/tags/admin bornées sur copie ou vault dédié | Optimike MCP en `headless-filesystem`                           | Sécurité de chemins, dry-run par défaut et préconditions.                         |
@@ -35,6 +40,30 @@ Utiliser `obsidian_manage_canvas` seulement en `headless-filesystem` :
 - `connect_nodes` ajoute une edge entre deux node IDs existants.
 
 Le dry-run est le défaut pour les opérations d'écriture.
+
+## Routage documentaire externe
+
+Un lien Obsidian vers un fichier local n’autorise pas l’accès à ce fichier.
+Employer les outils external-roots uniquement lorsque l’opérateur a
+explicitement configuré un identifiant logique.
+
+Workflow agent :
+
+1. Appeler `external_runtime_status` ou `external_roots_list` ; ne jamais déduire
+   une racine depuis un chemin physique trouvé dans une note.
+2. Employer `external_list` et `external_stat` avec l’identifiant et un chemin
+   relatif à la racine.
+3. Employer `external_read` uniquement pour du texte UTF-8 borné.
+4. Pour un PDF ou un document Office, demander explicitement
+   `external_handoff`, puis transmettre la copie temporaire retournée à un outil
+   local adapté du client.
+5. Conserver comme provenance l’identifiant logique, le chemin relatif et le
+   SHA-256. Ne jamais persister le chemin temporaire.
+
+Ne pas promettre l’extraction au seul motif que le handoff fonctionne :
+l’extraction dépend du client appelant. Ne pas copier silencieusement le contenu
+externe dans le coffre, le fusionner à la recherche du coffre ou traiter la
+racine configurée comme une sauvegarde.
 
 ## Ce que le headless valide mais ne garantit pas
 

--- a/docs/mcp-routing-guide.md
+++ b/docs/mcp-routing-guide.md
@@ -2,7 +2,10 @@
 
 French version: [mcp-routing-guide.fr.md](mcp-routing-guide.fr.md)
 
-Related docs: [README](../README.md), [Operations](../OPERATIONS.md), [Runtime Capability Matrix](runtime-capability-matrix.md), [Headless Server Profile](headless-server-profile.md)
+Related docs: [README](../README.md), [Operations](../OPERATIONS.md),
+[Runtime Capability Matrix](runtime-capability-matrix.md),
+[Headless Server Profile](headless-server-profile.md), and
+[External document roots](external-roots-setup.md)
 
 This guide helps agents choose the right layer for Obsidian work.
 
@@ -11,6 +14,7 @@ This guide helps agents choose the right layer for Obsidian work.
 | Need                                                                         | Use                                                           | Why                                                                     |
 | ---------------------------------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | Read, list, search, tasks, semantic search                                   | Optimike MCP                                                  | Stable tool surface across live, hybrid, and headless modes.            |
+| Read an explicitly configured document outside the vault                     | Optimike MCP external-root tools                              | Default-deny confinement with portable logical paths.                   |
 | Full Obsidian behavior, commands, active file, plugin-backed Bases           | Optimike MCP in `live` or `hybrid` with Obsidian Desktop open | This is the only mode with Desktop/plugin-backed semantics.             |
 | Safe backend server over a synced vault                                      | Optimike MCP in `headless-readonly` first                     | No Desktop required and no write risk.                                  |
 | Bounded Markdown/frontmatter/tag/admin writes on a copied or dedicated vault | Optimike MCP in `headless-filesystem`                         | Path safety, dry-run defaults, and preconditions.                       |
@@ -35,6 +39,28 @@ Use `obsidian_manage_canvas` only in `headless-filesystem`:
 - `connect_nodes` adds an edge between existing node IDs.
 
 Dry-run is the default for write operations.
+
+## External document routing
+
+An Obsidian link to a local file does not authorize access to that file. Use
+external-root tools only when the operator has explicitly configured a logical
+root ID.
+
+Agent workflow:
+
+1. Call `external_runtime_status` or `external_roots_list`; never infer a root
+   from a physical path found in a note.
+2. Use `external_list` and `external_stat` with a root ID and root-relative
+   path.
+3. Use `external_read` only for bounded UTF-8 text.
+4. For PDF or Office content, request `external_handoff` explicitly, then pass
+   the returned temporary copy to a suitable local client tool.
+5. Preserve the logical root ID, relative path, and SHA-256 as provenance.
+   Never persist the temporary path.
+
+Do not promise extraction merely because handoff succeeds: extraction depends
+on the calling client. Do not silently copy external content into the vault,
+merge it into vault search, or treat the configured root as a backup.
 
 ## What Headless Can Validate But Not Guarantee
 

--- a/docs/obsidian_mcp_tools_spec.md
+++ b/docs/obsidian_mcp_tools_spec.md
@@ -140,6 +140,7 @@ machine-local JSON configuration.
 
 The core MCP does not parse PDF or Office files. Handoff requires both
 `readable` and `handoff`; it is denied on HTTP. See
+[External document roots — setup and operations](external-roots-setup.md) and
 [ADR-External-Document-Roots.md](adr/ADR-External-Document-Roots.md).
 
 ## Filesystem Admin

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "docs/mcp-routing-guide.md",
     "docs/mcp-routing-guide.fr.md",
     "docs/external-roots.example.json",
+    "docs/external-roots-setup.md",
+    "docs/external-roots-setup.fr.md",
     "docs/adr/ADR-External-Document-Roots.md",
     "docs/adr/ADR-Operon-Bridge.md",
     "docs/operon-decision-report.md",


### PR DESCRIPTION
## Résumé
- publie les guides opérateur FR/EN pour les racines documentaires externes
- documente Codex Windows, le patron MCP multi-client, le handoff borné, le redémarrage, le rollback et le dépannage
- promeut l’ADR et rend la documentation découvrable depuis README/Operations/routing
- ajoute la suite external-roots à la matrice CI Linux/Windows et inclut les guides dans le paquet npm

## Validation locale
- npm run test:external-roots
- npm run test:runtime
- npm run test:tool-annotations
- npm run test:profiles
- npm run audit:production (0 vulnérabilité production)
- npm run test:package après build des Bridges
- git diff --check, liens Markdown, JSON, npm pack --dry-run

## Limites explicites
- Codex Windows testé réellement
- Claude Code, Gemini CLI, OpenClaw et Hermes : compatibles MCP par conception, pas encore testés client par client
