### PR TITLE
feat: transactional external file moves with ÉLYSIA link repair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,9 +84,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The move verifies source size, mtime and SHA-256, requires an absent target
   under an existing real parent, and uses a no-clobber same-volume
   hard-link/unlink sequence.
-- Exact note repairs use SHA-256 preconditions and Local REST API Markdown Patch
-  2.x `If-Match` in live mode. Direct HTTP refuses scan, plan/status, apply and
-  rollback.
+- Exact note repairs use SHA-256 preconditions in `headless-filesystem` on a
+  copied or dedicated vault. Live apply fails closed because Local REST API
+  4.1.7 does not enforce `If-Match` on whole-note writes. Direct HTTP refuses
+  scan, plan/status, apply and rollback.
 - Marked every legacy MCP tool as read-only, mutating, maintenance, or destructive for approval-aware clients.
 - Moved MCP Inspector to development dependencies and updated `fast-uri` to a patched release, removing the high-severity production audit finding.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   compatibility, verification, rollback, and troubleshooting.
 - Architecture decision record covering direct HTTP profiles, transport-aware
   delivery, the external-mutation hold, threat model, and rollback.
+- Local-stdio external reference integrity workflow with
+  `external_references_scan`, durable move plan/status, guarded apply and
+  rollback for one same-root regular file.
+- Canonical adjacent reference identity
+  `external-ref:<rootId>::<percent-encoded-relative-path>` for exact repair of
+  clickable `file:///` links without turning physical paths into authority.
+- Machine-local SQLite move journal, idempotency binding, exact note preimages,
+  no-clobber hard-link/unlink file moves, conditional note repairs and
+  compensating rollback.
+- Bilingual ADR and operator guidance for the external move/repair pilot,
+  including HTTP denial and the explicit create/replace/upload/delete/sync
+  exclusions.
 - ÉLYSIA Tasks profile 1.1 with global Inbox, This Week, bounded Now, Backlog, periodic-note leakage detection, and a P90-J admission gate.
 - Public task-governor guidance for distinct dry-run/apply idempotency keys and post-mutation visibility proof.
 - Regression coverage for Obsidian wikilink normalization in the Bases Bridge.
@@ -33,6 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   HTTP and pilot-only remote HTTP without contradictory stdio-only claims.
 - Runtime matrices now describe Operon as a common tool family and restrict
   Canvas, move and admin tools to the modes that actually register them.
+- External-root documentation now distinguishes the default read/handoff
+  contract from the separately gated local-stdio move/repair transaction.
 - The bundled Inspector HTTP example is now explicitly development-only instead
   of presenting an unused JWT secret as authentication.
 - HTTP and Inspector launch scripts now use cross-platform Node wrappers.
@@ -61,8 +75,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - HTTP ticket snapshots have independent file, aggregate-memory, count and TTL
   limits, including reservations for requests still buffering. The broker does
   not delete or mutate the local handoff cache owned by `ExternalRootsService`.
-- No upload, create, replace, move, delete or sync capability is introduced for
-  external roots.
+- No upload, create, replace, directory/cross-root move, overwrite, delete or
+  sync capability is introduced for external roots. The only mutation is an
+  opt-in same-root regular-file move through local stdio.
+- External move apply and rollback require `MCP_WRITE_MODE=full`,
+  `MCP_EXTERNAL_MOVE_ENABLED=true` and the root `move` capability. Ambiguous,
+  legacy or historical references block apply.
+- The move verifies source size, mtime and SHA-256, requires an absent target
+  under an existing real parent, and uses a no-clobber same-volume
+  hard-link/unlink sequence.
+- Exact note repairs use SHA-256 preconditions and Local REST API Markdown Patch
+  2.x `If-Match` in live mode. Direct HTTP refuses scan, plan/status, apply and
+  rollback.
 - Marked every legacy MCP tool as read-only, mutating, maintenance, or destructive for approval-aware clients.
 - Moved MCP Inspector to development dependencies and updated `fast-uri` to a patched release, removing the high-severity production audit finding.
 

--- a/SECURITY.fr.md
+++ b/SECURITY.fr.md
@@ -93,8 +93,9 @@ par défaut.
   hard-link/unlink sans écrasement échoue fermée sur un filesystem non supporté
   ou cross-volume.
 - Toute référence ambiguë, historique, legacy ou non supportée bloque l’apply.
-  Les réparations live emploient `If-Match` de la Local REST API ; les
-  réparations headless emploient une précondition de hash exacte.
+  Les réparations par hash exact sont limitées à `headless-filesystem` sur une
+  copie ou un coffre dédié. L’apply live échoue fermé, car les remplacements de
+  note complète via Local REST n’imposent pas `If-Match`.
 - `MCP_EXTERNAL_MOVE_JOURNAL_PATH` contient l’état durable des plans et les
   préimages de notes. Le conserver local à la machine, à accès restreint, hors
   dépôts, dossiers synchronisés et diagnostics publics.

--- a/SECURITY.fr.md
+++ b/SECURITY.fr.md
@@ -51,13 +51,17 @@ MCP_HTTP_HANDOFF_ENABLED=true
 Le broker refuse le placeholder d’authentification de développement. Les
 tickets sont liés à l’identité, éphémères, à usage unique et absents des URL.
 Ils n’autorisent aucune création, modification, suppression ou synchronisation.
+Le HTTP direct refuse aussi `external_references_scan` et toutes les opérations
+`external_move_*`.
 
 L’entrée HTTP fournie dans `mcp.json` est volontairement un profil de
 développement Inspector non authentifié, limité au loopback et avec handoff HTTP
 désactivé. Ce n’est pas une configuration de production.
 
 Voir [Configuration des racines](docs/external-roots-setup.fr.md) et
-[ADR HTTP](docs/adr/ADR-HTTP-External-Artifact-Delivery.md).
+[ADR HTTP](docs/adr/ADR-HTTP-External-Artifact-Delivery.md). La frontière du
+move local est définie dans
+[l’ADR Intégrité des références externes](docs/adr/ADR-External-Reference-Integrity.fr.md).
 
 ## Frontière reverse proxy
 
@@ -80,7 +84,22 @@ par défaut.
 - L’apply Operon exige le réglage Bridge et
   `OPERON_MUTATIONS_ENABLED=true`.
 - Utiliser dry-run, révisions/hashes attendus et preuve après écriture.
-- Les racines externes restent read-only dans le contrat actuel.
+- Les racines externes sont read-only par défaut. L’unique mutation est un move
+  stdio local d’un fichier régulier dans la même racine, avec réparation exacte
+  des références ÉLYSIA.
+- Apply et rollback exigent `MCP_WRITE_MODE=full`,
+  `MCP_EXTERNAL_MOVE_ENABLED=true` et une racine portant la capacité `move`.
+- La cible doit être absente sous un dossier parent réel existant. La séquence
+  hard-link/unlink sans écrasement échoue fermée sur un filesystem non supporté
+  ou cross-volume.
+- Toute référence ambiguë, historique, legacy ou non supportée bloque l’apply.
+  Les réparations live emploient `If-Match` de la Local REST API ; les
+  réparations headless emploient une précondition de hash exacte.
+- `MCP_EXTERNAL_MOVE_JOURNAL_PATH` contient l’état durable des plans et les
+  préimages de notes. Le conserver local à la machine, à accès restreint, hors
+  dépôts, dossiers synchronisés et diagnostics publics.
+- Aucun upload, create, replace, move de dossier/cross-root, overwrite, delete,
+  corbeille ou sync externe n’est activé.
 
 ## Contrôles dépendances et release
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -51,7 +51,8 @@ MCP_HTTP_HANDOFF_ENABLED=true
 
 The handoff broker rejects the development authentication placeholder. Tickets
 are identity-bound, short-lived, single-use and absent from URLs. They do not
-authorize upload, create, replace, move, delete or sync.
+authorize upload, create, replace, move, delete or sync. Direct HTTP also
+refuses `external_references_scan` and every `external_move_*` operation.
 
 The bundled `mcp.json` HTTP entry is intentionally an unauthenticated,
 loopback-only Inspector development profile with HTTP handoff disabled. It is
@@ -59,7 +60,8 @@ not a production configuration.
 
 See [External Roots Setup](docs/external-roots-setup.md) for the full
 configuration and [HTTP Delivery ADR](docs/adr/ADR-HTTP-External-Artifact-Delivery.md)
-for the threat model.
+for the transport threat model. The local move boundary is specified by the
+[External Reference Integrity ADR](docs/adr/ADR-External-Reference-Integrity.md).
 
 ## Reverse proxy boundary
 
@@ -81,7 +83,21 @@ by default.
 - Operon apply requires both the Bridge mutation setting and
   `OPERON_MUTATIONS_ENABLED=true`.
 - Use dry-run, expected revisions/hashes and post-write proof where supported.
-- External roots are read-only in the current contract.
+- External roots are read-only by default. The only external mutation is a
+  local-stdio same-root regular-file move with exact ÉLYSIA reference repair.
+- External move apply and rollback require `MCP_WRITE_MODE=full`,
+  `MCP_EXTERNAL_MOVE_ENABLED=true` and a root carrying the `move` capability.
+- The target must be absent under an existing real parent. The no-clobber
+  hard-link/unlink sequence fails closed on unsupported or cross-volume
+  filesystems.
+- Any ambiguous, historical, legacy or unsupported reference blocks apply.
+  Live note repairs use Local REST API `If-Match`; headless repairs use exact
+  hash preconditions.
+- `MCP_EXTERNAL_MOVE_JOURNAL_PATH` contains durable plan state and note
+  preimages. Keep it machine-local, access-restricted and outside repositories,
+  synchronized folders and public diagnostics.
+- No external upload, create, replace, directory/cross-root move, overwrite,
+  delete, trash or sync capability is enabled.
 
 ## Dependency and release checks
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -91,8 +91,9 @@ by default.
   hard-link/unlink sequence fails closed on unsupported or cross-volume
   filesystems.
 - Any ambiguous, historical, legacy or unsupported reference blocks apply.
-  Live note repairs use Local REST API `If-Match`; headless repairs use exact
-  hash preconditions.
+  Exact-hash repairs are limited to `headless-filesystem` on a copied or
+  dedicated vault. Live apply fails closed because whole-note Local REST writes
+  do not enforce `If-Match`.
 - `MCP_EXTERNAL_MOVE_JOURNAL_PATH` contains durable plan state and note
   preimages. Keep it machine-local, access-restricted and outside repositories,
   synchronized folders and public diagnostics.

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -7,30 +7,30 @@ question.
 
 ## Commencer selon son rôle
 
-| Je suis…                        | Commencer ici                                            | Puis utiliser                                                                                                      |
-| ------------------------------- | -------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
-| Nouvel utilisateur local        | [Présentation](../README.fr.md)                          | [Exploitation](../OPERATIONS.fr.md)                                                                                |
-| Opérateur Codex ou agent local  | [Exploitation](../OPERATIONS.fr.md)                      | [Routage agentique](mcp-routing-guide.fr.md)                                                                       |
-| Opérateur headless/serveur      | [Profil serveur headless](headless-server-profile.fr.md) | [Matrice runtime](runtime-capability-matrix.fr.md), [Sécurité](../SECURITY.fr.md)                                  |
-| Intégrateur d’un client MCP     | [Surface des outils](obsidian_mcp_tools_spec.md)         | [Matrice runtime](runtime-capability-matrix.fr.md)                                                                 |
-| Opérateur de documents externes | [Configuration des racines](external-roots-setup.fr.md)  | [ADR racines externes](adr/ADR-External-Document-Roots.md), [ADR HTTP](adr/ADR-HTTP-External-Artifact-Delivery.md) |
-| Opérateur Tasks/Operon          | [Contrat MCP Operon](operon-mcp-contract.md)             | [Validation locale](operon-local-validation.md), [profil public ÉLYSIA](../profiles/elysia-tasks/README.fr.md)     |
-| Contributeur ou relecteur       | [Décisions d’architecture](adr/README.md)                | [Arbre du dépôt](tree.md), README des plugins                                                                      |
+| Je suis…                        | Commencer ici                                            | Puis utiliser                                                                                                                          |
+| ------------------------------- | -------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| Nouvel utilisateur local        | [Présentation](../README.fr.md)                          | [Exploitation](../OPERATIONS.fr.md)                                                                                                    |
+| Opérateur Codex ou agent local  | [Exploitation](../OPERATIONS.fr.md)                      | [Routage agentique](mcp-routing-guide.fr.md)                                                                                           |
+| Opérateur headless/serveur      | [Profil serveur headless](headless-server-profile.fr.md) | [Matrice runtime](runtime-capability-matrix.fr.md), [Sécurité](../SECURITY.fr.md)                                                      |
+| Intégrateur d’un client MCP     | [Surface des outils](obsidian_mcp_tools_spec.md)         | [Matrice runtime](runtime-capability-matrix.fr.md)                                                                                     |
+| Opérateur de documents externes | [Configuration des racines](external-roots-setup.fr.md)  | [ADR racines externes](adr/ADR-External-Document-Roots.md), [ADR intégrité des références](adr/ADR-External-Reference-Integrity.fr.md) |
+| Opérateur Tasks/Operon          | [Contrat MCP Operon](operon-mcp-contract.md)             | [Validation locale](operon-local-validation.md), [profil public ÉLYSIA](../profiles/elysia-tasks/README.fr.md)                         |
+| Contributeur ou relecteur       | [Décisions d’architecture](adr/README.md)                | [Arbre du dépôt](tree.md), README des plugins                                                                                          |
 
 ## Trouver la page qui fait foi
 
-| Question                                                         | Autorité                                                                                |
-| ---------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| Quels outils existent ?                                          | [Surface des outils](obsidian_mcp_tools_spec.md)                                        |
-| Quels outils sont disponibles dans chaque runtime ?              | [Matrice des capacités](runtime-capability-matrix.fr.md)                                |
-| Comment lancer et maintenir le service ?                         | [Exploitation](../OPERATIONS.fr.md)                                                     |
-| Quelle surface un agent doit-il utiliser ?                       | [Guide de routage](mcp-routing-guide.fr.md)                                             |
-| Comment fonctionner sans Obsidian Desktop ?                      | [Profil serveur headless](headless-server-profile.fr.md)                                |
-| Comment fonctionne le handoff de documents externes ?            | [Configuration des racines](external-roots-setup.fr.md)                                 |
-| Quelle frontière de sécurité HTTP est supportée ?                | [Sécurité](../SECURITY.fr.md) et [ADR HTTP](adr/ADR-HTTP-External-Artifact-Delivery.md) |
-| Comment les lectures et mutations Operon sont-elles gouvernées ? | [Contrat MCP Operon](operon-mcp-contract.md)                                            |
-| Pourquoi une décision d’architecture a-t-elle été prise ?        | [Index des ADR](adr/README.md)                                                          |
-| Qu’est-ce qui a changé ?                                         | [Changelog](../CHANGELOG.md)                                                            |
+| Question                                                                      | Autorité                                                                                |
+| ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Quels outils existent ?                                                       | [Surface des outils](obsidian_mcp_tools_spec.md)                                        |
+| Quels outils sont disponibles dans chaque runtime ?                           | [Matrice des capacités](runtime-capability-matrix.fr.md)                                |
+| Comment lancer et maintenir le service ?                                      | [Exploitation](../OPERATIONS.fr.md)                                                     |
+| Quelle surface un agent doit-il utiliser ?                                    | [Guide de routage](mcp-routing-guide.fr.md)                                             |
+| Comment fonctionner sans Obsidian Desktop ?                                   | [Profil serveur headless](headless-server-profile.fr.md)                                |
+| Comment fonctionnent lecture, handoff, move et réparation de liens externes ? | [Configuration des racines](external-roots-setup.fr.md)                                 |
+| Quelle frontière de sécurité HTTP est supportée ?                             | [Sécurité](../SECURITY.fr.md) et [ADR HTTP](adr/ADR-HTTP-External-Artifact-Delivery.md) |
+| Comment les lectures et mutations Operon sont-elles gouvernées ?              | [Contrat MCP Operon](operon-mcp-contract.md)                                            |
+| Pourquoi une décision d’architecture a-t-elle été prise ?                     | [Index des ADR](adr/README.md)                                                          |
+| Qu’est-ce qui a changé ?                                                      | [Changelog](../CHANGELOG.md)                                                            |
 
 ## Familles de capacités
 
@@ -57,7 +57,9 @@ question.
 
 - configuration et parcours clients : [Configuration des racines](external-roots-setup.fr.md) ;
 - routage agentique : [Guide de routage](mcp-routing-guide.fr.md#routage-des-documents-externes) ;
-- sécurité et cycle de vie : [ADR HTTP](adr/ADR-HTTP-External-Artifact-Delivery.md).
+- frontière de livraison HTTP : [ADR HTTP](adr/ADR-HTTP-External-Artifact-Delivery.md) ;
+- move local, réparation exacte des liens et rollback :
+  [ADR intégrité des références](adr/ADR-External-Reference-Integrity.fr.md).
 
 ## Propriété documentaire
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,30 +7,30 @@ French operator guides are linked alongside their English equivalents.
 
 ## Start by role
 
-| I am…                           | Start here                                            | Then use                                                                                                         |
-| ------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| A new local user                | [Product overview](../README.md)                      | [Operations](../OPERATIONS.md)                                                                                   |
-| A Codex or local-agent operator | [Operations](../OPERATIONS.md)                        | [Agent routing](mcp-routing-guide.md)                                                                            |
-| A headless/server operator      | [Headless Server Profile](headless-server-profile.md) | [Runtime Matrix](runtime-capability-matrix.md), [Security](../SECURITY.md)                                       |
-| An MCP client integrator        | [Tool Surface](obsidian_mcp_tools_spec.md)            | [Runtime Matrix](runtime-capability-matrix.md)                                                                   |
-| An external-document operator   | [External Roots Setup](external-roots-setup.md)       | [External Roots ADR](adr/ADR-External-Document-Roots.md), [HTTP ADR](adr/ADR-HTTP-External-Artifact-Delivery.md) |
-| A Tasks/Operon operator         | [Operon MCP Contract](operon-mcp-contract.md)         | [Local Validation](operon-local-validation.md), [public ÉLYSIA profile](../profiles/elysia-tasks/README.fr.md)   |
-| A contributor or reviewer       | [Architecture decisions](adr/README.md)               | [Repository tree](tree.md), plugin READMEs                                                                       |
+| I am…                           | Start here                                            | Then use                                                                                                                     |
+| ------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------- |
+| A new local user                | [Product overview](../README.md)                      | [Operations](../OPERATIONS.md)                                                                                               |
+| A Codex or local-agent operator | [Operations](../OPERATIONS.md)                        | [Agent routing](mcp-routing-guide.md)                                                                                        |
+| A headless/server operator      | [Headless Server Profile](headless-server-profile.md) | [Runtime Matrix](runtime-capability-matrix.md), [Security](../SECURITY.md)                                                   |
+| An MCP client integrator        | [Tool Surface](obsidian_mcp_tools_spec.md)            | [Runtime Matrix](runtime-capability-matrix.md)                                                                               |
+| An external-document operator   | [External Roots Setup](external-roots-setup.md)       | [External Roots ADR](adr/ADR-External-Document-Roots.md), [Reference Integrity ADR](adr/ADR-External-Reference-Integrity.md) |
+| A Tasks/Operon operator         | [Operon MCP Contract](operon-mcp-contract.md)         | [Local Validation](operon-local-validation.md), [public ÉLYSIA profile](../profiles/elysia-tasks/README.fr.md)               |
+| A contributor or reviewer       | [Architecture decisions](adr/README.md)               | [Repository tree](tree.md), plugin READMEs                                                                                   |
 
 ## Find the authoritative page
 
-| Question                                      | Authority                                                                             |
-| --------------------------------------------- | ------------------------------------------------------------------------------------- |
-| Which tools exist?                            | [Tool Surface](obsidian_mcp_tools_spec.md)                                            |
-| Which tools are available in each runtime?    | [Runtime Capability Matrix](runtime-capability-matrix.md)                             |
-| How do I run and maintain the service?        | [Operations](../OPERATIONS.md)                                                        |
-| Which surface should an agent use?            | [MCP Routing Guide](mcp-routing-guide.md)                                             |
-| How do I run without Obsidian Desktop?        | [Headless Server Profile](headless-server-profile.md)                                 |
-| How do external documents and handoff work?   | [External Roots Setup](external-roots-setup.md)                                       |
-| What is the supported HTTP security boundary? | [Security](../SECURITY.md) and [HTTP ADR](adr/ADR-HTTP-External-Artifact-Delivery.md) |
-| How are Operon reads and mutations governed?  | [Operon MCP Contract](operon-mcp-contract.md)                                         |
-| Why was an architecture decision made?        | [ADR Index](adr/README.md)                                                            |
-| What changed?                                 | [Changelog](../CHANGELOG.md)                                                          |
+| Question                                                   | Authority                                                                             |
+| ---------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Which tools exist?                                         | [Tool Surface](obsidian_mcp_tools_spec.md)                                            |
+| Which tools are available in each runtime?                 | [Runtime Capability Matrix](runtime-capability-matrix.md)                             |
+| How do I run and maintain the service?                     | [Operations](../OPERATIONS.md)                                                        |
+| Which surface should an agent use?                         | [MCP Routing Guide](mcp-routing-guide.md)                                             |
+| How do I run without Obsidian Desktop?                     | [Headless Server Profile](headless-server-profile.md)                                 |
+| How do external reads, handoff, move and link repair work? | [External Roots Setup](external-roots-setup.md)                                       |
+| What is the supported HTTP security boundary?              | [Security](../SECURITY.md) and [HTTP ADR](adr/ADR-HTTP-External-Artifact-Delivery.md) |
+| How are Operon reads and mutations governed?               | [Operon MCP Contract](operon-mcp-contract.md)                                         |
+| Why was an architecture decision made?                     | [ADR Index](adr/README.md)                                                            |
+| What changed?                                              | [Changelog](../CHANGELOG.md)                                                          |
 
 ## Capability families
 
@@ -57,7 +57,9 @@ French operator guides are linked alongside their English equivalents.
 
 - configuration and client workflows: [External Roots Setup](external-roots-setup.md);
 - semantic routing for agents: [MCP Routing Guide](mcp-routing-guide.md#external-document-routing);
-- security and lifecycle decisions: [HTTP ADR](adr/ADR-HTTP-External-Artifact-Delivery.md).
+- HTTP delivery boundary: [HTTP ADR](adr/ADR-HTTP-External-Artifact-Delivery.md);
+- local move, exact link repair and rollback:
+  [Reference Integrity ADR](adr/ADR-External-Reference-Integrity.md).
 
 ## Documentation ownership
 

--- a/docs/adr/ADR-External-Document-Roots.md
+++ b/docs/adr/ADR-External-Document-Roots.md
@@ -1,7 +1,9 @@
 # ADR — External document roots
 
 - Status: accepted and implemented on `main`; handoff transport amended by
-  [ADR — Governed HTTP delivery](ADR-HTTP-External-Artifact-Delivery.md)
+  [ADR — Governed HTTP delivery](ADR-HTTP-External-Artifact-Delivery.md);
+  one local move/repair workflow amended by
+  [ADR — External reference integrity](ADR-External-Reference-Integrity.md)
 - Date: 2026-07-28
 - External-roots baseline:
   `optimikelabs/optimike-obsidian-mcp@7c2eaad5bf958fa0315d69a067f9972910f6c39d`
@@ -38,7 +40,7 @@ External document access uses an explicit
 - bounded listing, text reading, hashing, and explicit verified handoff;
 - no embedded Office/PDF extraction engine in the first release;
 - no external cache or search namespace in the first release;
-- no automatic copying, moving, renaming, overwriting, or synchronization.
+- no generic copying, moving, renaming, overwriting, or synchronization.
 
 The first implementation is intentionally a secure broker between logical roots
 and agent clients that already have document tools, including Codex, Claude
@@ -77,9 +79,10 @@ Initial capability vocabulary:
 `extractable` and `indexable` are reserved for optional future adapters. They
 are not implemented by the core service.
 
-`writable` is excluded from the first implementation. If it is ever proposed,
-it requires a separate ADR, threat model, mutation journal, optimistic
-preconditions, dry-run contract, explicit apply gate, and rollback evidence.
+`writable` remains excluded as a generic capability. The later reference
+integrity amendment adds only the narrower `move` capability for one same-root
+regular file, with a separate threat model, journal, optimistic preconditions,
+explicit apply gate and rollback evidence.
 
 The absence of a capability denies the corresponding file operation; root
 discovery remains available as described above.
@@ -155,9 +158,9 @@ from vault semantic search.
 - No startup scan of all external roots.
 - Deleting an index entry never deletes the source file.
 
-## Provisional tool surface
+## Tool surface
 
-Current first-release tool surface:
+Read and handoff surface:
 
 - `external_roots_list`
 - `external_list`
@@ -166,8 +169,11 @@ Current first-release tool surface:
 - `external_handoff`
 - `external_runtime_status`
 
-These tools are implemented on `main`. All are read-only and carry read-only
-MCP annotations.
+These tools are implemented on `main` and carry read-only MCP annotations. The
+later local-stdio amendment adds `external_references_scan`,
+`external_move_plan`, `external_move_status`, `external_move_apply` and
+`external_move_rollback`. Its first three operations are read-only; apply and
+rollback are destructive, separately gated, and refused over direct HTTP.
 
 ## Runtime and deployment policy
 
@@ -239,9 +245,18 @@ The promoted implementation provides:
 - stale/hash semantics;
 - no automatic startup crawl.
 
+### Phase 5 — Same-root file move with reference integrity — local pilot
+
+- canonical adjacent logical identity;
+- read-only inventory and durable plan/status;
+- one no-clobber regular-file move through local stdio;
+- exact conditional ÉLYSIA note repair;
+- journal, compensation and rollback;
+- direct HTTP mutation denied.
+
 ### Deferred
 
-- write tools;
+- generic write tools;
 - sync or migration;
 - watcher-driven recursive indexing;
 - network and collaborative-provider connectors;

--- a/docs/adr/ADR-External-Reference-Integrity.fr.md
+++ b/docs/adr/ADR-External-Reference-Integrity.fr.md
@@ -1,0 +1,147 @@
+# ADR — Déplacement gouverné et intégrité des références externes ÉLYSIA
+
+- Statut : accepté et implémenté pour un pilote stdio local
+- Périmètre : un fichier régulier dans une racine externe locale configurée
+- Version anglaise : [ADR-External-Reference-Integrity.md](ADR-External-Reference-Integrity.md)
+- Amende : [Racines documentaires externes](ADR-External-Document-Roots.md)
+- N’amende pas : [Livraison HTTP gouvernée](ADR-HTTP-External-Artifact-Delivery.md)
+
+## Contexte
+
+Les racines externes exposaient initialement la découverte, les lectures
+bornées, le hash et le handoff vérifié. Un harnais local sait déjà déplacer un
+fichier, mais cette opération seule peut casser silencieusement les notes
+Obsidian qui expliquent son rôle.
+
+La capacité utile n’est donc pas un gestionnaire de fichiers générique. C’est
+une transaction bornée qui inventorie les références ÉLYSIA, planifie un
+déplacement dans la même racine, ne répare que les références exactes, prouve le
+résultat et sait revenir en arrière.
+
+## Décision
+
+Ajouter un workflow réservé au stdio local :
+
+1. `external_references_scan` inventorie les références vers un fichier externe.
+2. `external_move_plan` vérifie source et cible, inventorie le coffre et
+   persiste un plan.
+3. `external_move_status` retourne le reçu durable sans chemin physique.
+4. `external_move_apply` déplace le fichier et répare conditionnellement les
+   notes exactes.
+5. `external_move_rollback` restaure les deux surfaces si toutes les
+   préconditions tiennent encore.
+
+Le scan et le plan sont en lecture seule. L’apply et le rollback exigent les
+trois autorisations positives :
+
+- `MCP_WRITE_MODE=full` ;
+- `MCP_EXTERNAL_MOVE_ENABLED=true` ;
+- la racine sélectionnée déclare la capacité `move`.
+
+Cette capacité n’implique jamais upload, create, replace, delete ou sync.
+
+## Identité canonique de référence
+
+Une référence réparable automatiquement est un paragraphe Markdown contenant :
+
+```md
+[Ouvrir le brief](file:///B:/Documents/Projet/brief%20final.docx) — `external-ref:project.documents::brief%20final.docx`
+```
+
+Le lien `file:///` reste le localisateur cliquable pour l’humain. Le code inline
+adjacent porte l’identité machine stable :
+
+```text
+external-ref:<rootId>::<chemin-relatif-encode-en-pourcentage>
+```
+
+Chaque segment utilise l’encodage canonique `encodeURIComponent`, tandis que
+`/` sépare les segments. Les identifiants de racine suivent la grammaire logique
+en minuscules de la configuration. Sont refusés : chemins absolus, traversals,
+segments vides, séparateurs encodés, hôtes UNC, fragments et query strings.
+
+Le token n’autorise pas l’accès filesystem et n’est pas un protocole URI
+personnalisé. La racine configurée reste l’unique frontière d’autorisation.
+
+Seule une paire exacte token/lien dans un paragraphe Markdown actif est
+réparable automatiquement. Chemins nus, tokens orphelins, paires incohérentes,
+liens candidats multiples, syntaxes non supportées et références sous des
+headings d’historique, archive, exemple, release notes ou changelog exigent une
+revue manuelle. Toute occurrence en revue manuelle bloque l’apply.
+
+## Transaction filesystem
+
+Le contrat V1 est volontairement étroit :
+
+- un seul fichier régulier ;
+- source et cible dans la même racine logique et sur le même volume ;
+- dossier parent cible déjà existant et réel ;
+- cible absente ;
+- politique include/exclude valide sur les deux chemins ;
+- aucun suivi de lien ou junction ;
+- taille, date de modification et SHA-256 source inchangés depuis le plan.
+
+L’apply emploie une séquence hard-link/unlink sans écrasement : il crée le lien
+cible, prouve que source et cible désignent le même objet filesystem, puis
+retire la source. Un filesystem incapable de fournir ces garanties échoue fermé.
+
+## Réparation du coffre et concurrence
+
+Chaque réparation planifiée conserve le contenu exact avant/après et le SHA-256
+attendu de la note. L’apply relit toutes les notes avant de déplacer le fichier.
+En mode Obsidian live, il récupère la version Local REST API et utilise Markdown
+Patch 2.x avec `If-Match` ; une édition concurrente produit un conflit au lieu
+d’être écrasée. En headless, l’écriture utilise la précondition de hash exacte.
+
+Si une réparation échoue après le move, le coordinateur compense les notes déjà
+modifiées et replace le fichier quand son état vérifié le permet encore.
+
+## Journal et récupération
+
+Les plans et transitions d’état vivent dans un journal SQLite local à la
+machine, avec WAL et `synchronous=FULL`. Sous Windows, le défaut vit sous
+`LOCALAPPDATA` ; l’opérateur devrait définir un
+`MCP_EXTERNAL_MOVE_JOURNAL_PATH` absolu et privé, notamment sur les autres
+plateformes.
+
+Le journal contient les préimages de notes nécessaires à la compensation. Il
+appartient donc à la même frontière locale de confiance que le coffre et ne doit
+jamais être committé, partagé ou joint à un diagnostic public. Les résultats
+publics exposent identifiants logiques, chemins relatifs, hashes, chemins de
+notes et états, jamais les chemins physiques des racines.
+
+La clé d’idempotence est liée à une seule requête source/cible. Rejouer un apply
+ou rollback terminé retourne l’état enregistré ; réutiliser la clé pour un
+autre move est refusé.
+
+## Frontière de transport
+
+Le proxy stdio possède la configuration des racines, le move physique et le
+journal. Le backend ne fournit que recherche/lecture du coffre et remplacement
+conditionnel des notes.
+
+Le HTTP direct enregistre les noms d’outils pour leur découvrabilité, mais
+refuse scan, plan, status, apply et rollback. Les tickets HTTP restent des
+téléchargements en lecture seule et n’autorisent jamais une mutation. Une
+mutation externe distante ou multi-tenant exigerait un contrat distinct pour
+l’identité, l’isolation tenant et les stockages réseau.
+
+## Explicitement hors périmètre
+
+- create ou replace de fichiers externes ;
+- upload, y compris par ticket HTTP ;
+- déplacement de dossier ou move entre racines/volumes ;
+- overwrite ;
+- delete, y compris une sémantique de corbeille ;
+- synchronisation ;
+- mutation générique cloud, lecteur mappé ou stockage réseau ;
+- réparation automatique des références ambiguës ou legacy.
+
+Ces capacités exigent une valeur ÉLYSIA démontrée et une décision séparée.
+
+## Vérification
+
+La régression doit couvrir parsing canonique, références exclues ou ambiguës,
+collision cible, source modifiée, note modifiée, move sans écrasement,
+compensation, rollback, journal résilient au redémarrage, refus HTTP et
+non-divulgation des chemins, sous Windows et Linux lorsque pertinent.

--- a/docs/adr/ADR-External-Reference-Integrity.fr.md
+++ b/docs/adr/ADR-External-Reference-Integrity.fr.md
@@ -89,9 +89,11 @@ retire la source. Un filesystem incapable de fournir ces garanties échoue ferm�
 
 Chaque réparation planifiée conserve le contenu exact avant/après et le SHA-256
 attendu de la note. L’apply relit toutes les notes avant de déplacer le fichier.
-En mode Obsidian live, il récupère la version Local REST API et utilise Markdown
-Patch 2.x avec `If-Match` ; une édition concurrente produit un conflit au lieu
-d’être écrasée. En headless, l’écriture utilise la précondition de hash exacte.
+L’apply et le rollback sont limités à `headless-filesystem` sur une copie ou un
+coffre dédié, où la précondition de hash exacte est imposée. Local REST API
+4.1.7 expose un ETag mais n’impose pas `If-Match` lors d’un remplacement de note
+complète ; l’apply live échoue donc fermé avant le déplacement du fichier
+externe.
 
 Si une réparation échoue après le move, le coordinateur compense les notes déjà
 modifiées et replace le fichier quand son état vérifié le permet encore.

--- a/docs/adr/ADR-External-Reference-Integrity.md
+++ b/docs/adr/ADR-External-Reference-Integrity.md
@@ -85,10 +85,11 @@ the source. Filesystems that cannot provide these guarantees fail closed.
 ## Vault repair and concurrency
 
 Each planned note repair stores its exact before/after content and expected
-SHA-256. Apply re-reads every note before moving the file. Live Obsidian writes
-obtain the Local REST API document version and use Markdown Patch 2.x with
-`If-Match`; a concurrent edit returns a conflict instead of being overwritten.
-Headless writes use the existing exact-hash precondition.
+SHA-256. Apply re-reads every note before moving the file. Apply and rollback
+are restricted to `headless-filesystem` on a copied or dedicated vault, where
+the existing exact-hash precondition is enforced. Local REST API 4.1.7 exposes
+an ETag but does not enforce `If-Match` on whole-note writes; live apply
+therefore fails closed before the external file is moved.
 
 If a repair fails after the file move, the coordinator compensates completed
 note repairs and rolls the file back when the verified state still permits it.

--- a/docs/adr/ADR-External-Reference-Integrity.md
+++ b/docs/adr/ADR-External-Reference-Integrity.md
@@ -1,0 +1,142 @@
+# ADR — Governed external-file move and ÉLYSIA reference integrity
+
+- Status: accepted and implemented for a local stdio pilot
+- Scope: one regular file inside one configured local external root
+- French version: [ADR-External-Reference-Integrity.fr.md](ADR-External-Reference-Integrity.fr.md)
+- Amends: [External document roots](ADR-External-Document-Roots.md)
+- Does not amend: [Governed HTTP delivery](ADR-HTTP-External-Artifact-Delivery.md)
+
+## Context
+
+External roots originally exposed discovery, bounded reads, hashing and verified
+handoff only. A local harness can already move a file, but that operation alone
+can silently break the Obsidian notes that explain the file's role.
+
+The useful product capability is therefore not a generic file manager. It is a
+bounded transaction that inventories ÉLYSIA references, plans one same-root file
+move, repairs only exact references, proves the result and can roll it back.
+
+## Decision
+
+Add a local-stdio-only workflow:
+
+1. `external_references_scan` inventories references to one external file.
+2. `external_move_plan` verifies the source and target, inventories the vault
+   and persists a plan.
+3. `external_move_status` returns the durable, path-redacted receipt.
+4. `external_move_apply` moves the file and conditionally repairs exact notes.
+5. `external_move_rollback` restores both surfaces when every precondition still
+   holds.
+
+Planning and scanning are read-only. Apply and rollback require all three
+positive gates:
+
+- `MCP_WRITE_MODE=full`;
+- `MCP_EXTERNAL_MOVE_ENABLED=true`;
+- the selected root declares the `move` capability.
+
+The root capability never implies upload, create, replace, delete or sync.
+
+## Canonical reference identity
+
+An automatically repairable reference is one Markdown paragraph containing:
+
+```md
+[Open the brief](file:///B:/Documents/Project/brief%20final.docx) — `external-ref:project.documents::brief%20final.docx`
+```
+
+The `file:///` link remains the human-clickable locator. The adjacent inline
+code token is the stable machine identity:
+
+```text
+external-ref:<rootId>::<percent-encoded-root-relative-path>
+```
+
+Each path segment uses canonical `encodeURIComponent` encoding while `/`
+separates segments. Root IDs use the configured lowercase logical-ID grammar.
+Absolute paths, traversal, empty segments, encoded separators, UNC hosts,
+fragments and query strings are rejected.
+
+The token does not authorize filesystem access and is not a custom URI scheme.
+The configured root remains the sole authorization boundary.
+
+Only an exact token/link pair in an active Markdown paragraph is automatically
+repairable. Bare paths, unmatched tokens, mismatched pairs, multiple candidate
+links, unsupported syntax, and references under history, archive, example,
+release-note or changelog headings require manual review. Any manual-review
+occurrence blocks apply.
+
+## Filesystem transaction
+
+The V1 move contract is intentionally narrow:
+
+- one regular file only;
+- source and target inside the same logical root and filesystem volume;
+- target parent already exists and is a real directory;
+- target does not exist;
+- include/exclude policy accepts both paths;
+- links and junctions are not followed;
+- source size, modification time and SHA-256 still match the plan.
+
+Apply uses a no-clobber hard-link/unlink sequence. It creates the target link,
+proves that source and target identify the same filesystem object, then removes
+the source. Filesystems that cannot provide these guarantees fail closed.
+
+## Vault repair and concurrency
+
+Each planned note repair stores its exact before/after content and expected
+SHA-256. Apply re-reads every note before moving the file. Live Obsidian writes
+obtain the Local REST API document version and use Markdown Patch 2.x with
+`If-Match`; a concurrent edit returns a conflict instead of being overwritten.
+Headless writes use the existing exact-hash precondition.
+
+If a repair fails after the file move, the coordinator compensates completed
+note repairs and rolls the file back when the verified state still permits it.
+
+## Journal and recovery
+
+Plans and state transitions are stored in a machine-local SQLite journal using
+WAL and `synchronous=FULL`. Windows defaults beneath `LOCALAPPDATA`; operators
+should set an explicit private absolute `MCP_EXTERNAL_MOVE_JOURNAL_PATH`,
+especially on other platforms.
+
+The journal contains note preimages required for compensation. It therefore
+belongs inside the same trusted local boundary as the vault and must never be
+committed, shared, or attached to public diagnostics. Public tool results expose
+logical root IDs, relative paths, hashes, note paths and state, never physical
+root paths.
+
+The idempotency key is bound to one source/target request. Replaying a completed
+apply or rollback returns the recorded state; reusing the key for another move
+is rejected.
+
+## Transport boundary
+
+The stdio proxy owns external-root configuration, the physical move and the
+journal. The backend only supplies vault search/read and conditional note
+replacement.
+
+Direct HTTP registers the tool names for discoverability but rejects scan,
+plan, status, apply and rollback. HTTP tickets remain read-only downloads and
+never authorize mutation. Remote and multi-tenant external mutation would need
+a separate identity, tenant-isolation and network-storage contract.
+
+## Explicitly out of scope
+
+- create or replace of external files;
+- upload, including upload by HTTP ticket;
+- directory move or cross-root/cross-volume move;
+- overwrite;
+- delete, including trash semantics;
+- synchronization;
+- generic cloud, mapped-drive or network-storage mutation;
+- automatic repair of ambiguous or legacy references.
+
+These capabilities require demonstrated ÉLYSIA value and a separate decision.
+
+## Verification
+
+The regression suite must cover canonical parsing, excluded/ambiguous
+references, target collision, changed sources, changed notes, no-clobber move,
+compensation, rollback, restart-safe journal state, HTTP denial and path
+redaction on Windows and Linux where applicable.

--- a/docs/adr/ADR-HTTP-External-Artifact-Delivery.md
+++ b/docs/adr/ADR-HTTP-External-Artifact-Delivery.md
@@ -221,7 +221,10 @@ The stdio proxy keeps its existing auto-start and reconnect behavior.
 
 ## Mutation decision
 
-External mutation is not implemented in this change.
+External mutation is not implemented in this HTTP change. A later
+[reference-integrity ADR](ADR-External-Reference-Integrity.md) adopts one
+same-root regular-file move through local stdio only; direct HTTP still refuses
+its scan, plan, status, apply and rollback operations.
 
 A generic `writable` capability is rejected because it collapses materially
 different risks. A future vocabulary should evaluate at least:
@@ -260,17 +263,17 @@ other payload or target is rejected.
 
 ### Milestone verdicts
 
-| Milestone                        | Verdict         | Reason                                                                                         |
-| -------------------------------- | --------------- | ---------------------------------------------------------------------------------------------- |
-| M1 direct loopback HTTP profile  | `APPLY_READY`   | Transport and health endpoint already exist; deterministic and security hardening are bounded. |
-| M2 transport-independent handoff | `APPLY_READY`   | Preserves stdio and adds one explicit delivery mode.                                           |
-| M3 HTTP read-only handoff        | `APPLY_READY`   | One-file, one-use, authenticated, bounded, path-redacted transfer.                             |
-| M4 upload staging                | `EVAL_FIRST`    | Useful only as part of a mutation contract; must not imply apply.                              |
-| M5 governed replace              | `HOLD`          | Requires independent journal, backup, crash, Windows, and rollback evidence.                   |
-| M6 create                        | `EVAL_FIRST`    | Target non-existence and idempotence semantics need proof.                                     |
-| M6 move                          | `HOLD`          | Reference breakage and cross-filesystem behavior need a separate plan.                         |
-| M6 delete                        | `REJECT` for V1 | Irreversible risk is not justified by the current use case.                                    |
-| `sync`                           | `REJECT`        | It is a reconciliation product, not a file-write operation.                                    |
+| Milestone                        | Verdict             | Reason                                                                                         |
+| -------------------------------- | ------------------- | ---------------------------------------------------------------------------------------------- |
+| M1 direct loopback HTTP profile  | `APPLY_READY`       | Transport and health endpoint already exist; deterministic and security hardening are bounded. |
+| M2 transport-independent handoff | `APPLY_READY`       | Preserves stdio and adds one explicit delivery mode.                                           |
+| M3 HTTP read-only handoff        | `APPLY_READY`       | One-file, one-use, authenticated, bounded, path-redacted transfer.                             |
+| M4 upload staging                | `EVAL_FIRST`        | Useful only as part of a mutation contract; must not imply apply.                              |
+| M5 governed replace              | `HOLD`              | Requires independent journal, backup, crash, Windows, and rollback evidence.                   |
+| M6 create                        | `EVAL_FIRST`        | Target non-existence and idempotence semantics need proof.                                     |
+| M6 move                          | `LOCAL_STDIO_PILOT` | Adopted only by the separate reference-integrity ADR; HTTP move remains denied.                |
+| M6 delete                        | `REJECT` for V1     | Irreversible risk is not justified by the current use case.                                    |
+| `sync`                           | `REJECT`            | It is a reconciliation product, not a file-write operation.                                    |
 
 ## Storage classes
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -3,11 +3,12 @@
 ADRs record decisions and their boundaries. Operational commands belong in
 setup or operations guides, not in this index.
 
-| ADR                                                              | Current status                                                                      | Relationship                                                      |
-| ---------------------------------------------------------------- | ----------------------------------------------------------------------------------- | ----------------------------------------------------------------- |
-| [External document roots](ADR-External-Document-Roots.md)        | Accepted and implemented; handoff transport amended                                 | Base authorization, confinement and read-only contract            |
-| [Governed HTTP delivery](ADR-HTTP-External-Artifact-Delivery.md) | Accepted and implemented on `main` for authenticated loopback; remote remains pilot | Adds `http_ticket` without changing external-root mutation policy |
-| [Operon Bridge](ADR-Operon-Bridge.md)                            | Accepted for bounded pilot                                                          | Versioned task-domain bridge and guarded mutation contract        |
+| ADR                                                                                                                | Current status                                                                      | Relationship                                                             |
+| ------------------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
+| [External document roots](ADR-External-Document-Roots.md)                                                          | Accepted and implemented; handoff and local move contracts later amended            | Base authorization, confinement and read/handoff contract                |
+| [Governed HTTP delivery](ADR-HTTP-External-Artifact-Delivery.md)                                                   | Accepted and implemented on `main` for authenticated loopback; remote remains pilot | Adds `http_ticket`; HTTP mutation remains denied                         |
+| [External reference integrity](ADR-External-Reference-Integrity.md) / [FR](ADR-External-Reference-Integrity.fr.md) | Accepted and implemented for a local stdio pilot                                    | Same-root file move, exact ÉLYSIA reference repair, journal and rollback |
+| [Operon Bridge](ADR-Operon-Bridge.md)                                                                              | Accepted for bounded pilot                                                          | Versioned task-domain bridge and guarded mutation contract               |
 
 ## Status vocabulary
 
@@ -19,5 +20,7 @@ setup or operations guides, not in this index.
 - `superseded`: a later ADR replaces the decision.
 
 The external-roots ADR remains authoritative for root authorization,
-confinement, provenance and read-only policy. The HTTP ADR amends only its
-stdio-only delivery restriction.
+confinement, provenance, reads and handoff. The HTTP ADR amends its stdio-only
+delivery restriction. The external-reference-integrity ADR adds one opt-in
+local stdio mutation without opening upload, replace, delete, sync or HTTP
+mutation.

--- a/docs/external-roots-setup.fr.md
+++ b/docs/external-roots-setup.fr.md
@@ -401,20 +401,28 @@ Puis configurer le processus stdio local :
 ```text
 MCP_WRITE_MODE=full
 MCP_EXTERNAL_MOVE_ENABLED=true
+MCP_EXTERNAL_MOVE_PROFILE_ID=<identifiant-stable-du-profil-coffre>
 MCP_EXTERNAL_MOVE_JOURNAL_PATH=<chemin-sqlite-local-absolu-optionnel>
 ```
 
-Les trois autorisations sont nécessaires pour l’apply et le rollback : mode
-write complet, feature flag et capacité `move` de la racine. Scan, plan et
+L’identifiant de profil est requis lorsque le backend live ne peut pas prouver
+un chemin de coffre configuré. Il est hashé dans le binding
+backend/coffre/racines et doit changer si le coffre sélectionné change. Le nom
+du journal est automatiquement profilé avec ce binding.
+
+Les trois autorisations write sont nécessaires pour l’apply et le rollback :
+mode write complet, feature flag et capacité `move` de la racine. Scan, plan et
 status ne déplacent pas le fichier, mais restent stdio-only car le proxy possède
 la racine locale et le journal.
 
 ### Exécuter la transaction
 
-1. Appeler `external_references_scan` avec `rootId`, `relativePath` et un
-   `searchInPath` relatif au coffre, optionnel.
+1. Appeler `external_references_scan` avec `rootId` et `relativePath`. Le scan
+   inventorie tout le coffre gouverné.
 2. Appeler `external_move_plan` avec `sourceRelativePath`,
-   `targetRelativePath`, `searchInPath` et une `idempotencyKey` unique.
+   `targetRelativePath` et une `idempotencyKey` unique. Le plan inventorie
+   toujours tout le coffre gouverné ; il ne peut pas être limité à un
+   sous-dossier.
 3. Examiner `external_move_status` ; ne poursuivre que si `readyToApply` vaut
    true et `manualReview` est vide.
 4. Appeler `external_move_apply` avec le `planId` retourné et la même
@@ -429,11 +437,13 @@ doit être absente. L’apply revérifie taille, date de modification et SHA-256
 la source. Il emploie une séquence hard-link/unlink sans écrasement et échoue
 fermé si le filesystem ne peut pas prouver le move.
 
-Chaque réparation de note est planifiée avec un SHA-256 attendu. En Obsidian
-live, l’écriture utilise la version Local REST API et `If-Match` de Markdown
-Patch 2.x ; une édition concurrente provoque un conflit, jamais un écrasement.
-Le journal SQLite local persiste l’état du plan et les préimages des notes pour
-la compensation. Le traiter comme une donnée locale sensible : ne jamais le
+Chaque réparation de note est planifiée avec un SHA-256 attendu. L’apply et le
+rollback sont actuellement limités à `headless-filesystem` sur une copie ou un
+coffre dédié, où ce hash est imposé par l’écriture filesystem. Local REST API
+4.1.7 renvoie un ETag mais n’impose pas `If-Match` lors d’un remplacement de
+note complète : l’apply live échoue donc fermé avant de déplacer le fichier
+externe. Le journal SQLite local persiste l’état du plan et les préimages des
+notes pour la compensation. Le traiter comme une donnée locale sensible : ne jamais le
 committer ni le partager.
 
 Le HTTP direct refuse scan, plan, status, apply et rollback. Les tickets HTTP

--- a/docs/external-roots-setup.fr.md
+++ b/docs/external-roots-setup.fr.md
@@ -7,7 +7,8 @@ de lire des fichiers explicitement autorisés qui restent hors du coffre
 Obsidian : PDF, documents Office, jeux de données, dossiers projet ou
 bibliothèques gérées par une autre application.
 
-Cette fonction est un courtier en lecture seule, pas un second coffre :
+Cette fonction est principalement un courtier en lecture, pas un second coffre
+ni un gestionnaire de fichiers générique :
 
 - le MCP autorise des identifiants logiques et confine chaque requête à une
   racine ;
@@ -15,8 +16,10 @@ Cette fonction est un courtier en lecture seule, pas un second coffre :
   dans des limites explicites ;
 - `external_handoff` peut préparer un snapshot vérifié pour un client qui possède
   les outils PDF, Office, OCR ou binaires adaptés ;
-- il n’indexe, ne synchronise, ne déplace, ne renomme, n’écrit et ne sauvegarde
-  aucun document externe.
+- un workflow stdio local, autorisé séparément, peut déplacer un fichier régulier
+  dans la même racine et réparer ses références ÉLYSIA exactes ;
+- il n’indexe, ne synchronise, n’upload, ne crée, ne remplace, ne supprime et ne
+  sauvegarde aucun document externe.
 
 Le mode de livraison dépend du transport :
 
@@ -27,6 +30,8 @@ Le mode de livraison dépend du transport :
 
 Voir [ADR — Racines documentaires externes](adr/ADR-External-Document-Roots.md)
 et [ADR — Livraison HTTP gouvernée des artefacts externes](adr/ADR-HTTP-External-Artifact-Delivery.md).
+La frontière move/réparation est portée par
+[ADR — Intégrité des références externes](adr/ADR-External-Reference-Integrity.fr.md).
 
 ## 1. Créer une configuration locale à la machine
 
@@ -95,14 +100,14 @@ L’objet racine est strict :
 
 Chaque racine est également stricte :
 
-| Champ          | Contrat                                                                                                                            |
-| -------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `id`           | Identifiant logique stable en minuscules : lettres, chiffres, `.`, `_` et `-`.                                                     |
-| `path`         | Dossier absolu. Les chemins préfixés UNC sont refusés ; un stockage réseau mappé ou monté n’est pas détecté et reste non supporté. |
-| `capabilities` | Une ou plusieurs valeurs parmi `visible`, `readable`, `handoff`. `handoff` exige `readable`.                                       |
-| `include`      | Allowlist de globs de style Git. Défaut : `["**"]`. Un fichier qui ne correspond à aucun motif est refusé, même sans extension.    |
-| `exclude`      | Denylist de globs. Défaut : `.git` et `node_modules`. `exclude` l’emporte sur `include`.                                           |
-| `limits`       | Limites bornées optionnelles décrites ci-dessous. Les champs inconnus sont refusés.                                                |
+| Champ          | Contrat                                                                                                                                                  |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `id`           | Identifiant logique stable en minuscules : lettres, chiffres, `.`, `_` et `-`.                                                                           |
+| `path`         | Dossier absolu. Les chemins préfixés UNC sont refusés ; un stockage réseau mappé ou monté n’est pas détecté et reste non supporté.                       |
+| `capabilities` | Une ou plusieurs valeurs parmi `visible`, `readable`, `handoff`, `move`. `handoff` exige `readable` ; `move` est une autorisation positive indépendante. |
+| `include`      | Allowlist de globs de style Git. Défaut : `["**"]`. Un fichier qui ne correspond à aucun motif est refusé, même sans extension.                          |
+| `exclude`      | Denylist de globs. Défaut : `.git` et `node_modules`. `exclude` l’emporte sur `include`.                                                                 |
+| `limits`       | Limites bornées optionnelles décrites ci-dessous. Les champs inconnus sont refusés.                                                                      |
 
 Les capacités sont distinctes :
 
@@ -113,6 +118,9 @@ Les capacités sont distinctes :
 - `readable` autorise le hash et la lecture UTF-8 directe ;
 - `handoff` autorise un snapshot vérifié via un mode de livraison supporté par
   le transport actif.
+- `move` autorise la planification d’un déplacement de fichier régulier dans la
+  même racine. L’apply et le rollback exigent encore les deux gates du processus
+  et le stdio local.
 
 Valeurs par défaut et plafonds du schéma :
 
@@ -356,15 +364,83 @@ sans livraison.
 La provenance portable est l’identifiant logique, le chemin relatif, la taille,
 la date de modification et le SHA-256, pas un chemin local ni un ticket.
 
-## 8. Les mutations restent hors périmètre
+## 8. Move local gouverné et réparation des références
 
-La surface `external_roots` actuelle ne possède aucun upload, create, replace,
-move, delete ou sync.
+L’unique mutation external-root est une transaction stdio locale sur un fichier
+régulier. Elle sert à préserver les références ÉLYSIA, pas à remplacer les
+outils filesystem.
 
-Une future proposition de mutation exige un ADR séparé, des capacités positives
-granulaires, des préconditions de hash attendu, un plan et un apply explicite,
-l’idempotence, un remplacement atomique, un journal, une sauvegarde, une preuve
-après écriture, des tests de crash et un rollback démontré.
+### Ajouter l’identité stable à côté du lien cliquable
+
+```md
+- [Ouvrir le brief](file:///B:/Documents/Projet/brief%20final.docx) — `external-ref:project.documents::brief%20final.docx`
+```
+
+Le lien reste cliquable. Le code inline adjacent porte l’identifiant logique et
+le chemin relatif à la racine, encodé canoniquement en pourcentage. `/` sépare
+les segments encodés. Le token n’expose pas le chemin configuré de la racine et
+n’autorise aucun accès par lui-même.
+
+Seule une paire exacte token/lien dans le même paragraphe Markdown actif peut
+être réparée automatiquement. Chemins physiques nus, tokens incohérents ou
+orphelins, candidats multiples, syntaxe non supportée et sections
+d’historique/exemple/archive/release passent en revue manuelle. Une seule
+occurrence en revue manuelle bloque l’apply.
+
+### Activer explicitement le pilote
+
+Conserver les exemples ordinaires ci-dessus en lecture seule. Pour une racine
+pilote non sensible, ajouter volontairement `move` :
+
+```json
+"capabilities": ["visible", "readable", "handoff", "move"]
+```
+
+Puis configurer le processus stdio local :
+
+```text
+MCP_WRITE_MODE=full
+MCP_EXTERNAL_MOVE_ENABLED=true
+MCP_EXTERNAL_MOVE_JOURNAL_PATH=<chemin-sqlite-local-absolu-optionnel>
+```
+
+Les trois autorisations sont nécessaires pour l’apply et le rollback : mode
+write complet, feature flag et capacité `move` de la racine. Scan, plan et
+status ne déplacent pas le fichier, mais restent stdio-only car le proxy possède
+la racine locale et le journal.
+
+### Exécuter la transaction
+
+1. Appeler `external_references_scan` avec `rootId`, `relativePath` et un
+   `searchInPath` relatif au coffre, optionnel.
+2. Appeler `external_move_plan` avec `sourceRelativePath`,
+   `targetRelativePath`, `searchInPath` et une `idempotencyKey` unique.
+3. Examiner `external_move_status` ; ne poursuivre que si `readyToApply` vaut
+   true et `manualReview` est vide.
+4. Appeler `external_move_apply` avec le `planId` retourné et la même
+   `idempotencyKey`.
+5. Vérifier cible et notes réparées. Si le résultat vérifié doit être annulé,
+   appeler `external_move_rollback` avec les mêmes identifiants avant de modifier
+   le fichier ou les notes réparées.
+
+Le dossier parent cible doit déjà exister. Source et cible doivent être des
+fichiers réguliers dans la même racine logique et sur le même volume ; la cible
+doit être absente. L’apply revérifie taille, date de modification et SHA-256 de
+la source. Il emploie une séquence hard-link/unlink sans écrasement et échoue
+fermé si le filesystem ne peut pas prouver le move.
+
+Chaque réparation de note est planifiée avec un SHA-256 attendu. En Obsidian
+live, l’écriture utilise la version Local REST API et `If-Match` de Markdown
+Patch 2.x ; une édition concurrente provoque un conflit, jamais un écrasement.
+Le journal SQLite local persiste l’état du plan et les préimages des notes pour
+la compensation. Le traiter comme une donnée locale sensible : ne jamais le
+committer ni le partager.
+
+Le HTTP direct refuse scan, plan, status, apply et rollback. Les tickets HTTP
+restent des handoffs en lecture seule.
+
+Il n’existe toujours aucun upload, create, replace, déplacement de dossier,
+move entre racines/volumes, overwrite, delete, corbeille ou sync external-root.
 
 Les stockages cloud, synchronisés, mappés ou montés n’héritent pas des garanties
 de mutation du filesystem local. SharePoint, Google Drive, OneDrive et services
@@ -394,6 +470,8 @@ Erreurs fréquentes :
 | `capability_denied`      | La racine déclare la capacité exigée ; le mode ticket HTTP est activé et utilise une vraie authentification.    |
 | `path_not_allowed`       | Le chemin relatif correspond à `include` et pas à `exclude`.                                                    |
 | `path_link_unsupported`  | Retirer les symlinks ou jonctions du chemin demandé.                                                            |
+| `target_exists`          | Choisir une cible absente ; l’overwrite n’est jamais autorisé.                                                  |
+| `precondition_failed`    | Refaire scan et plan après modification de source, note ou état de plan.                                        |
 | `too_large`              | Limites de racine et budget agrégé du handoff local ou HTTP.                                                    |
 | `unsupported`            | Employer un texte UTF-8 avec `external_read`, ou un mode de handoff supporté pour le binaire.                   |
 | Ticket HTTP indisponible | Vérifier feature flag, auth, identité bearer, TTL, usage unique et redémarrage du service.                      |
@@ -402,3 +480,6 @@ Erreurs fréquentes :
 
 Le serveur ne déduit jamais une nouvelle racine à partir d’un chemin trouvé dans
 une note Obsidian.
+Désactiver le move sans affecter les lectures en passant
+`MCP_EXTERNAL_MOVE_ENABLED=false` ou en retirant `move` de la racine, puis en
+redémarrant le processus stdio.

--- a/docs/external-roots-setup.md
+++ b/docs/external-roots-setup.md
@@ -6,14 +6,17 @@ External document roots let an MCP client discover and read explicitly allowed
 files that remain outside the Obsidian vault. Typical examples are PDFs, Office
 documents, datasets, project folders, and application-managed libraries.
 
-This feature is a read-only broker, not a second vault:
+This feature is primarily a read broker, not a second vault or a general file
+manager:
 
 - the MCP authorizes logical root IDs and confines every request to one root;
 - it can list, stat, hash, and read bounded UTF-8 text;
 - `external_handoff` can prepare one verified snapshot for a client that owns the
   appropriate PDF, Office, OCR, or binary tooling;
-- it does not index, synchronize, move, rename, write, or back up external
-  documents.
+- one separately gated local-stdio workflow can move a regular file inside the
+  same root and repair exact ÉLYSIA references;
+- it does not index, synchronize, upload, create, replace, delete, or back up
+  external documents.
 
 Handoff delivery depends on the transport:
 
@@ -24,6 +27,8 @@ Handoff delivery depends on the transport:
 
 See [ADR — External document roots](adr/ADR-External-Document-Roots.md) and
 [ADR — Governed HTTP delivery for external artifacts](adr/ADR-HTTP-External-Artifact-Delivery.md).
+The move/repair boundary is owned by
+[ADR — External reference integrity](adr/ADR-External-Reference-Integrity.md).
 
 ## 1. Create a machine-local configuration
 
@@ -91,14 +96,14 @@ The top-level object is strict:
 
 Each root is also strict:
 
-| Field          | Contract                                                                                                                        |
-| -------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `id`           | Stable lowercase logical ID: letters, digits, `.`, `_`, and `-`.                                                                |
-| `path`         | Absolute directory. UNC-prefixed paths are rejected; mapped or mounted network storage is not detected and remains unsupported. |
-| `capabilities` | One or more of `visible`, `readable`, `handoff`. `handoff` requires `readable`.                                                 |
-| `include`      | Git-style glob allowlist. Default: `["**"]`. A file that matches no include pattern is denied, including extensionless files.   |
-| `exclude`      | Git-style glob denylist. Default: `.git` and `node_modules`. Exclude wins over include.                                         |
-| `limits`       | Optional bounded limits described below. Unknown fields are rejected.                                                           |
+| Field          | Contract                                                                                                                         |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `id`           | Stable lowercase logical ID: letters, digits, `.`, `_`, and `-`.                                                                 |
+| `path`         | Absolute directory. UNC-prefixed paths are rejected; mapped or mounted network storage is not detected and remains unsupported.  |
+| `capabilities` | One or more of `visible`, `readable`, `handoff`, `move`. `handoff` requires `readable`; `move` is an independent positive grant. |
+| `include`      | Git-style glob allowlist. Default: `["**"]`. A file that matches no include pattern is denied, including extensionless files.    |
+| `exclude`      | Git-style glob denylist. Default: `.git` and `node_modules`. Exclude wins over include.                                          |
+| `limits`       | Optional bounded limits described below. Unknown fields are rejected.                                                            |
 
 Capabilities are independent:
 
@@ -108,6 +113,8 @@ Capabilities are independent:
 - `readable` permits hashing and direct UTF-8 reads;
 - `handoff` permits one verified snapshot through a delivery mode supported by
   the active transport.
+- `move` permits planning one same-root regular-file move. Apply and rollback
+  still require the two process-level write gates and local stdio.
 
 Limit defaults and schema ceilings:
 
@@ -346,15 +353,82 @@ ticket is swept without delivery.
 Portable provenance is the logical root ID, root-relative path, size,
 modification time, and SHA-256, not a local path or ticket.
 
-## 8. Mutations remain out of scope
+## 8. Governed local move and reference repair
 
-The current `external_roots` surface has no upload, create, replace, move, delete,
-or sync operation.
+The only external-root mutation is a local stdio transaction for one regular
+file. It is designed to preserve ÉLYSIA references, not to replace filesystem
+tools.
 
-A future mutation proposal requires a separate ADR, granular positive
-capabilities, expected-hash preconditions, plan and explicit apply calls,
-idempotency, atomic replacement, journal, backup, post-write proof, crash tests,
-and rollback evidence.
+### Add the stable identity next to the clickable link
+
+```md
+- [Open the brief](file:///B:/Documents/Project/brief%20final.docx) — `external-ref:project.documents::brief%20final.docx`
+```
+
+The link remains clickable. The adjacent inline-code token carries the logical
+root ID and the canonically percent-encoded root-relative path. `/` separates
+encoded path segments. The token neither exposes the configured root path nor
+authorizes access by itself.
+
+Only an exact token/link pair in the same active Markdown paragraph can be
+repaired automatically. Bare physical paths, mismatched or orphan tokens,
+multiple candidates, unsupported syntax and historical/example/archive/release
+sections are classified for manual review. One manual-review occurrence blocks
+apply.
+
+### Enable the pilot explicitly
+
+Keep the ordinary examples above read-only. For one non-sensitive pilot root,
+add `move` deliberately:
+
+```json
+"capabilities": ["visible", "readable", "handoff", "move"]
+```
+
+Then configure the local stdio process:
+
+```text
+MCP_WRITE_MODE=full
+MCP_EXTERNAL_MOVE_ENABLED=true
+MCP_EXTERNAL_MOVE_JOURNAL_PATH=<optional-absolute-local-sqlite-path>
+```
+
+All three grants are required for apply and rollback: full write mode, the
+feature flag and the root `move` capability. Scan, plan and status do not move
+the file, but remain stdio-only because the proxy owns the local root and
+journal.
+
+### Use the transaction
+
+1. Call `external_references_scan` with `rootId`, `relativePath` and an optional
+   vault-relative `searchInPath`.
+2. Call `external_move_plan` with `sourceRelativePath`,
+   `targetRelativePath`, `searchInPath` and a unique `idempotencyKey`.
+3. Inspect `external_move_status`; proceed only when `readyToApply` is true and
+   `manualReview` is empty.
+4. Call `external_move_apply` with the returned `planId` and the same
+   `idempotencyKey`.
+5. Verify the target and repaired notes. If the verified result must be undone,
+   call `external_move_rollback` with the same identifiers before changing the
+   file or repaired notes.
+
+The target parent must already exist. Source and target must be regular-file
+paths in the same logical root and filesystem volume, and the target must be
+absent. Apply revalidates the source size, modification time and SHA-256. It
+uses a no-clobber hard-link/unlink sequence and fails closed when the filesystem
+cannot prove the move.
+
+Each note repair is planned with an expected SHA-256. Live Obsidian writes use
+the Local REST API document version and Markdown Patch 2.x `If-Match`; a
+concurrent edit produces a conflict rather than an overwrite. The machine-local
+SQLite journal persists plan state and note preimages for compensation. Treat
+that journal as sensitive local data and never commit or share it.
+
+Direct HTTP refuses scan, plan, status, apply and rollback. HTTP tickets remain
+read-only handoffs.
+
+There is still no external-root upload, create, replace, directory move,
+cross-root/cross-volume move, overwrite, delete, trash or sync operation.
 
 Cloud, synchronized, mapped, or mounted network storage does not inherit local
 filesystem mutation guarantees. SharePoint, Google Drive, OneDrive and similar
@@ -383,6 +457,8 @@ Common failures:
 | `capability_denied`     | The root declares the required capability; HTTP ticket mode is enabled and uses real auth.              |
 | `path_not_allowed`      | The relative file path matches `include` and does not match `exclude`.                                  |
 | `path_link_unsupported` | Remove symlinks or junctions from the requested path.                                                   |
+| `target_exists`         | Choose an absent target; overwrite is never allowed.                                                    |
+| `precondition_failed`   | Re-scan and create a new plan after a source, note or plan-state change.                                |
 | `too_large`             | Root limits plus the local or HTTP aggregate handoff budget.                                            |
 | `unsupported`           | Use UTF-8 text for `external_read`, or a supported handoff mode for binary content.                     |
 | HTTP ticket unavailable | Check feature flag, auth mode, bearer identity, TTL, one-use semantics, and service restart.            |
@@ -390,3 +466,5 @@ Common failures:
 | Remote client failure   | Verify TLS proxy, Origin allowlist, auth metadata, forwarding trust, firewall and client compatibility. |
 
 The server never infers a new root from a path found in an Obsidian note.
+Disable move without affecting reads by setting `MCP_EXTERNAL_MOVE_ENABLED=false`
+or removing `move` from the root, then restarting the stdio process.

--- a/docs/external-roots-setup.md
+++ b/docs/external-roots-setup.md
@@ -390,20 +390,27 @@ Then configure the local stdio process:
 ```text
 MCP_WRITE_MODE=full
 MCP_EXTERNAL_MOVE_ENABLED=true
+MCP_EXTERNAL_MOVE_PROFILE_ID=<stable-lowercase-vault-profile-id>
 MCP_EXTERNAL_MOVE_JOURNAL_PATH=<optional-absolute-local-sqlite-path>
 ```
 
-All three grants are required for apply and rollback: full write mode, the
-feature flag and the root `move` capability. Scan, plan and status do not move
-the file, but remain stdio-only because the proxy owns the local root and
+The profile ID is required when the live backend cannot prove a configured
+vault path. It is hashed into the backend/vault/root binding and must change
+when the selected vault changes. The journal filename is automatically
+namespaced by that binding.
+
+All three write grants are required for apply and rollback: full write mode,
+the feature flag and the root `move` capability. Scan, plan and status do not
+move the file, but remain stdio-only because the proxy owns the local root and
 journal.
 
 ### Use the transaction
 
-1. Call `external_references_scan` with `rootId`, `relativePath` and an optional
-   vault-relative `searchInPath`.
+1. Call `external_references_scan` with `rootId` and `relativePath`. The scan
+   inventories the whole governed vault.
 2. Call `external_move_plan` with `sourceRelativePath`,
-   `targetRelativePath`, `searchInPath` and a unique `idempotencyKey`.
+   `targetRelativePath` and a unique `idempotencyKey`. Planning always
+   inventories the whole governed vault; it cannot be narrowed to a subfolder.
 3. Inspect `external_move_status`; proceed only when `readyToApply` is true and
    `manualReview` is empty.
 4. Call `external_move_apply` with the returned `planId` and the same
@@ -418,11 +425,13 @@ absent. Apply revalidates the source size, modification time and SHA-256. It
 uses a no-clobber hard-link/unlink sequence and fails closed when the filesystem
 cannot prove the move.
 
-Each note repair is planned with an expected SHA-256. Live Obsidian writes use
-the Local REST API document version and Markdown Patch 2.x `If-Match`; a
-concurrent edit produces a conflict rather than an overwrite. The machine-local
-SQLite journal persists plan state and note preimages for compensation. Treat
-that journal as sensitive local data and never commit or share it.
+Each note repair is planned with an expected SHA-256. Apply and rollback are
+currently restricted to `headless-filesystem` on a copied or dedicated vault,
+where that hash is enforced by the filesystem writer. Local REST API 4.1.7
+returns an ETag but does not enforce `If-Match` on whole-note writes, so live
+apply fails closed before moving the external file. The machine-local SQLite
+journal persists plan state and note preimages for compensation. Treat that
+journal as sensitive local data and never commit or share it.
 
 Direct HTTP refuses scan, plan, status, apply and rollback. HTTP tickets remain
 read-only handoffs.

--- a/docs/mcp-routing-guide.fr.md
+++ b/docs/mcp-routing-guide.fr.md
@@ -81,9 +81,11 @@ Pour un move gouverné par ÉLYSIA :
 Cette transaction est réservée au stdio local. Elle accepte un fichier régulier,
 une cible absente dans un dossier parent existant, et un move sans écrasement
 dans la même racine et sur le même volume. Les éditions concurrentes de notes
-sont protégées par SHA-256 et, en mode live, par `If-Match` de la Local REST API.
-Ne pas router create, replace, upload, delete, sync, dossier, cross-root ou
-cross-volume dans ce workflow.
+sont protégées par une précondition SHA-256 exacte en `headless-filesystem` sur
+une copie ou un coffre dédié. L’apply live via Local REST échoue fermé, car les
+remplacements de note complète n’imposent pas encore `If-Match`. Ne pas router
+create, replace, upload, delete, sync, dossier, cross-root ou cross-volume dans
+ce workflow.
 
 Toute opération external-root en HTTP direct exige `external:read`. Le HTTP
 distant reste pilote derrière un proxy TLS et des contrôles réseau revus.

--- a/docs/mcp-routing-guide.fr.md
+++ b/docs/mcp-routing-guide.fr.md
@@ -16,6 +16,7 @@ Ce guide aide les agents à choisir la bonne couche pour travailler avec Obsidia
 | -------------------------------------------------------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------- |
 | Lire, lister, rechercher, Tasks, recherche sémantique                      | Optimike MCP                                                    | Surface stable entre live, hybrid et headless.                                    |
 | Lire un document explicitement configuré hors du coffre                    | Outils external-roots du MCP                                    | Confinement default-deny avec chemins logiques portables.                         |
+| Déplacer un fichier externe sans casser silencieusement ses liens ÉLYSIA   | Workflow de move externe en stdio local                         | Inventaire, plan durable, réparations CAS exactes, reçu et rollback.              |
 | Comportement Obsidian complet, commandes, active file, Bases via plugin    | Optimike MCP en `live` ou `hybrid` avec Obsidian Desktop ouvert | C'est le seul mode avec sémantique Desktop/plugin.                                |
 | Serveur backend sûr au-dessus d'un vault synchronisé                       | Optimike MCP en `headless-readonly` d'abord                     | Pas besoin de Desktop et aucun risque d'écriture.                                 |
 | Écritures Markdown/frontmatter/tags/admin bornées sur copie ou vault dédié | Optimike MCP en `headless-filesystem`                           | Sécurité de chemins, dry-run par défaut et préconditions.                         |
@@ -63,8 +64,31 @@ Workflow agent :
 5. Conserver comme provenance l’identifiant logique, le chemin relatif, la
    taille et le SHA-256. Ne jamais persister le chemin temporaire ni le ticket.
 
+Pour un move gouverné par ÉLYSIA :
+
+1. vérifier que le lien `file:///` cliquable possède l’identité canonique
+   adjacente `external-ref:<rootId>::<chemin-relatif-encode-en-pourcentage>` ;
+2. employer `external_references_scan`, puis `external_move_plan` ;
+3. s’arrêter si `manualReview` n’est pas vide ; ne jamais réparer
+   automatiquement une occurrence legacy ou ambiguë ;
+4. examiner `external_move_status`, puis appeler `external_move_apply`
+   uniquement avec les gates write locaux explicites et la même clé
+   d’idempotence ;
+5. vérifier le fichier cible et les notes réparées ; employer
+   `external_move_rollback` seulement tant que ses préconditions persistées
+   tiennent encore.
+
+Cette transaction est réservée au stdio local. Elle accepte un fichier régulier,
+une cible absente dans un dossier parent existant, et un move sans écrasement
+dans la même racine et sur le même volume. Les éditions concurrentes de notes
+sont protégées par SHA-256 et, en mode live, par `If-Match` de la Local REST API.
+Ne pas router create, replace, upload, delete, sync, dossier, cross-root ou
+cross-volume dans ce workflow.
+
 Toute opération external-root en HTTP direct exige `external:read`. Le HTTP
 distant reste pilote derrière un proxy TLS et des contrôles réseau revus.
+Le HTTP direct refuse scan de références, plan/status de move, apply et
+rollback ; un ticket d’artefact autorise uniquement le téléchargement.
 
 Ne pas promettre l’extraction au seul motif que le handoff fonctionne :
 l’extraction dépend du client appelant. Ne pas copier silencieusement le contenu

--- a/docs/mcp-routing-guide.md
+++ b/docs/mcp-routing-guide.md
@@ -15,7 +15,7 @@ This guide helps agents choose the right layer for Obsidian work.
 | ---------------------------------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | Read, list, search, tasks, semantic search                                   | Optimike MCP                                                  | Stable tool surface across live, hybrid, and headless modes.            |
 | Read an explicitly configured document outside the vault                     | Optimike MCP external-root tools                              | Default-deny confinement with portable logical paths.                   |
-| Move one external file without silently breaking ÉLYSIA links                | Local stdio external move workflow                            | Inventory, durable plan, exact CAS repairs, receipt and rollback.       |
+| Move one external file without silently breaking ÉLYSIA links                | Local stdio on a copied or dedicated vault                    | Inventory, durable plan, exact hash repairs, receipt and rollback.      |
 | Full Obsidian behavior, commands, active file, plugin-backed Bases           | Optimike MCP in `live` or `hybrid` with Obsidian Desktop open | This is the only mode with Desktop/plugin-backed semantics.             |
 | Safe backend server over a synced vault                                      | Optimike MCP in `headless-readonly` first                     | No Desktop required and no write risk.                                  |
 | Bounded Markdown/frontmatter/tag/admin writes on a copied or dedicated vault | Optimike MCP in `headless-filesystem`                         | Path safety, dry-run defaults, and preconditions.                       |
@@ -76,9 +76,11 @@ For an ÉLYSIA-managed move:
 
 This transaction is local stdio only. It supports one regular file, an absent
 target in an existing parent, and a same-root/same-volume no-clobber move.
-Concurrent note edits are protected by SHA-256 and, in live mode, Local REST
-API `If-Match`. Do not route create, replace, upload, delete, sync, directory,
-cross-root or cross-volume operations through this workflow.
+Concurrent note edits are protected by an exact SHA-256 precondition in
+`headless-filesystem` on a copied or dedicated vault. Live Local REST apply
+fails closed because whole-note writes do not currently enforce `If-Match`.
+Do not route create, replace, upload, delete, sync, directory, cross-root or
+cross-volume operations through this workflow.
 
 Every direct HTTP external-root operation requires `external:read`. Remote HTTP
 remains pilot-only behind reviewed TLS proxy and network controls.

--- a/docs/mcp-routing-guide.md
+++ b/docs/mcp-routing-guide.md
@@ -15,6 +15,7 @@ This guide helps agents choose the right layer for Obsidian work.
 | ---------------------------------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------- |
 | Read, list, search, tasks, semantic search                                   | Optimike MCP                                                  | Stable tool surface across live, hybrid, and headless modes.            |
 | Read an explicitly configured document outside the vault                     | Optimike MCP external-root tools                              | Default-deny confinement with portable logical paths.                   |
+| Move one external file without silently breaking ÉLYSIA links                | Local stdio external move workflow                            | Inventory, durable plan, exact CAS repairs, receipt and rollback.       |
 | Full Obsidian behavior, commands, active file, plugin-backed Bases           | Optimike MCP in `live` or `hybrid` with Obsidian Desktop open | This is the only mode with Desktop/plugin-backed semantics.             |
 | Safe backend server over a synced vault                                      | Optimike MCP in `headless-readonly` first                     | No Desktop required and no write risk.                                  |
 | Bounded Markdown/frontmatter/tag/admin writes on a copied or dedicated vault | Optimike MCP in `headless-filesystem`                         | Path safety, dry-run defaults, and preconditions.                       |
@@ -61,8 +62,28 @@ Agent workflow:
 5. Preserve the logical root ID, relative path, size and SHA-256 as provenance.
    Never persist a temporary path or ticket.
 
+For an ÉLYSIA-managed move:
+
+1. ensure the clickable `file:///` link has an adjacent canonical identity:
+   `external-ref:<rootId>::<percent-encoded-relative-path>`;
+2. use `external_references_scan`, then `external_move_plan`;
+3. stop when `manualReview` is non-empty; never repair a legacy or ambiguous
+   occurrence automatically;
+4. inspect `external_move_status`, then call `external_move_apply` only with
+   explicit local write gates and the same idempotency key;
+5. verify both the target file and repaired notes; use
+   `external_move_rollback` only while its stored preconditions still hold.
+
+This transaction is local stdio only. It supports one regular file, an absent
+target in an existing parent, and a same-root/same-volume no-clobber move.
+Concurrent note edits are protected by SHA-256 and, in live mode, Local REST
+API `If-Match`. Do not route create, replace, upload, delete, sync, directory,
+cross-root or cross-volume operations through this workflow.
+
 Every direct HTTP external-root operation requires `external:read`. Remote HTTP
 remains pilot-only behind reviewed TLS proxy and network controls.
+Direct HTTP rejects external reference scan, move plan/status, apply and
+rollback; an artifact ticket authorizes download only.
 
 Do not promise extraction merely because handoff succeeds: extraction depends
 on the calling client. Do not silently copy external content into the vault,

--- a/docs/obsidian_mcp_tools_spec.md
+++ b/docs/obsidian_mcp_tools_spec.md
@@ -140,6 +140,15 @@ machine-local JSON configuration.
   supported by the active transport:
   - `local_path` for a local stdio client sharing the server filesystem;
   - optional `http_ticket` for an authenticated direct HTTP client.
+- `external_references_scan`: stdio-only inventory of exact, ambiguous and
+  historical ÉLYSIA references to one external file.
+- `external_move_plan`: persist a verified same-root regular-file move plan and
+  exact note repairs.
+- `external_move_status`: return the durable, redacted plan receipt.
+- `external_move_apply`: execute an eligible plan and its conditional note
+  repairs.
+- `external_move_rollback`: restore an applied move and its note repairs while
+  every stored precondition still holds.
 
 The core MCP does not parse PDF or Office files. Handoff requires both
 `readable` and `handoff`. HTTP ticket delivery is disabled by default and must be
@@ -150,13 +159,21 @@ discloses the physical source or temporary path. Issuance requires the
 `external:read` scope.
 
 Every external-root tool invoked through direct HTTP requires
-`external:read`. Local stdio keeps its process-local trust model.
+`external:read`. Local stdio keeps its process-local trust model. Direct HTTP
+explicitly refuses the five reference-integrity operations.
 
-Neither handoff mode authorizes upload, create, replace, move, delete, or sync.
-The client owns binary extraction and must verify the returned size and SHA-256.
+Neither handoff mode authorizes mutation. Local move apply and rollback instead
+require `MCP_WRITE_MODE=full`, `MCP_EXTERNAL_MOVE_ENABLED=true`, a root carrying
+`move`, an unambiguous canonical `file:///` plus
+`external-ref:<rootId>::<encoded-relative-path>` pair, and unchanged source and
+note preconditions. There is no upload, create, replace, directory/cross-root
+move, overwrite, delete or sync. The client owns binary extraction and must
+verify the returned size and SHA-256.
 See [External document roots — setup and operations](external-roots-setup.md),
 [ADR — External document roots](adr/ADR-External-Document-Roots.md), and
-[ADR — Governed HTTP delivery](adr/ADR-HTTP-External-Artifact-Delivery.md).
+[ADR — Governed HTTP delivery](adr/ADR-HTTP-External-Artifact-Delivery.md). The
+move contract is defined in
+[ADR — External reference integrity](adr/ADR-External-Reference-Integrity.md).
 
 ## Filesystem Admin
 

--- a/docs/runtime-capability-matrix.fr.md
+++ b/docs/runtime-capability-matrix.fr.md
@@ -119,6 +119,8 @@ du mode runtime :
   `external-ref:<rootId>::<chemin-relatif-encode-en-pourcentage>`. Toute
   occurrence ambiguë, historique ou non supportée bloque l’apply.
 - Le move externe emploie une séquence hard-link/unlink sans écrasement sur le
-  même volume et des écritures conditionnelles de notes. Le live utilise
-  `If-Match` de la Local REST API.
+  même volume et des écritures de notes préconditionnées par hash exact en
+  `headless-filesystem`, sur une copie ou un coffre dédié. L’apply live échoue
+  fermé tant que Local REST ne fournit pas d’écriture atomique conditionnelle
+  de note complète.
 - Une validation d’écriture headless doit créer un nouveau brouillon dans un dossier sandbox. Elle ne doit pas modifier des notes existantes d’un vrai vault.

--- a/docs/runtime-capability-matrix.fr.md
+++ b/docs/runtime-capability-matrix.fr.md
@@ -30,6 +30,8 @@ Optimike Obsidian MCP possède cinq contrats runtime. Les modes headless tournen
 | Recherche sémantique Smart Connections | Si `.smart-env` existe    | Si `.smart-env` existe                   | Si `.smart-env` existe    | Si `.smart-env` existe          | Si `.smart-env` existe              | Si `.smart-env` existe                                                     |
 | Status/maintenance runtime             | Oui                       | Oui                                      | Oui                       | Oui                             | Oui                                 | Oui                                                                        |
 | Racines documentaires externes         | Config locale optionnelle | Config locale optionnelle                | Config locale optionnelle | Config locale optionnelle       | Config locale optionnelle           | Config locale optionnelle                                                  |
+| Scan/plan des références externes      | Stdio local               | Stdio local                              | Stdio local               | Stdio local                     | Stdio local                         | Stdio local                                                                |
+| Apply/rollback de move externe         | Stdio + trois opt-ins     | Stdio + API + trois opt-ins              | Non                       | Non                             | Stdio + override `full` explicite   | Stdio + override `full` explicite                                          |
 | Validation de format                   | Markdown/Base/Canvas      | Markdown/Base/Canvas                     | Markdown/Base/Canvas      | Markdown/Base/Canvas            | Markdown/Base/Canvas                | Markdown/Base/Canvas                                                       |
 | Update note                            | Outil REST complet        | Outil REST complet                       | Non                       | Non                             | Append/prepend seulement            | Append/prepend seulement                                                   |
 | Search/replace                         | Outil REST complet        | Outil REST complet                       | Non                       | Non                             | Remplacements exacts par `filePath` | Remplacements exacts par `filePath`                                        |
@@ -47,9 +49,17 @@ Optimike Obsidian MCP possède cinq contrats runtime. Les modes headless tournen
 ## Registre des tools par mode
 
 Tous les modes enregistrent aussi `external_runtime_status`,
-`external_roots_list`, `external_list`, `external_stat`, `external_read` et
-`external_handoff`. Sans `MCP_EXTERNAL_ROOTS_FILE`, le statut reste désactivé et
-les opérations échouent fermées.
+`external_roots_list`, `external_list`, `external_stat`, `external_read`,
+`external_handoff`, `external_references_scan`, `external_move_plan`,
+`external_move_status`, `external_move_apply` et `external_move_rollback`. Sans
+`MCP_EXTERNAL_ROOTS_FILE`, le statut reste désactivé et les opérations échouent
+fermées.
+
+Le serveur HTTP direct enregistre les cinq noms d’intégrité uniquement pour
+retourner un refus stdio-only explicite. Le proxy stdio local les implémente.
+Scan, plan et status sont read-only. Apply et rollback exigent en plus
+`MCP_WRITE_MODE=full`, `MCP_EXTERNAL_MOVE_ENABLED=true`, la capacité `move` de
+la racine et un backend qui expose `obsidian_search_replace` conditionnel.
 
 Tous les modes enregistrent aussi les 13 outils du contrat Operon :
 `operon_status`, `operon_get_configuration`, `operon_list_tasks`,
@@ -70,8 +80,11 @@ du mode runtime :
   les racines externes exige `external:read` ;
 - le ticket HTTP reste en lecture seule, expurgé de tout chemin physique, borné,
   à usage unique et désactivé par défaut ;
-- aucun mode runtime ne gagne d’upload, create, replace, move, delete ou sync sur
-  une racine externe grâce à ce profil de livraison.
+- aucun mode runtime ne gagne d’upload, create, replace, delete ou sync sur une
+  racine externe grâce à ce profil de livraison ;
+- le contrat de move stdio local séparé porte un fichier régulier dans la même
+  racine, une cible absente, la réparation exacte des références ÉLYSIA et le
+  rollback.
 
 | Mode runtime                     | Tools enregistrées                                                                                                                                                                                                                                                                                                                                                  |
 | -------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -100,5 +113,12 @@ du mode runtime :
 - Le `/healthz` public est limité à la vie du service et ne divulgue aucun chemin ; l’état détaillé du runtime et de l’intégrité reste derrière l’outil MCP authentifié.
 - Un profil HTTP distant reste un pilote derrière des contrôles TLS, auth, proxy et réseau revus. L’exposition publique directe n’est pas supportée.
 - Les tickets HTTP d’artefacts exigent une vraie identité authentifiée avec
-  `external:read` et n’autorisent jamais une mutation de racine externe.
+  `external:read` et n’autorisent jamais une mutation de racine externe. Le HTTP
+  direct refuse aussi scan de références, plan/status de move, apply et rollback.
+- La réparation automatique exige le token adjacent exact
+  `external-ref:<rootId>::<chemin-relatif-encode-en-pourcentage>`. Toute
+  occurrence ambiguë, historique ou non supportée bloque l’apply.
+- Le move externe emploie une séquence hard-link/unlink sans écrasement sur le
+  même volume et des écritures conditionnelles de notes. Le live utilise
+  `If-Match` de la Local REST API.
 - Une validation d’écriture headless doit créer un nouveau brouillon dans un dossier sandbox. Elle ne doit pas modifier des notes existantes d’un vrai vault.

--- a/docs/runtime-capability-matrix.md
+++ b/docs/runtime-capability-matrix.md
@@ -117,5 +117,7 @@ Handoff delivery is a transport contract, not a runtime-mode write capability:
   `external-ref:<rootId>::<percent-encoded-relative-path>` token. Any ambiguous,
   historical or unsupported occurrence blocks apply.
 - External move uses a no-clobber same-volume hard-link/unlink sequence and
-  conditional note writes. Live writes use Local REST API `If-Match`.
+  exact-hash note writes in `headless-filesystem` on a copied or dedicated
+  vault. Live apply fails closed until Local REST provides atomic conditional
+  whole-note writes.
 - Headless write validation should create a new draft file in a sandbox folder. It should not edit existing notes in a real vault.

--- a/docs/runtime-capability-matrix.md
+++ b/docs/runtime-capability-matrix.md
@@ -30,6 +30,8 @@ Optimike Obsidian MCP has five runtime contracts. Headless modes run over a sync
 | Smart semantic search            | If `.smart-env` exists | If `.smart-env` exists                  | If `.smart-env` exists   | If `.smart-env` exists  | If `.smart-env` exists           | If `.smart-env` exists                                                   |
 | Runtime status/maintenance       | Yes                    | Yes                                     | Yes                      | Yes                     | Yes                              | Yes                                                                      |
 | External document roots          | Optional local config  | Optional local config                   | Optional local config    | Optional local config   | Optional local config            | Optional local config                                                    |
+| External reference scan/plan     | Local stdio            | Local stdio                             | Local stdio              | Local stdio             | Local stdio                      | Local stdio                                                              |
+| External move apply/rollback     | Stdio + three opt-ins  | Stdio + API + three opt-ins             | No                       | No                      | Stdio + explicit `full` override | Stdio + explicit `full` override                                         |
 | Format validation                | Markdown/Base/Canvas   | Markdown/Base/Canvas                    | Markdown/Base/Canvas     | Markdown/Base/Canvas    | Markdown/Base/Canvas             | Markdown/Base/Canvas                                                     |
 | Update note                      | REST full tool         | REST full tool                          | No                       | No                      | Append/prepend only              | Append/prepend only                                                      |
 | Search/replace                   | REST full tool         | REST full tool                          | No                       | No                      | Exact filePath replacements only | Exact filePath replacements only                                         |
@@ -47,9 +49,18 @@ Optimike Obsidian MCP has five runtime contracts. Headless modes run over a sync
 ## Tool Registry By Mode
 
 Every mode also registers `external_runtime_status`, `external_roots_list`,
-`external_list`, `external_stat`, `external_read`, and `external_handoff`.
+`external_list`, `external_stat`, `external_read`, `external_handoff`,
+`external_references_scan`, `external_move_plan`, `external_move_status`,
+`external_move_apply`, and `external_move_rollback`.
 Without `MCP_EXTERNAL_ROOTS_FILE`, status remains disabled and operations fail
 closed.
+
+The direct HTTP server registers the five reference-integrity names only to
+return an explicit stdio-only denial. The local stdio proxy implements them.
+Scan, plan and status are read-only. Apply and rollback additionally require
+`MCP_WRITE_MODE=full`, `MCP_EXTERNAL_MOVE_ENABLED=true`, the root `move`
+capability, and a backend mode that exposes conditional
+`obsidian_search_replace`.
 
 Every mode also registers the 13 Operon contract tools:
 `operon_status`, `operon_get_configuration`, `operon_list_tasks`,
@@ -68,8 +79,10 @@ Handoff delivery is a transport contract, not a runtime-mode write capability:
   operation requires `external:read`;
 - HTTP ticket delivery remains read-only, path-redacted, bounded, single-use and
   disabled by default;
-- no runtime mode gains external-root upload, create, replace, move, delete or
-  sync from this delivery profile.
+- no runtime mode gains external-root upload, create, replace, delete or sync
+  from this delivery profile;
+- the separate local-stdio move contract is one same-root regular file with an
+  absent target, exact ÉLYSIA reference repair and rollback.
 
 | Runtime mode                    | Tools registered                                                                                                                                                                                                                                                                                                                                                  |
 | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -98,5 +111,11 @@ Handoff delivery is a transport contract, not a runtime-mode write capability:
 - Public `/healthz` is liveness-only and path-free; detailed runtime and integrity state remains behind the authenticated MCP tool.
 - A remote HTTP profile is pilot-only behind reviewed TLS, authentication, proxy and network controls. Direct public exposure is not supported.
 - HTTP artifact tickets require a real authenticated identity with
-  `external:read` and never authorize external-root mutation.
+  `external:read` and never authorize external-root mutation. Direct HTTP also
+  refuses reference scan, move plan/status, apply and rollback.
+- Automatic external-link repair requires an exact adjacent
+  `external-ref:<rootId>::<percent-encoded-relative-path>` token. Any ambiguous,
+  historical or unsupported occurrence blocks apply.
+- External move uses a no-clobber same-volume hard-link/unlink sequence and
+  conditional note writes. Live writes use Local REST API `If-Match`.
 - Headless write validation should create a new draft file in a sandbox folder. It should not edit existing notes in a real vault.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optimike-obsidian-mcp",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optimike-obsidian-mcp",
-      "version": "2.3.0",
+      "version": "2.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.12",
@@ -22,6 +22,9 @@
         "jose": "^6.0.11",
         "js-yaml": "^4.1.0",
         "json5": "^2.2.3",
+        "mdast-util-from-markdown": "^2.0.3",
+        "mdast-util-gfm": "^3.1.0",
+        "micromark-extension-gfm": "^3.0.0",
         "openai": "^5.6.0",
         "partial-json": "^0.1.7",
         "sanitize-html": "^2.17.0",
@@ -1476,6 +1479,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -1491,6 +1503,21 @@
       "resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.9.tgz",
       "integrity": "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
     "node_modules/@types/node": {
@@ -1522,7 +1549,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/validator": {
@@ -1800,6 +1826,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1828,6 +1864,16 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chrono-node": {
@@ -2136,6 +2182,19 @@
         }
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deepmerge": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -2206,12 +2265,34 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/diff": {
       "version": "4.0.4",
@@ -3200,6 +3281,16 @@
         "node": ">= 12.0.0"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3265,6 +3356,16 @@
         "markdown-it": "bin/markdown-it.mjs"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -3272,6 +3373,207 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/mdurl": {
@@ -3301,6 +3603,569 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/mime-db": {
       "version": "1.54.0",
@@ -4629,6 +5494,61 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -4928,6 +5848,16 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.25.28 || ^4"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optimike-obsidian-mcp",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Unified Obsidian MCP server with shared local cache, Operon and Tasks tools, Bases support, semantic search, runtime observability, and degraded read mode for durable agent workflows.",
   "main": "dist/index.js",
   "files": [
@@ -26,6 +26,8 @@
     "docs/external-roots-setup.fr.md",
     "docs/adr/ADR-External-Document-Roots.md",
     "docs/adr/ADR-HTTP-External-Artifact-Delivery.md",
+    "docs/adr/ADR-External-Reference-Integrity.md",
+    "docs/adr/ADR-External-Reference-Integrity.fr.md",
     "docs/adr/ADR-Operon-Bridge.md",
     "docs/adr/README.md",
     "docs/operon-decision-report.md",
@@ -100,7 +102,7 @@
     "smoke:operon-rich-mutations": "node scripts/smoke-operon-rich-mutations.mjs",
     "test:profiles": "node scripts/test-elysia-task-profile.mjs",
     "test:tool-annotations": "node scripts/test-tool-annotations.mjs",
-    "test:external-roots": "npm run build && node scripts/test-external-roots.mjs && node scripts/test-stdio-proxy-external-roots.mjs && node scripts/test-http-external-handoff.mjs",
+    "test:external-roots": "npm run build && node scripts/test-external-reference-parser.mjs && node scripts/test-external-move-integrity.mjs && node scripts/test-obsidian-cas.mjs && node scripts/test-obsidian-search-replace-cas.mjs && node scripts/test-external-roots.mjs && node scripts/test-stdio-proxy-external-roots.mjs && node scripts/test-http-external-handoff.mjs",
     "test:external-roots:proxy": "npm run build && node scripts/test-stdio-proxy-external-roots.mjs",
     "test:http-external-handoff": "npm run build && node scripts/test-http-external-handoff.mjs",
     "smoke:external-roots": "npm run build && node scripts/smoke-external-roots.mjs",
@@ -108,7 +110,10 @@
     "test:migrations:windows": "pwsh -NoProfile -File scripts/test-task-engine-migrations.ps1",
     "test:package": "node scripts/test-package-contents.mjs",
     "test:docs": "node scripts/test-doc-contract.mjs",
-    "test:launchers": "npm run build && node scripts/test-launchers.mjs"
+    "test:launchers": "npm run build && node scripts/test-launchers.mjs",
+    "test:external-reference-parser": "node scripts/test-external-reference-parser.mjs",
+    "test:obsidian-cas": "node scripts/test-obsidian-cas.mjs && node scripts/test-obsidian-search-replace-cas.mjs",
+    "test:external-move": "node scripts/test-external-move-integrity.mjs"
   },
   "dependencies": {
     "@hono/node-server": "^2.0.12",
@@ -124,6 +129,9 @@
     "jose": "^6.0.11",
     "js-yaml": "^4.1.0",
     "json5": "^2.2.3",
+    "mdast-util-from-markdown": "^2.0.3",
+    "mdast-util-gfm": "^3.1.0",
+    "micromark-extension-gfm": "^3.0.0",
     "openai": "^5.6.0",
     "partial-json": "^0.1.7",
     "sanitize-html": "^2.17.0",

--- a/scripts/fixtures/external-references/active.md
+++ b/scripts/fixtures/external-references/active.md
@@ -1,0 +1,13 @@
+---
+example: "`external-ref:pilot.docs::frontmatter.txt`"
+---
+
+# Active references
+
+- [Pilot brief](file:///C:/Pilot/brief%20final.md) — `external-ref:pilot.docs::brief%20final.md`
+- [Legacy sheet](file:///C:/Pilot/legacy.xlsx)
+- `external-ref:pilot.docs::orphan.txt`
+- [Wrong file](file:///C:/Pilot/other.txt) — `external-ref:pilot.docs::expected.txt`
+- [Bad URI](file://server/share/report.pdf) — `external-ref:pilot.docs::report.pdf`
+- [Two A](file:///C:/Pilot/a.txt) and [Two B](file:///C:/Pilot/b.txt) — `external-ref:pilot.docs::a.txt`
+- [Invalid token](file:///C:/Pilot/report.pdf) — `external-ref:PILOT::report.pdf`

--- a/scripts/fixtures/external-references/excluded.md
+++ b/scripts/fixtures/external-references/excluded.md
@@ -22,6 +22,10 @@
 
 - [Release](file:///C:/Pilot/release.txt) — `external-ref:pilot.docs::release.txt`
 
+## Archives
+
+- [Archived](file:///C:/Pilot/archived.txt) — `external-ref:pilot.docs::archived.txt`
+
 ## Current again
 
 - [Live](file:///C:/Pilot/live.txt) — `external-ref:pilot.docs::live.txt`

--- a/scripts/fixtures/external-references/excluded.md
+++ b/scripts/fixtures/external-references/excluded.md
@@ -1,0 +1,27 @@
+# Current
+
+```md
+[Fenced](file:///C:/Pilot/fenced.txt) `external-ref:pilot.docs::fenced.txt`
+```
+
+<!-- [Commented](file:///C:/Pilot/commented.txt) `external-ref:pilot.docs::commented.txt` -->
+
+## Historique
+
+- [Old](file:///C:/Pilot/old.txt) — `external-ref:pilot.docs::old.txt`
+
+### Nested history
+
+- [Still old](file:///C:/Pilot/still-old.txt) — `external-ref:pilot.docs::still-old.txt`
+
+## Examples
+
+- [Sample](file:///C:/Pilot/sample.txt) — `external-ref:pilot.docs::sample.txt`
+
+## Changelog
+
+- [Release](file:///C:/Pilot/release.txt) — `external-ref:pilot.docs::release.txt`
+
+## Current again
+
+- [Live](file:///C:/Pilot/live.txt) — `external-ref:pilot.docs::live.txt`

--- a/scripts/run-external-move-pilot.mjs
+++ b/scripts/run-external-move-pilot.mjs
@@ -1,0 +1,224 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { access, readFile } from "node:fs/promises";
+import { createServer } from "node:net";
+import path from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const required = [
+  "PILOT_VAULT",
+  "PILOT_ROOTS_FILE",
+  "PILOT_ROOT_ID",
+  "PILOT_SOURCE",
+  "PILOT_TARGET",
+  "PILOT_NOTE",
+  "PILOT_JOURNAL",
+  "PILOT_PROFILE_ID",
+];
+for (const name of required) {
+  if (!process.env[name]) throw new Error(`Missing required ${name}.`);
+}
+const runtimeMode = process.env.PILOT_RUNTIME_MODE ?? "headless-filesystem";
+if (runtimeMode !== "headless-filesystem") {
+  throw new Error(
+    "The external-move pilot requires headless-filesystem on a copied or dedicated vault.",
+  );
+}
+
+function jsonOf(result) {
+  const text =
+    result.content?.map((item) => item.text ?? "").join("\n") ?? "{}";
+  if (result.isError) throw new Error(text);
+  return JSON.parse(text);
+}
+
+async function unusedPort() {
+  const server = createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  await new Promise((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  return address.port;
+}
+
+async function waitForHealth(url, child, processText) {
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(
+        `HTTP backend exited with code ${child.exitCode}: ${processText()}`,
+      );
+    }
+    try {
+      const response = await fetch(url);
+      if (response.ok) return;
+    } catch {
+      // Backend is still starting.
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+  }
+  throw new Error(`Timed out waiting for ${url}.`);
+}
+
+async function exists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+const vault = path.resolve(process.env.PILOT_VAULT);
+const rootsFile = path.resolve(process.env.PILOT_ROOTS_FILE);
+const notePath = process.env.PILOT_NOTE.replaceAll("\\", "/");
+const rootConfig = JSON.parse(await readFile(rootsFile, "utf8"));
+const root = rootConfig.roots.find(
+  (candidate) => candidate.id === process.env.PILOT_ROOT_ID,
+);
+if (!root) throw new Error("Pilot rootId is absent from the roots file.");
+const rootPath = path.resolve(root.path);
+const sourcePath = path.join(rootPath, process.env.PILOT_SOURCE);
+const targetPath = path.join(rootPath, process.env.PILOT_TARGET);
+assert.equal(await exists(sourcePath), true, "Pilot source must exist.");
+assert.equal(await exists(targetPath), false, "Pilot target must be absent.");
+
+const port = await unusedPort();
+const commonEnv = {
+  ...process.env,
+  OBSIDIAN_RUNTIME_MODE: runtimeMode,
+  OBSIDIAN_VAULT: vault,
+  OBSIDIAN_API_KEY: "",
+  OBSIDIAN_CACHE_SOURCE: "filesystem",
+  OBSIDIAN_ENABLE_CACHE: "true",
+  OBSIDIAN_SHARED_CACHE_DB_PATH:
+    process.env.PILOT_CACHE ??
+    `${path.resolve(process.env.PILOT_JOURNAL)}.cache.sqlite`,
+  OBSIDIAN_STARTUP_BLOCKING: "false",
+  MCP_WRITE_MODE: "full",
+  MCP_EXTERNAL_MOVE_ENABLED: "true",
+  MCP_EXTERNAL_ROOTS_FILE: rootsFile,
+  MCP_EXTERNAL_MOVE_JOURNAL_PATH: path.resolve(process.env.PILOT_JOURNAL),
+  MCP_EXTERNAL_MOVE_PROFILE_ID: process.env.PILOT_PROFILE_ID,
+  MCP_TRANSPORT_TYPE: "http",
+  MCP_HTTP_HOST: "127.0.0.1",
+  MCP_HTTP_PORT: String(port),
+  MCP_LOG_LEVEL: "error",
+  LOGS_DIR: path.join(process.cwd(), "logs", "pilot-runtime"),
+  SEMANTIC_SEARCH_PREWARM: "false",
+};
+const backend = spawn(process.execPath, ["dist/index.js"], {
+  cwd: process.cwd(),
+  env: commonEnv,
+  stdio: ["ignore", "pipe", "pipe"],
+});
+let backendOutput = "";
+backend.stdout?.on("data", (chunk) => {
+  backendOutput += String(chunk);
+});
+backend.stderr?.on("data", (chunk) => {
+  backendOutput += String(chunk);
+});
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: ["dist/stdio-proxy.js"],
+  cwd: process.cwd(),
+  env: { ...commonEnv, MCP_PROXY_START_TIMEOUT_MS: "20000" },
+});
+const client = new Client({
+  name: "optimike-external-move-real-pilot",
+  version: "1",
+});
+
+try {
+  await waitForHealth(
+    `http://127.0.0.1:${port}/healthz`,
+    backend,
+    () => backendOutput,
+  );
+  await client.connect(transport);
+  const key = `pilot-${Date.now()}`;
+  const scan = jsonOf(
+    await client.callTool({
+      name: "external_references_scan",
+      arguments: {
+        rootId: process.env.PILOT_ROOT_ID,
+        relativePath: process.env.PILOT_SOURCE,
+      },
+    }),
+  );
+  const plan = jsonOf(
+    await client.callTool({
+      name: "external_move_plan",
+      arguments: {
+        rootId: process.env.PILOT_ROOT_ID,
+        sourceRelativePath: process.env.PILOT_SOURCE,
+        targetRelativePath: process.env.PILOT_TARGET,
+        idempotencyKey: key,
+      },
+    }),
+  );
+  assert.equal(
+    plan.readyToApply,
+    true,
+    `Pilot plan was not ready: ${JSON.stringify(plan)}`,
+  );
+  assert.equal(
+    plan.manualReview.length,
+    0,
+    `Pilot plan requires manual review: ${JSON.stringify(plan.manualReview)}`,
+  );
+  assert.ok(
+    plan.repairs.some(
+      (repair) => repair.filePath.replace(/^\/+/u, "") === notePath,
+    ),
+  );
+
+  const applied = jsonOf(
+    await client.callTool({
+      name: "external_move_apply",
+      arguments: { planId: plan.planId, idempotencyKey: key },
+    }),
+  );
+  assert.equal(applied.status, "applied");
+  assert.equal(await exists(sourcePath), false);
+  assert.equal(await exists(targetPath), true);
+
+  const rolledBack = jsonOf(
+    await client.callTool({
+      name: "external_move_rollback",
+      arguments: { planId: plan.planId, idempotencyKey: key },
+    }),
+  );
+  assert.equal(rolledBack.status, "rolled_back");
+  assert.equal(await exists(sourcePath), true);
+  assert.equal(await exists(targetPath), false);
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        planId: plan.planId,
+        sourceSha256: plan.sourceSha256,
+        inventoryDigest: plan.inventoryDigest,
+        bindingFingerprint: plan.bindingFingerprint,
+        scanReparable: scan.reparable?.length ?? 0,
+        repairedNotes: plan.repairs.length,
+        finalStatus: rolledBack.status,
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  await client.close().catch(() => undefined);
+  backend.kill();
+}

--- a/scripts/smoke-external-move-pilot.mjs
+++ b/scripts/smoke-external-move-pilot.mjs
@@ -1,0 +1,123 @@
+import assert from "node:assert/strict";
+import { createHash, randomUUID } from "node:crypto";
+import { readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+const required = [
+  "MCP_EXTERNAL_ROOTS_FILE",
+  "MCP_EXTERNAL_MOVE_PILOT_NOTE",
+  "MCP_EXTERNAL_MOVE_PILOT_ROOT_ID",
+  "MCP_EXTERNAL_MOVE_PILOT_SOURCE",
+  "MCP_EXTERNAL_MOVE_PILOT_TARGET",
+  "MCP_EXTERNAL_MOVE_JOURNAL_PATH",
+];
+for (const name of required) {
+  assert.ok(process.env[name], `${name} is required`);
+}
+process.env.MCP_WRITE_MODE = "full";
+process.env.MCP_EXTERNAL_MOVE_ENABLED = "true";
+process.env.OBSIDIAN_RUNTIME_MODE = "headless-filesystem";
+process.env.OBSIDIAN_VAULT ??= path.dirname(
+  process.env.MCP_EXTERNAL_MOVE_PILOT_NOTE,
+);
+
+const [
+  { ExternalRootsService },
+  { ExternalMoveCoordinator },
+  { ExternalMoveJournal },
+  { sha256Text },
+] = await Promise.all([
+  import("../dist/services/externalRootsService.js"),
+  import("../dist/services/externalReferences/externalMoveCoordinator.js"),
+  import("../dist/services/externalReferences/externalMoveJournal.js"),
+  import("../dist/services/externalReferences/backendVaultAdapter.js"),
+]);
+
+const notePath = path.resolve(process.env.MCP_EXTERNAL_MOVE_PILOT_NOTE);
+assert.equal(path.extname(notePath).toLowerCase(), ".md");
+const initialNote = await readFile(notePath, "utf8");
+
+const directVault = {
+  async searchPaths(query) {
+    const content = await readFile(notePath, "utf8");
+    return content.includes(query) ? [path.basename(notePath)] : [];
+  },
+  async read(filePath) {
+    assert.equal(filePath, path.basename(notePath));
+    const content = await readFile(notePath, "utf8");
+    return { filePath, content, sha256: sha256Text(content) };
+  },
+  async conditionalReplace(filePath, before, after, expectedSha256) {
+    assert.equal(filePath, path.basename(notePath));
+    const current = await readFile(notePath, "utf8");
+    assert.equal(sha256Text(current), expectedSha256);
+    assert.equal(current, before);
+    const temporary = `${notePath}.${randomUUID()}.tmp`;
+    await writeFile(temporary, after, { encoding: "utf8", flag: "wx" });
+    await rename(temporary, notePath);
+  },
+};
+
+const roots = await ExternalRootsService.fromConfigFile(
+  process.env.MCP_EXTERNAL_ROOTS_FILE,
+);
+const coordinator = new ExternalMoveCoordinator(
+  roots,
+  directVault,
+  new ExternalMoveJournal(process.env.MCP_EXTERNAL_MOVE_JOURNAL_PATH),
+);
+if (process.env.MCP_EXTERNAL_MOVE_PILOT_RECOVER_PLAN_ID) {
+  const recovered = await coordinator.rollback(
+    process.env.MCP_EXTERNAL_MOVE_PILOT_RECOVER_PLAN_ID,
+    process.env.MCP_EXTERNAL_MOVE_PILOT_RECOVER_IDEMPOTENCY_KEY,
+  );
+  assert.equal(recovered.status, "rolled_back");
+  const recoveredNote = await readFile(notePath, "utf8");
+  assert.ok(
+    recoveredNote.includes(
+      `external-ref:${process.env.MCP_EXTERNAL_MOVE_PILOT_ROOT_ID}::${process.env.MCP_EXTERNAL_MOVE_PILOT_SOURCE}`,
+    ),
+  );
+  console.log(
+    JSON.stringify({ ok: true, recovery: true, ...recovered }, null, 2),
+  );
+  process.exit(0);
+}
+const idempotencyKey = `pilot-${randomUUID()}`;
+const plan = await coordinator.plan({
+  rootId: process.env.MCP_EXTERNAL_MOVE_PILOT_ROOT_ID,
+  sourceRelativePath: process.env.MCP_EXTERNAL_MOVE_PILOT_SOURCE,
+  targetRelativePath: process.env.MCP_EXTERNAL_MOVE_PILOT_TARGET,
+  idempotencyKey,
+});
+assert.equal(plan.readyToApply, true);
+assert.deepEqual(plan.manualReview, []);
+assert.equal(plan.repairs.length, 1);
+
+const applied = await coordinator.apply(plan.planId, idempotencyKey);
+assert.equal(applied.status, "applied");
+const repairedNote = await readFile(notePath, "utf8");
+assert.ok(
+  repairedNote.includes(
+    `external-ref:${process.env.MCP_EXTERNAL_MOVE_PILOT_ROOT_ID}::${process.env.MCP_EXTERNAL_MOVE_PILOT_TARGET}`,
+  ),
+);
+
+const rolledBack = await coordinator.rollback(plan.planId, idempotencyKey);
+assert.equal(rolledBack.status, "rolled_back");
+assert.equal(await readFile(notePath, "utf8"), initialNote);
+
+console.log(
+  JSON.stringify(
+    {
+      ok: true,
+      status: rolledBack.status,
+      planId: plan.planId,
+      sourceSha256: plan.sourceSha256,
+      repairedNotes: plan.repairs.length,
+      manualReview: plan.manualReview.length,
+    },
+    null,
+    2,
+  ),
+);

--- a/scripts/test-external-move-integrity.mjs
+++ b/scripts/test-external-move-integrity.mjs
@@ -107,12 +107,15 @@ class FakeVault {
     }
   }
 
-  async searchPaths(query, searchInPath = "") {
+  async searchPaths(query, searchInPath = "", caseSensitive = true) {
+    const normalizedQuery = caseSensitive ? query : query.toLowerCase();
     return [...this.notes.entries()]
       .filter(
         ([filePath, content]) =>
           (!searchInPath || filePath.startsWith(searchInPath)) &&
-          content.includes(query),
+          (caseSensitive ? content : content.toLowerCase()).includes(
+            normalizedQuery,
+          ),
       )
       .map(([filePath]) => filePath)
       .sort((left, right) => left.localeCompare(right));
@@ -527,6 +530,29 @@ try {
   assert.equal(await readFile(recoverySource, "utf8"), "recovery");
   assert.equal(await exists(recoveryTarget), false);
   assert.equal(recoveryVault.notes.get(recoveryNotePath), recoveryNote);
+
+  // Legacy physical paths are inventoried case-insensitively and block apply.
+  const legacyCaseSource = path.join(rootPath, "legacy-case.txt");
+  await writeFile(legacyCaseSource, "legacy case", "utf8");
+  const legacyCaseVault = new FakeVault({
+    "Efforts/Projets/Legacy case.md":
+      `Legacy location: ${legacyCaseSource.toUpperCase()}\n`,
+  });
+  const legacyCaseCoordinator = new ExternalMoveCoordinator(
+    service,
+    legacyCaseVault,
+    new ExternalMoveJournal(":memory:"),
+  );
+  const legacyCasePlan = await legacyCaseCoordinator.plan({
+    rootId: "pilot.move",
+    sourceRelativePath: "legacy-case.txt",
+    targetRelativePath: "archive/legacy-case.txt",
+    idempotencyKey: "coordinator-legacy-case",
+  });
+  assert.equal(legacyCasePlan.readyToApply, false);
+  assert.equal(legacyCasePlan.repairs.length, 0);
+  assert.equal(legacyCasePlan.manualReview.length, 1);
+  assert.equal(await readFile(legacyCaseSource, "utf8"), "legacy case");
 
   // Historical and legacy references are inventoried, never auto-repaired.
   const manualSource = path.join(rootPath, "manual.txt");

--- a/scripts/test-external-move-integrity.mjs
+++ b/scripts/test-external-move-integrity.mjs
@@ -256,7 +256,11 @@ try {
     targetRelativePath: "archive/coordinated.txt",
     idempotencyKey: "coordinator-round-trip",
   });
-  assert.equal(coordinatedPlan.readyToApply, true);
+  assert.equal(
+    coordinatedPlan.readyToApply,
+    true,
+    JSON.stringify(coordinatedPlan),
+  );
   assert.equal(coordinatedPlan.repairs.length, 1);
   assert.equal(coordinatedPlan.manualReview.length, 0);
 

--- a/scripts/test-external-move-integrity.mjs
+++ b/scripts/test-external-move-integrity.mjs
@@ -83,6 +83,28 @@ function createRootService(
 class FakeVault {
   constructor(entries = {}) {
     this.notes = new Map(Object.entries(entries));
+    this.bindingFingerprint = "test-binding";
+    this.conditionalWritesSupported = true;
+  }
+
+  async getBindingIdentity() {
+    return {
+      schemaVersion: 1,
+      backendFingerprint: "test-backend",
+      vaultFingerprint: "test-vault",
+      rootConfigFingerprint: "test-roots",
+      bindingFingerprint: this.bindingFingerprint,
+      vaultIdentitySource: "explicit_profile",
+      verifiable: true,
+    };
+  }
+
+  async refreshInventory() {}
+
+  async assertConditionalWritesSupported() {
+    if (!this.conditionalWritesSupported) {
+      throw new Error("Conditional note writes are unavailable.");
+    }
   }
 
   async searchPaths(query, searchInPath = "") {
@@ -355,6 +377,156 @@ try {
   );
   assert.equal(await readFile(casSource, "utf8"), "CAS");
   assert.equal(await exists(casTarget), false);
+
+  // An unsupported vault writer is rejected before the external file moves.
+  const unsupportedSource = path.join(rootPath, "unsupported-writer.txt");
+  const unsupportedTarget = path.join(
+    archivePath,
+    "unsupported-writer.txt",
+  );
+  await writeFile(unsupportedSource, "unsupported writer", "utf8");
+  const unsupportedUri = pathToFileURL(unsupportedSource).href;
+  const unsupportedVault = new FakeVault({
+    "Efforts/Projets/Unsupported writer.md":
+      `[Unsupported](${unsupportedUri}) ` +
+      "`external-ref:pilot.move::unsupported-writer.txt`\n",
+  });
+  const unsupportedCoordinator = new ExternalMoveCoordinator(
+    service,
+    unsupportedVault,
+    new ExternalMoveJournal(":memory:"),
+  );
+  const unsupportedPlan = await unsupportedCoordinator.plan({
+    rootId: "pilot.move",
+    sourceRelativePath: "unsupported-writer.txt",
+    targetRelativePath: "archive/unsupported-writer.txt",
+    idempotencyKey: "coordinator-unsupported-writer",
+  });
+  unsupportedVault.conditionalWritesSupported = false;
+  await assert.rejects(
+    () =>
+      unsupportedCoordinator.apply(
+        unsupportedPlan.planId,
+        "coordinator-unsupported-writer",
+      ),
+    /Conditional note writes are unavailable/u,
+  );
+  assert.equal(
+    await readFile(unsupportedSource, "utf8"),
+    "unsupported writer",
+  );
+  assert.equal(await exists(unsupportedTarget), false);
+
+  // Apply rescans the complete vault. A new canonical reference created after
+  // planning invalidates the inventory before the external file is moved.
+  const inventorySource = path.join(rootPath, "inventory-change.txt");
+  const inventoryTarget = path.join(archivePath, "inventory-change.txt");
+  await writeFile(inventorySource, "inventory", "utf8");
+  const inventoryUri = pathToFileURL(inventorySource).href;
+  const inventoryVault = new FakeVault({
+    "Efforts/Projets/Inventory one.md":
+      `[Inventory](${inventoryUri}) ` +
+      "`external-ref:pilot.move::inventory-change.txt`\n",
+  });
+  const inventoryCoordinator = new ExternalMoveCoordinator(
+    service,
+    inventoryVault,
+    new ExternalMoveJournal(":memory:"),
+  );
+  const inventoryPlan = await inventoryCoordinator.plan({
+    rootId: "pilot.move",
+    sourceRelativePath: "inventory-change.txt",
+    targetRelativePath: "archive/inventory-change.txt",
+    idempotencyKey: "coordinator-inventory-change",
+  });
+  inventoryVault.notes.set(
+    "Efforts/Projets/Inventory two.md",
+    `[Inventory 2](${inventoryUri}) ` +
+      "`external-ref:pilot.move::inventory-change.txt`\n",
+  );
+  await expectExternalCode(
+    () =>
+      inventoryCoordinator.apply(
+        inventoryPlan.planId,
+        "coordinator-inventory-change",
+      ),
+    "precondition_failed",
+  );
+  assert.equal(await readFile(inventorySource, "utf8"), "inventory");
+  assert.equal(await exists(inventoryTarget), false);
+
+  // A plan is bound to one backend/vault/root profile and cannot be replayed
+  // after that binding changes.
+  const bindingSource = path.join(rootPath, "binding-change.txt");
+  const bindingTarget = path.join(archivePath, "binding-change.txt");
+  await writeFile(bindingSource, "binding", "utf8");
+  const bindingUri = pathToFileURL(bindingSource).href;
+  const bindingVault = new FakeVault({
+    "Efforts/Projets/Binding.md":
+      `[Binding](${bindingUri}) ` +
+      "`external-ref:pilot.move::binding-change.txt`\n",
+  });
+  const bindingCoordinator = new ExternalMoveCoordinator(
+    service,
+    bindingVault,
+    new ExternalMoveJournal(":memory:"),
+  );
+  const bindingPlan = await bindingCoordinator.plan({
+    rootId: "pilot.move",
+    sourceRelativePath: "binding-change.txt",
+    targetRelativePath: "archive/binding-change.txt",
+    idempotencyKey: "coordinator-binding-change",
+  });
+  bindingVault.bindingFingerprint = "different-binding";
+  await expectExternalCode(
+    () =>
+      bindingCoordinator.apply(
+        bindingPlan.planId,
+        "coordinator-binding-change",
+      ),
+    "precondition_failed",
+  );
+  assert.equal(await readFile(bindingSource, "utf8"), "binding");
+  assert.equal(await exists(bindingTarget), false);
+
+  // A process crash after the file move is recoverable from the durable
+  // intermediate journal state through the ordinary rollback tool.
+  const recoverySource = path.join(rootPath, "recovery.txt");
+  const recoveryTarget = path.join(archivePath, "recovery.txt");
+  await writeFile(recoverySource, "recovery", "utf8");
+  const recoveryUri = pathToFileURL(recoverySource).href;
+  const recoveryNotePath = "Efforts/Projets/Recovery.md";
+  const recoveryNote =
+    `[Recovery](${recoveryUri}) ` + "`external-ref:pilot.move::recovery.txt`\n";
+  const recoveryVault = new FakeVault({ [recoveryNotePath]: recoveryNote });
+  const recoveryJournal = new ExternalMoveJournal(":memory:");
+  const recoveryCoordinator = new ExternalMoveCoordinator(
+    service,
+    recoveryVault,
+    recoveryJournal,
+  );
+  const recoveryPlan = await recoveryCoordinator.plan({
+    rootId: "pilot.move",
+    sourceRelativePath: "recovery.txt",
+    targetRelativePath: "archive/recovery.txt",
+    idempotencyKey: "coordinator-recovery",
+  });
+  const recoveryStored = recoveryJournal.get(recoveryPlan.planId);
+  await service.applyMove(recoveryStored.snapshot);
+  recoveryJournal.transition(recoveryPlan.planId, ["planned"], "applying_file");
+  recoveryJournal.transition(
+    recoveryPlan.planId,
+    ["applying_file"],
+    "file_moved",
+  );
+  const recovered = await recoveryCoordinator.rollback(
+    recoveryPlan.planId,
+    "coordinator-recovery",
+  );
+  assert.equal(recovered.status, "rolled_back");
+  assert.equal(await readFile(recoverySource, "utf8"), "recovery");
+  assert.equal(await exists(recoveryTarget), false);
+  assert.equal(recoveryVault.notes.get(recoveryNotePath), recoveryNote);
 
   // Historical and legacy references are inventoried, never auto-repaired.
   const manualSource = path.join(rootPath, "manual.txt");

--- a/scripts/test-external-move-integrity.mjs
+++ b/scripts/test-external-move-integrity.mjs
@@ -1,0 +1,394 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+
+// The coordinator reads these gates when its config module is first imported.
+process.env.MCP_EXTERNAL_MOVE_ENABLED = "true";
+process.env.MCP_WRITE_MODE = "full";
+process.env.OBSIDIAN_RUNTIME_MODE = "headless-readonly";
+process.env.OBSIDIAN_VAULT = os.tmpdir();
+
+const { ExternalRootError, ExternalRootsService } = await import(
+  "../dist/services/externalRootsService.js"
+);
+const { ExternalMoveCoordinator } = await import(
+  "../dist/services/externalReferences/externalMoveCoordinator.js"
+);
+const { ExternalMoveJournal } = await import(
+  "../dist/services/externalReferences/externalMoveJournal.js"
+);
+
+const sandbox = await mkdtemp(
+  path.join(os.tmpdir(), "optimike-external-move-integrity-"),
+);
+
+function hashText(content) {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+async function exists(filePath) {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function expectExternalCode(operation, expectedCode) {
+  await assert.rejects(operation, (error) => {
+    assert.ok(
+      error instanceof ExternalRootError,
+      `Expected ExternalRootError, received ${error?.constructor?.name}`,
+    );
+    assert.equal(error.code, expectedCode);
+    return true;
+  });
+}
+
+function createRootService(
+  rootPath,
+  capabilities = ["visible", "readable", "move"],
+) {
+  return ExternalRootsService.fromConfig({
+    version: 1,
+    roots: [
+      {
+        id: "pilot.move",
+        path: rootPath,
+        capabilities,
+        include: ["**"],
+        exclude: [],
+        limits: {
+          maxDepth: 6,
+          maxFileBytes: 1024 * 1024,
+          maxListEntries: 100,
+          maxTextChars: 100_000,
+        },
+      },
+    ],
+  });
+}
+
+class FakeVault {
+  constructor(entries = {}) {
+    this.notes = new Map(Object.entries(entries));
+  }
+
+  async searchPaths(query, searchInPath = "") {
+    return [...this.notes.entries()]
+      .filter(
+        ([filePath, content]) =>
+          (!searchInPath || filePath.startsWith(searchInPath)) &&
+          content.includes(query),
+      )
+      .map(([filePath]) => filePath)
+      .sort((left, right) => left.localeCompare(right));
+  }
+
+  async read(filePath) {
+    const content = this.notes.get(filePath);
+    if (content === undefined)
+      throw new Error(`Missing fake note: ${filePath}`);
+    return { filePath, content, sha256: hashText(content) };
+  }
+
+  async conditionalReplace(filePath, before, after, expectedSha256) {
+    const current = await this.read(filePath);
+    if (current.sha256 !== expectedSha256 || current.content !== before) {
+      throw new ExternalRootError(
+        "precondition_failed",
+        `Fake vault CAS rejected ${filePath}.`,
+      );
+    }
+    this.notes.set(filePath, after);
+  }
+}
+
+try {
+  const rootPath = path.join(sandbox, "root");
+  const archivePath = path.join(rootPath, "archive");
+  await mkdir(archivePath, { recursive: true });
+
+  // The move capability is never inferred from readable/visible.
+  const noMoveService = createRootService(rootPath, ["visible", "readable"]);
+  const noMoveSource = path.join(rootPath, "no-move.txt");
+  await writeFile(noMoveSource, "no move", "utf8");
+  await expectExternalCode(
+    () =>
+      noMoveService.planMove(
+        "pilot.move",
+        "no-move.txt",
+        "archive/no-move.txt",
+      ),
+    "capability_denied",
+  );
+
+  const service = createRootService(rootPath);
+
+  // Planning refuses a missing parent and an occupied target.
+  const guardSource = path.join(rootPath, "guard.txt");
+  await writeFile(guardSource, "guard", "utf8");
+  await expectExternalCode(
+    () => service.planMove("pilot.move", "guard.txt", "missing/guard.txt"),
+    "not_a_directory",
+  );
+  const occupiedTarget = path.join(archivePath, "occupied.txt");
+  await writeFile(occupiedTarget, "occupied", "utf8");
+  await expectExternalCode(
+    () => service.planMove("pilot.move", "guard.txt", "archive/occupied.txt"),
+    "target_exists",
+  );
+
+  // A same-volume plan/apply/rollback preserves bytes and never overwrites.
+  const roundTripSource = path.join(rootPath, "round-trip.txt");
+  const roundTripTarget = path.join(archivePath, "round-trip.txt");
+  await writeFile(roundTripSource, "round trip", "utf8");
+  const roundTripPlan = await service.planMove(
+    "pilot.move",
+    "round-trip.txt",
+    "archive/round-trip.txt",
+  );
+  await service.applyMove(roundTripPlan);
+  assert.equal(await exists(roundTripSource), false);
+  assert.equal(await readFile(roundTripTarget, "utf8"), "round trip");
+  await service.rollbackMove(roundTripPlan);
+  assert.equal(await readFile(roundTripSource, "utf8"), "round trip");
+  assert.equal(await exists(roundTripTarget), false);
+
+  // A stale source invalidates the immutable plan before any link is created.
+  const staleSource = path.join(rootPath, "stale.txt");
+  const staleTarget = path.join(archivePath, "stale.txt");
+  await writeFile(staleSource, "version one", "utf8");
+  const stalePlan = await service.planMove(
+    "pilot.move",
+    "stale.txt",
+    "archive/stale.txt",
+  );
+  await writeFile(staleSource, "version two and different", "utf8");
+  await expectExternalCode(
+    () => service.applyMove(stalePlan),
+    "precondition_failed",
+  );
+  assert.equal(
+    await readFile(staleSource, "utf8"),
+    "version two and different",
+  );
+  assert.equal(await exists(staleTarget), false);
+
+  // Rollback refuses to destroy a target modified after the move.
+  const changedSource = path.join(rootPath, "changed-after-move.txt");
+  const changedTarget = path.join(archivePath, "changed-after-move.txt");
+  await writeFile(changedSource, "original", "utf8");
+  const changedPlan = await service.planMove(
+    "pilot.move",
+    "changed-after-move.txt",
+    "archive/changed-after-move.txt",
+  );
+  await service.applyMove(changedPlan);
+  await writeFile(changedTarget, "changed after move", "utf8");
+  await expectExternalCode(
+    () => service.rollbackMove(changedPlan),
+    "precondition_failed",
+  );
+  assert.equal(await exists(changedSource), false);
+  assert.equal(await readFile(changedTarget, "utf8"), "changed after move");
+
+  // Coordinator happy path: exact canonical pair, CAS repair, then rollback.
+  const coordinatedSource = path.join(rootPath, "coordinated.txt");
+  const coordinatedTarget = path.join(archivePath, "coordinated.txt");
+  await writeFile(coordinatedSource, "coordinated", "utf8");
+  const coordinatedSourceUri = pathToFileURL(coordinatedSource).href;
+  const coordinatedTargetUri = pathToFileURL(coordinatedTarget).href;
+  const notePath = "Efforts/Projets/Pilot.md";
+  const originalNote =
+    "---\n" +
+    "création: 2026-07-28T10:00\n" +
+    "modification: 2026-07-28T10:00\n" +
+    "type: projet\n" +
+    "---\n\n" +
+    `# Pilot\n\n- [Open](${coordinatedSourceUri}) — ` +
+    "`external-ref:pilot.move::coordinated.txt`\n";
+  const vault = new FakeVault({ [notePath]: originalNote });
+  const coordinator = new ExternalMoveCoordinator(
+    service,
+    vault,
+    new ExternalMoveJournal(":memory:"),
+  );
+  const coordinatedPlan = await coordinator.plan({
+    rootId: "pilot.move",
+    sourceRelativePath: "coordinated.txt",
+    targetRelativePath: "archive/coordinated.txt",
+    idempotencyKey: "coordinator-round-trip",
+  });
+  assert.equal(coordinatedPlan.readyToApply, true);
+  assert.equal(coordinatedPlan.repairs.length, 1);
+  assert.equal(coordinatedPlan.manualReview.length, 0);
+
+  const applied = await coordinator.apply(
+    coordinatedPlan.planId,
+    "coordinator-round-trip",
+  );
+  assert.equal(applied.status, "applied");
+  assert.equal(await exists(coordinatedSource), false);
+  assert.equal(await readFile(coordinatedTarget, "utf8"), "coordinated");
+  const repairedNote = vault.notes.get(notePath);
+  assert.ok(repairedNote.includes(coordinatedTargetUri));
+  assert.ok(
+    repairedNote.includes("`external-ref:pilot.move::archive/coordinated.txt`"),
+  );
+
+  // Runtime-maintained frontmatter may change after apply. Rollback must
+  // preserve those current values while reverting only the canonical pair.
+  const runtimeCreation = "création: 2026-07-28T10:03";
+  const runtimeModification = "modification: 2026-07-28T10:04";
+  vault.notes.set(
+    notePath,
+    repairedNote
+      .replace("création: 2026-07-28T10:00", runtimeCreation)
+      .replace("modification: 2026-07-28T10:00", runtimeModification),
+  );
+  const rolledBack = await coordinator.rollback(
+    coordinatedPlan.planId,
+    "coordinator-round-trip",
+  );
+  assert.equal(rolledBack.status, "rolled_back");
+  assert.equal(await readFile(coordinatedSource, "utf8"), "coordinated");
+  assert.equal(await exists(coordinatedTarget), false);
+  const expectedRuntimePreservingRollback = originalNote
+    .replace("création: 2026-07-28T10:00", runtimeCreation)
+    .replace("modification: 2026-07-28T10:00", runtimeModification);
+  assert.equal(vault.notes.get(notePath), expectedRuntimePreservingRollback);
+
+  // Any non-protected body edit after apply still blocks rollback.
+  const editedBodySource = path.join(rootPath, "edited-body.txt");
+  const editedBodyTarget = path.join(archivePath, "edited-body.txt");
+  await writeFile(editedBodySource, "edited body", "utf8");
+  const editedBodyUri = pathToFileURL(editedBodySource).href;
+  const editedBodyNotePath = "Efforts/Projets/Edited body.md";
+  const editedBodyVault = new FakeVault({
+    [editedBodyNotePath]:
+      "---\n" +
+      "création: 2026-07-28T11:00\n" +
+      "modification: 2026-07-28T11:00\n" +
+      "---\n\n" +
+      `[Body](${editedBodyUri}) ` +
+      "`external-ref:pilot.move::edited-body.txt`\n",
+  });
+  const editedBodyCoordinator = new ExternalMoveCoordinator(
+    service,
+    editedBodyVault,
+    new ExternalMoveJournal(":memory:"),
+  );
+  const editedBodyPlan = await editedBodyCoordinator.plan({
+    rootId: "pilot.move",
+    sourceRelativePath: "edited-body.txt",
+    targetRelativePath: "archive/edited-body.txt",
+    idempotencyKey: "coordinator-edited-body",
+  });
+  await editedBodyCoordinator.apply(
+    editedBodyPlan.planId,
+    "coordinator-edited-body",
+  );
+  editedBodyVault.notes.set(
+    editedBodyNotePath,
+    `${editedBodyVault.notes.get(editedBodyNotePath)}\nConcurrent body edit.\n`,
+  );
+  await expectExternalCode(
+    () =>
+      editedBodyCoordinator.rollback(
+        editedBodyPlan.planId,
+        "coordinator-edited-body",
+      ),
+    "precondition_failed",
+  );
+  assert.equal(await exists(editedBodySource), false);
+  assert.equal(await readFile(editedBodyTarget, "utf8"), "edited body");
+  assert.ok(
+    editedBodyVault.notes
+      .get(editedBodyNotePath)
+      .includes("Concurrent body edit."),
+  );
+  assert.equal(
+    editedBodyCoordinator.status(editedBodyPlan.planId).status,
+    "applied",
+  );
+
+  // A changed note fails the coordinator's CAS gate before the file move.
+  const casSource = path.join(rootPath, "cas-source.txt");
+  const casTarget = path.join(archivePath, "cas-source.txt");
+  await writeFile(casSource, "CAS", "utf8");
+  const casUri = pathToFileURL(casSource).href;
+  const casNotePath = "Efforts/Projets/CAS.md";
+  const casVault = new FakeVault({
+    [casNotePath]:
+      `[CAS](${casUri}) ` + "`external-ref:pilot.move::cas-source.txt`\n",
+  });
+  const casCoordinator = new ExternalMoveCoordinator(
+    service,
+    casVault,
+    new ExternalMoveJournal(":memory:"),
+  );
+  const casPlan = await casCoordinator.plan({
+    rootId: "pilot.move",
+    sourceRelativePath: "cas-source.txt",
+    targetRelativePath: "archive/cas-source.txt",
+    idempotencyKey: "coordinator-cas",
+  });
+  casVault.notes.set(
+    casNotePath,
+    `${casVault.notes.get(casNotePath)}\nConcurrent edit.\n`,
+  );
+  await expectExternalCode(
+    () => casCoordinator.apply(casPlan.planId, "coordinator-cas"),
+    "precondition_failed",
+  );
+  assert.equal(await readFile(casSource, "utf8"), "CAS");
+  assert.equal(await exists(casTarget), false);
+
+  // Historical and legacy references are inventoried, never auto-repaired.
+  const manualSource = path.join(rootPath, "manual.txt");
+  await writeFile(manualSource, "manual", "utf8");
+  const manualUri = pathToFileURL(manualSource).href;
+  const manualNotePath = "Efforts/Projets/Manual.md";
+  const manualVault = new FakeVault({
+    [manualNotePath]:
+      `## Historique\n\n[Old](${manualUri}) ` +
+      "`external-ref:pilot.move::manual.txt`\n",
+  });
+  const manualCoordinator = new ExternalMoveCoordinator(
+    service,
+    manualVault,
+    new ExternalMoveJournal(":memory:"),
+  );
+  const manualPlan = await manualCoordinator.plan({
+    rootId: "pilot.move",
+    sourceRelativePath: "manual.txt",
+    targetRelativePath: "archive/manual.txt",
+    idempotencyKey: "coordinator-manual-review",
+  });
+  assert.equal(manualPlan.readyToApply, false);
+  assert.equal(manualPlan.repairs.length, 0);
+  assert.equal(manualPlan.manualReview.length, 1);
+  await expectExternalCode(
+    () =>
+      manualCoordinator.apply(manualPlan.planId, "coordinator-manual-review"),
+    "precondition_failed",
+  );
+  assert.equal(await readFile(manualSource, "utf8"), "manual");
+  assert.equal(await exists(path.join(archivePath, "manual.txt")), false);
+
+  console.log("External move integrity tests passed.");
+} finally {
+  await rm(sandbox, { recursive: true, force: true });
+}

--- a/scripts/test-external-reference-parser.mjs
+++ b/scripts/test-external-reference-parser.mjs
@@ -112,7 +112,7 @@ const excluded = await readFile(
 const excludedResult = scanCanonicalExternalReferences(excluded);
 assert.equal(excludedResult.reparable.length, 1);
 assert.equal(excludedResult.manualReview.length, 0);
-assert.equal(excludedResult.ignored.length, 4);
+assert.equal(excludedResult.ignored.length, 5);
 assert.equal(
   excludedResult.occurrences.some((occurrence) =>
     excluded

--- a/scripts/test-external-reference-parser.mjs
+++ b/scripts/test-external-reference-parser.mjs
@@ -1,0 +1,195 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  applyCanonicalExternalReferenceRepair,
+  buildCanonicalExternalReferenceRepairEdits,
+  canonicalExternalReference,
+  encodeCanonicalExternalReference,
+  scanCanonicalExternalReferences,
+} from "../dist/services/externalReferences/index.js";
+
+const scriptDirectory = path.dirname(fileURLToPath(import.meta.url));
+const fixtureDirectory = path.join(
+  scriptDirectory,
+  "fixtures",
+  "external-references",
+);
+
+function assertExactRange(source, range, expected) {
+  assert.equal(
+    source.slice(range.start.offset, range.end.offset),
+    expected,
+    `Expected exact source range for ${expected}`,
+  );
+}
+
+const active = await readFile(path.join(fixtureDirectory, "active.md"), "utf8");
+const activeResult = scanCanonicalExternalReferences(active);
+
+assert.equal(activeResult.reparable.length, 1);
+assert.equal(activeResult.manualReview.length, 6);
+assert.equal(activeResult.ignored.length, 0);
+
+const canonical = activeResult.reparable[0];
+assert.equal(canonical.reason, "canonical_pair");
+assert.equal(canonical.token.rootId, "pilot.docs");
+assert.equal(canonical.token.relativePath, "brief final.md");
+assert.equal(canonical.token.encodedRelativePath, "brief%20final.md");
+assert.ok(
+  canonical.fileLink.localPath
+    .replaceAll("\\", "/")
+    .endsWith("Pilot/brief final.md"),
+);
+assertExactRange(
+  active,
+  canonical.token.range,
+  "`external-ref:pilot.docs::brief%20final.md`",
+);
+assertExactRange(
+  active,
+  canonical.fileLink.range,
+  "[Pilot brief](file:///C:/Pilot/brief%20final.md)",
+);
+assertExactRange(
+  active,
+  canonical.fileLink.destinationRange,
+  "file:///C:/Pilot/brief%20final.md",
+);
+assert.equal(canonical.containerRange.start.line, 7);
+assert.equal(canonical.containerRange.start.column, 3);
+
+assert.equal(
+  encodeCanonicalExternalReference("pilot.docs", "livrés/été final.md"),
+  "external-ref:pilot.docs::livr%C3%A9s/%C3%A9t%C3%A9%20final.md",
+);
+const repairTarget = {
+  rootId: "pilot.docs",
+  relativePath: "archive/brief livré.md",
+  fileUrl: "file:///C:/Pilot/archive/brief%20livr%C3%A9.md",
+};
+const edits = buildCanonicalExternalReferenceRepairEdits(
+  active,
+  canonical,
+  repairTarget,
+);
+assert.equal(edits.length, 2);
+assert.ok(edits[0].startOffset > edits[1].startOffset);
+const repaired = applyCanonicalExternalReferenceRepair(
+  active,
+  canonical,
+  repairTarget,
+);
+assert.ok(
+  repaired.includes(
+    "[Pilot brief](file:///C:/Pilot/archive/brief%20livr%C3%A9.md) — `external-ref:pilot.docs::archive/brief%20livr%C3%A9.md`",
+  ),
+);
+const repairedResult = scanCanonicalExternalReferences(repaired);
+assert.equal(repairedResult.reparable.length, 1);
+assert.equal(
+  repairedResult.reparable[0].token.relativePath,
+  "archive/brief livré.md",
+);
+
+assert.deepEqual(
+  activeResult.manualReview.map((occurrence) => occurrence.reason),
+  [
+    "missing_identity_token",
+    "missing_file_link",
+    "basename_mismatch",
+    "invalid_file_uri",
+    "multiple_file_links",
+    "invalid_token",
+  ],
+);
+
+const excluded = await readFile(
+  path.join(fixtureDirectory, "excluded.md"),
+  "utf8",
+);
+const excludedResult = scanCanonicalExternalReferences(excluded);
+assert.equal(excludedResult.reparable.length, 1);
+assert.equal(excludedResult.manualReview.length, 0);
+assert.equal(excludedResult.ignored.length, 4);
+assert.equal(
+  excludedResult.occurrences.some((occurrence) =>
+    excluded
+      .slice(
+        occurrence.containerRange.start.offset,
+        occurrence.containerRange.end.offset,
+      )
+      .includes("Fenced"),
+  ),
+  false,
+);
+assert.equal(
+  excludedResult.occurrences.some((occurrence) =>
+    excluded
+      .slice(
+        occurrence.containerRange.start.offset,
+        occurrence.containerRange.end.offset,
+      )
+      .includes("Commented"),
+  ),
+  false,
+);
+
+const unsafeTokens = [
+  "external-ref:pilot.docs::../secret.txt",
+  "external-ref:pilot.docs::%2e%2e/secret.txt",
+  "external-ref:pilot.docs::folder%2Fsecret.txt",
+  "external-ref:pilot.docs::folder%5Csecret.txt",
+  "external-ref:pilot.docs::folder\\secret.txt",
+  "external-ref:pilot.docs::nul%00byte.txt",
+  "external-ref:pilot.docs::bad%2.txt",
+  "external-ref:pilot.docs::caf%c3%a9.txt",
+  "external-ref:pilot.docs::",
+];
+for (const token of unsafeTokens) {
+  const source = `[Unsafe](file:///C:/Pilot/secret.txt) \`${token}\``;
+  const result = scanCanonicalExternalReferences(source);
+  assert.equal(result.reparable.length, 0, token);
+  assert.equal(result.manualReview.length, 1, token);
+  assert.equal(result.manualReview[0].reason, "invalid_token", token);
+}
+
+const unsafeUris = [
+  "file://server/share/report.pdf",
+  "file:////server/share/report.pdf",
+  "file:/C:/Pilot/report.pdf",
+  "file:///C:/Pilot/%2Freport.pdf",
+  "file:///C:/Pilot/%5Creport.pdf",
+  "file:///C:/Pilot/%00report.pdf",
+  "file:///C:/Pilot/../report.pdf",
+  "file:///C:/Pilot/report.pdf?download=1",
+  "file:///C:/Pilot/report.pdf#page=2",
+  "file:///C:/Pilot/folder/",
+];
+for (const uri of unsafeUris) {
+  const source = `[Unsafe](${uri}) \`external-ref:pilot.docs::report.pdf\``;
+  const result = scanCanonicalExternalReferences(source);
+  assert.equal(result.reparable.length, 0, uri);
+  assert.equal(result.manualReview.length, 1, uri);
+  assert.equal(result.manualReview[0].reason, "invalid_file_uri", uri);
+}
+
+const crlf =
+  "# Références\r\n\r\n- [Été](file:///C:/Pilot/%C3%A9t%C3%A9.txt) — `external-ref:pilot.docs::%C3%A9t%C3%A9.txt`\r\n";
+const crlfResult = scanCanonicalExternalReferences(crlf);
+assert.equal(crlfResult.reparable.length, 1);
+assert.equal(crlfResult.reparable[0].containerRange.start.line, 3);
+assertExactRange(
+  crlf,
+  crlfResult.reparable[0].token.range,
+  "`external-ref:pilot.docs::%C3%A9t%C3%A9.txt`",
+);
+
+assert.ok(canonicalExternalReference.rootIdPattern.test("pilot.docs"));
+assert.equal(
+  canonicalExternalReference.rootIdPattern.test("Pilot.Docs"),
+  false,
+);
+
+console.log("External reference parser tests passed.");

--- a/scripts/test-external-roots.mjs
+++ b/scripts/test-external-roots.mjs
@@ -278,12 +278,16 @@ try {
     },
   };
   await registerExternalRootsTools(fakeServer, service, false);
-  assert.equal(handlers.size, 6);
-  assert.ok(
-    [...annotations.values()].every(
-      (value) => value.readOnlyHint === true && value.destructiveHint === false,
-    ),
-  );
+  assert.equal(handlers.size, 11);
+  for (const [name, value] of annotations) {
+    if (name === "external_move_apply" || name === "external_move_rollback") {
+      assert.equal(value.readOnlyHint, false);
+      assert.equal(value.destructiveHint, true);
+    } else {
+      assert.equal(value.readOnlyHint, true);
+      assert.equal(value.destructiveHint, false);
+    }
+  }
   const deniedHttpHandoff = await handlers.get("external_handoff")({
     rootId: "pilot.docs",
     relativePath: "hello.txt",

--- a/scripts/test-obsidian-cas.mjs
+++ b/scripts/test-obsidian-cas.mjs
@@ -1,0 +1,163 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import path from "node:path";
+
+const logsRoot = path.join(process.cwd(), "logs");
+await mkdir(logsRoot, { recursive: true });
+const logsDir = await mkdtemp(path.join(logsRoot, "cas-test-"));
+process.env.OBSIDIAN_API_KEY = "test-only-api-key";
+process.env.OBSIDIAN_BASE_URL = "http://127.0.0.1:27123";
+process.env.MCP_LOG_LEVEL = "error";
+process.env.LOGS_DIR = logsDir;
+
+const { BaseErrorCode, McpError } = await import(
+  "../dist/types-global/errors.js"
+);
+const { getFileDocumentMap, replaceFileContentIfMatch, updateFileContent } =
+  await import("../dist/services/obsidianRestAPI/methods/vaultMethods.js");
+const { ObsidianRestApiService } = await import(
+  "../dist/services/obsidianRestAPI/service.js"
+);
+
+const context = {
+  requestId: "cas-test",
+  timestamp: new Date(0).toISOString(),
+  operation: "testObsidianCas",
+};
+
+try {
+  const requests = [];
+  const request = async (requestConfig, _context, operationName) => {
+    requests.push({ requestConfig, operationName });
+    if (operationName === "getFileDocumentMap") {
+      return {
+        headings: { Projet: {} },
+        blocks: [],
+        frontmatterFields: ["statut"],
+        version: "version-123",
+      };
+    }
+  };
+
+  const documentMap = await getFileDocumentMap(
+    request,
+    "Dossier riche/Note ÉLYSIA.md",
+    context,
+  );
+  assert.equal(documentMap.version, "version-123");
+  assert.deepEqual(requests[0], {
+    operationName: "getFileDocumentMap",
+    requestConfig: {
+      method: "GET",
+      url: "/vault/Dossier%20riche/Note%20%C3%89LYSIA.md",
+      headers: {
+        Accept: "application/vnd.olrapi.document-map+json",
+      },
+    },
+  });
+
+  await replaceFileContentIfMatch(
+    request,
+    "Dossier riche/Note ÉLYSIA.md",
+    "# Projet\n\nContenu réparé.\n",
+    '  "version-123"  ',
+    context,
+  );
+  assert.deepEqual(requests[1], {
+    operationName: "replaceFileContentIfMatch",
+    requestConfig: {
+      method: "PATCH",
+      url: "/vault/Dossier%20riche/Note%20%C3%89LYSIA.md",
+      headers: {
+        "Content-Type": "text/markdown",
+        Operation: "replace",
+        "If-Match": '"version-123"',
+      },
+      data: "# Projet\n\nContenu réparé.\n",
+    },
+  });
+
+  await assert.rejects(
+    () =>
+      replaceFileContentIfMatch(request, "Note.md", "# Note\n", "   ", context),
+    (error) =>
+      error instanceof McpError &&
+      error.code === BaseErrorCode.VALIDATION_ERROR,
+  );
+  await assert.rejects(
+    () =>
+      replaceFileContentIfMatch(request, "Note.md", "", "version-123", context),
+    (error) =>
+      error instanceof McpError &&
+      error.code === BaseErrorCode.VALIDATION_ERROR,
+  );
+
+  await assert.rejects(
+    () =>
+      getFileDocumentMap(
+        async () => ({
+          headings: {},
+          blocks: [],
+          frontmatterFields: [],
+        }),
+        "Legacy.md",
+        context,
+      ),
+    (error) =>
+      error instanceof McpError &&
+      error.code === BaseErrorCode.SERVICE_UNAVAILABLE,
+  );
+
+  const legacyRequests = [];
+  await updateFileContent(
+    async (requestConfig, _context, operationName) => {
+      legacyRequests.push({ requestConfig, operationName });
+    },
+    "Note.md",
+    "legacy behavior",
+    context,
+  );
+  assert.deepEqual(legacyRequests[0], {
+    operationName: "updateFileContent",
+    requestConfig: {
+      method: "PUT",
+      url: "/vault/Note.md",
+      headers: { "Content-Type": "text/markdown" },
+      data: "legacy behavior",
+    },
+  });
+
+  const service = new ObsidianRestApiService();
+  service.axiosInstance = {
+    request: async () => {
+      const error = new Error("Request failed with status code 412");
+      error.response = {
+        status: 412,
+        data: {
+          errorCode: 41200,
+          message: "Document version does not match",
+        },
+      };
+      throw error;
+    },
+  };
+
+  await assert.rejects(
+    () =>
+      service.replaceFileContentIfMatch(
+        "Note.md",
+        "# Concurrent edit\n",
+        "stale-version",
+        context,
+      ),
+    (error) =>
+      error instanceof McpError &&
+      error.code === BaseErrorCode.CONFLICT &&
+      error.message ===
+        "Obsidian API Precondition Failed: the note changed after it was read.",
+  );
+
+  console.log("Obsidian REST CAS tests passed.");
+} finally {
+  await rm(logsDir, { recursive: true, force: true });
+}

--- a/scripts/test-obsidian-cas.mjs
+++ b/scripts/test-obsidian-cas.mjs
@@ -4,7 +4,7 @@ import path from "node:path";
 
 const logsRoot = path.join(process.cwd(), "logs");
 await mkdir(logsRoot, { recursive: true });
-const logsDir = await mkdtemp(path.join(logsRoot, "cas-test-"));
+const logsDir = await mkdtemp(path.join(logsRoot, "live-write-boundary-test-"));
 process.env.OBSIDIAN_API_KEY = "test-only-api-key";
 process.env.OBSIDIAN_BASE_URL = "http://127.0.0.1:27123";
 process.env.MCP_LOG_LEVEL = "error";
@@ -13,117 +13,36 @@ process.env.LOGS_DIR = logsDir;
 const { BaseErrorCode, McpError } = await import(
   "../dist/types-global/errors.js"
 );
-const { getFileDocumentMap, replaceFileContentIfMatch, updateFileContent } =
-  await import("../dist/services/obsidianRestAPI/methods/vaultMethods.js");
+const { updateFileContent } = await import(
+  "../dist/services/obsidianRestAPI/methods/vaultMethods.js"
+);
 const { ObsidianRestApiService } = await import(
   "../dist/services/obsidianRestAPI/service.js"
 );
 
 const context = {
-  requestId: "cas-test",
+  requestId: "live-write-boundary-test",
   timestamp: new Date(0).toISOString(),
-  operation: "testObsidianCas",
+  operation: "testLiveWriteBoundary",
 };
 
 try {
   const requests = [];
-  const request = async (requestConfig, _context, operationName) => {
-    requests.push({ requestConfig, operationName });
-    if (operationName === "getFileDocumentMap") {
-      return {
-        headings: { Projet: {} },
-        blocks: [],
-        frontmatterFields: ["statut"],
-        version: "version-123",
-      };
-    }
-  };
-
-  const documentMap = await getFileDocumentMap(
-    request,
-    "Dossier riche/Note ÉLYSIA.md",
-    context,
-  );
-  assert.equal(documentMap.version, "version-123");
-  assert.deepEqual(requests[0], {
-    operationName: "getFileDocumentMap",
-    requestConfig: {
-      method: "GET",
-      url: "/vault/Dossier%20riche/Note%20%C3%89LYSIA.md",
-      headers: {
-        Accept: "application/vnd.olrapi.document-map+json",
-      },
-    },
-  });
-
-  await replaceFileContentIfMatch(
-    request,
-    "Dossier riche/Note ÉLYSIA.md",
-    "# Projet\n\nContenu réparé.\n",
-    '  "version-123"  ',
-    context,
-  );
-  assert.deepEqual(requests[1], {
-    operationName: "replaceFileContentIfMatch",
-    requestConfig: {
-      method: "PATCH",
-      url: "/vault/Dossier%20riche/Note%20%C3%89LYSIA.md",
-      headers: {
-        "Content-Type": "text/markdown",
-        Operation: "replace",
-        "If-Match": '"version-123"',
-      },
-      data: "# Projet\n\nContenu réparé.\n",
-    },
-  });
-
-  await assert.rejects(
-    () =>
-      replaceFileContentIfMatch(request, "Note.md", "# Note\n", "   ", context),
-    (error) =>
-      error instanceof McpError &&
-      error.code === BaseErrorCode.VALIDATION_ERROR,
-  );
-  await assert.rejects(
-    () =>
-      replaceFileContentIfMatch(request, "Note.md", "", "version-123", context),
-    (error) =>
-      error instanceof McpError &&
-      error.code === BaseErrorCode.VALIDATION_ERROR,
-  );
-
-  await assert.rejects(
-    () =>
-      getFileDocumentMap(
-        async () => ({
-          headings: {},
-          blocks: [],
-          frontmatterFields: [],
-        }),
-        "Legacy.md",
-        context,
-      ),
-    (error) =>
-      error instanceof McpError &&
-      error.code === BaseErrorCode.SERVICE_UNAVAILABLE,
-  );
-
-  const legacyRequests = [];
   await updateFileContent(
     async (requestConfig, _context, operationName) => {
-      legacyRequests.push({ requestConfig, operationName });
+      requests.push({ requestConfig, operationName });
     },
-    "Note.md",
-    "legacy behavior",
+    "Dossier riche/Note ÉLYSIA.md",
+    "# Note\n",
     context,
   );
-  assert.deepEqual(legacyRequests[0], {
+  assert.deepEqual(requests[0], {
     operationName: "updateFileContent",
     requestConfig: {
       method: "PUT",
-      url: "/vault/Note.md",
+      url: "/vault/Dossier%20riche/Note%20%C3%89LYSIA.md",
       headers: { "Content-Type": "text/markdown" },
-      data: "legacy behavior",
+      data: "# Note\n",
     },
   });
 
@@ -135,21 +54,14 @@ try {
         status: 412,
         data: {
           errorCode: 41200,
-          message: "Document version does not match",
+          message: "Precondition failed",
         },
       };
       throw error;
     },
   };
-
   await assert.rejects(
-    () =>
-      service.replaceFileContentIfMatch(
-        "Note.md",
-        "# Concurrent edit\n",
-        "stale-version",
-        context,
-      ),
+    () => service.updateFileContent("Note.md", "# Concurrent edit\n", context),
     (error) =>
       error instanceof McpError &&
       error.code === BaseErrorCode.CONFLICT &&
@@ -157,7 +69,7 @@ try {
         "Obsidian API Precondition Failed: the note changed after it was read.",
   );
 
-  console.log("Obsidian REST CAS tests passed.");
+  console.log("Obsidian REST live-write boundary tests passed.");
 } finally {
   await rm(logsDir, { recursive: true, force: true });
 }

--- a/scripts/test-obsidian-search-replace-cas.mjs
+++ b/scripts/test-obsidian-search-replace-cas.mjs
@@ -24,7 +24,6 @@ const context = {
   timestamp: new Date(0).toISOString(),
   operation: "testSearchReplaceCas",
 };
-
 const filePath = "Projet/Pilote.md";
 const originalContent = "# Pilote\n\nLien ancien\n";
 const modifiedContent = "# Pilote\n\nLien nouveau\n";
@@ -42,26 +41,9 @@ function params(overrides = {}) {
   });
 }
 
-function createService({
-  documentVersions = ["version-1", "version-1"],
-  markdownContent = originalContent,
-} = {}) {
+function createService() {
   const calls = [];
-  let mapIndex = 0;
-
   const service = {
-    async getFileDocumentMap(requestedPath) {
-      calls.push({ method: "getFileDocumentMap", path: requestedPath });
-      const version =
-        documentVersions[Math.min(mapIndex, documentVersions.length - 1)];
-      mapIndex += 1;
-      return {
-        headings: {},
-        blocks: [],
-        frontmatterFields: [],
-        version,
-      };
-    },
     async getFileContent(requestedPath, format) {
       calls.push({ method: "getFileContent", path: requestedPath, format });
       if (format === "json") {
@@ -73,15 +55,7 @@ function createService({
           tags: [],
         };
       }
-      return markdownContent;
-    },
-    async replaceFileContentIfMatch(requestedPath, content, expectedVersion) {
-      calls.push({
-        method: "replaceFileContentIfMatch",
-        path: requestedPath,
-        content,
-        expectedVersion,
-      });
+      return originalContent;
     },
     async updateFileContent(requestedPath, content) {
       calls.push({
@@ -92,89 +66,26 @@ function createService({
     },
     async getActiveFile(format) {
       calls.push({ method: "getActiveFile", format });
-      return markdownContent;
+      return originalContent;
     },
   };
-
   return { service, calls };
-}
-
-function writeCalls(calls) {
-  return calls.filter((call) =>
-    ["replaceFileContentIfMatch", "updateFileContent"].includes(call.method),
-  );
 }
 
 try {
   {
     const { service, calls } = createService();
-    const result = await processObsidianSearchReplace(
-      params(),
-      context,
-      service,
-      undefined,
-    );
-
-    assert.equal(result.success, true);
-    assert.equal(result.totalReplacementsMade, 1);
-    assert.deepEqual(
-      calls.slice(0, 4).map((call) => call.method),
-      [
-        "getFileDocumentMap",
-        "getFileContent",
-        "getFileDocumentMap",
-        "replaceFileContentIfMatch",
-      ],
-    );
-    assert.deepEqual(writeCalls(calls), [
-      {
-        method: "replaceFileContentIfMatch",
-        path: filePath,
-        content: modifiedContent,
-        expectedVersion: "version-1",
-      },
-    ]);
-  }
-
-  {
-    const { service, calls } = createService();
-    await assert.rejects(
-      () =>
-        processObsidianSearchReplace(
-          params({ expectedSha256: "0".repeat(64) }),
-          context,
-          service,
-          undefined,
-        ),
-      (error) =>
-        error instanceof McpError &&
-        error.code === BaseErrorCode.CONFLICT &&
-        error.message === "The note content does not match expectedSha256.",
-    );
-    assert.deepEqual(
-      calls.map((call) => call.method),
-      ["getFileDocumentMap", "getFileContent"],
-    );
-    assert.deepEqual(writeCalls(calls), []);
-  }
-
-  {
-    const { service, calls } = createService({
-      documentVersions: ["version-1", "version-2"],
-    });
     await assert.rejects(
       () => processObsidianSearchReplace(params(), context, service, undefined),
       (error) =>
         error instanceof McpError &&
-        error.code === BaseErrorCode.CONFLICT &&
-        error.message ===
-          "The note changed while the conditional replacement was being prepared.",
+        error.code === BaseErrorCode.SERVICE_UNAVAILABLE &&
+        error.message.includes("Atomic expectedSha256 writes are unavailable"),
     );
     assert.deepEqual(
       calls.map((call) => call.method),
-      ["getFileDocumentMap", "getFileContent", "getFileDocumentMap"],
+      ["getFileContent"],
     );
-    assert.deepEqual(writeCalls(calls), []);
   }
 
   {
@@ -200,7 +111,6 @@ try {
       calls.map((call) => call.method),
       ["getActiveFile"],
     );
-    assert.deepEqual(writeCalls(calls), []);
   }
 
   {
@@ -214,20 +124,21 @@ try {
 
     assert.equal(result.success, true);
     assert.equal(result.totalReplacementsMade, 1);
-    assert.equal(
-      calls.some((call) => call.method === "getFileDocumentMap"),
-      false,
+    assert.deepEqual(
+      calls.filter((call) => call.method === "updateFileContent"),
+      [
+        {
+          method: "updateFileContent",
+          path: filePath,
+          content: modifiedContent,
+        },
+      ],
     );
-    assert.deepEqual(writeCalls(calls), [
-      {
-        method: "updateFileContent",
-        path: filePath,
-        content: modifiedContent,
-      },
-    ]);
   }
 
-  console.log("Obsidian search/replace expectedSha256 tests passed.");
+  console.log(
+    "Obsidian search/replace live CAS refusal and normal write tests passed.",
+  );
 } finally {
   await rm(logsDir, { recursive: true, force: true });
 }

--- a/scripts/test-obsidian-search-replace-cas.mjs
+++ b/scripts/test-obsidian-search-replace-cas.mjs
@@ -1,0 +1,233 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdir, mkdtemp, rm } from "node:fs/promises";
+import path from "node:path";
+
+const logsRoot = path.join(process.cwd(), "logs");
+await mkdir(logsRoot, { recursive: true });
+const logsDir = await mkdtemp(path.join(logsRoot, "search-replace-cas-test-"));
+
+process.env.OBSIDIAN_API_KEY = "test-only-api-key";
+process.env.OBSIDIAN_BASE_URL = "http://127.0.0.1:27123";
+process.env.MCP_LOG_LEVEL = "error";
+process.env.LOGS_DIR = logsDir;
+process.env.MCP_WRITE_MODE = "full";
+
+const { BaseErrorCode, McpError } = await import(
+  "../dist/types-global/errors.js"
+);
+const { ObsidianSearchReplaceInputSchema, processObsidianSearchReplace } =
+  await import("../dist/mcp-server/tools/obsidianSearchReplaceTool/logic.js");
+
+const context = {
+  requestId: "search-replace-cas-test",
+  timestamp: new Date(0).toISOString(),
+  operation: "testSearchReplaceCas",
+};
+
+const filePath = "Projet/Pilote.md";
+const originalContent = "# Pilote\n\nLien ancien\n";
+const modifiedContent = "# Pilote\n\nLien nouveau\n";
+const originalSha256 = createHash("sha256")
+  .update(originalContent, "utf8")
+  .digest("hex");
+
+function params(overrides = {}) {
+  return ObsidianSearchReplaceInputSchema.parse({
+    targetType: "filePath",
+    targetIdentifier: filePath,
+    replacements: [{ search: "Lien ancien", replace: "Lien nouveau" }],
+    expectedSha256: originalSha256,
+    ...overrides,
+  });
+}
+
+function createService({
+  documentVersions = ["version-1", "version-1"],
+  markdownContent = originalContent,
+} = {}) {
+  const calls = [];
+  let mapIndex = 0;
+
+  const service = {
+    async getFileDocumentMap(requestedPath) {
+      calls.push({ method: "getFileDocumentMap", path: requestedPath });
+      const version =
+        documentVersions[Math.min(mapIndex, documentVersions.length - 1)];
+      mapIndex += 1;
+      return {
+        headings: {},
+        blocks: [],
+        frontmatterFields: [],
+        version,
+      };
+    },
+    async getFileContent(requestedPath, format) {
+      calls.push({ method: "getFileContent", path: requestedPath, format });
+      if (format === "json") {
+        return {
+          content: modifiedContent,
+          frontmatter: {},
+          path: requestedPath,
+          stat: null,
+          tags: [],
+        };
+      }
+      return markdownContent;
+    },
+    async replaceFileContentIfMatch(requestedPath, content, expectedVersion) {
+      calls.push({
+        method: "replaceFileContentIfMatch",
+        path: requestedPath,
+        content,
+        expectedVersion,
+      });
+    },
+    async updateFileContent(requestedPath, content) {
+      calls.push({
+        method: "updateFileContent",
+        path: requestedPath,
+        content,
+      });
+    },
+    async getActiveFile(format) {
+      calls.push({ method: "getActiveFile", format });
+      return markdownContent;
+    },
+  };
+
+  return { service, calls };
+}
+
+function writeCalls(calls) {
+  return calls.filter((call) =>
+    ["replaceFileContentIfMatch", "updateFileContent"].includes(call.method),
+  );
+}
+
+try {
+  {
+    const { service, calls } = createService();
+    const result = await processObsidianSearchReplace(
+      params(),
+      context,
+      service,
+      undefined,
+    );
+
+    assert.equal(result.success, true);
+    assert.equal(result.totalReplacementsMade, 1);
+    assert.deepEqual(
+      calls.slice(0, 4).map((call) => call.method),
+      [
+        "getFileDocumentMap",
+        "getFileContent",
+        "getFileDocumentMap",
+        "replaceFileContentIfMatch",
+      ],
+    );
+    assert.deepEqual(writeCalls(calls), [
+      {
+        method: "replaceFileContentIfMatch",
+        path: filePath,
+        content: modifiedContent,
+        expectedVersion: "version-1",
+      },
+    ]);
+  }
+
+  {
+    const { service, calls } = createService();
+    await assert.rejects(
+      () =>
+        processObsidianSearchReplace(
+          params({ expectedSha256: "0".repeat(64) }),
+          context,
+          service,
+          undefined,
+        ),
+      (error) =>
+        error instanceof McpError &&
+        error.code === BaseErrorCode.CONFLICT &&
+        error.message === "The note content does not match expectedSha256.",
+    );
+    assert.deepEqual(
+      calls.map((call) => call.method),
+      ["getFileDocumentMap", "getFileContent"],
+    );
+    assert.deepEqual(writeCalls(calls), []);
+  }
+
+  {
+    const { service, calls } = createService({
+      documentVersions: ["version-1", "version-2"],
+    });
+    await assert.rejects(
+      () => processObsidianSearchReplace(params(), context, service, undefined),
+      (error) =>
+        error instanceof McpError &&
+        error.code === BaseErrorCode.CONFLICT &&
+        error.message ===
+          "The note changed while the conditional replacement was being prepared.",
+    );
+    assert.deepEqual(
+      calls.map((call) => call.method),
+      ["getFileDocumentMap", "getFileContent", "getFileDocumentMap"],
+    );
+    assert.deepEqual(writeCalls(calls), []);
+  }
+
+  {
+    const { service, calls } = createService();
+    await assert.rejects(
+      () =>
+        processObsidianSearchReplace(
+          params({
+            targetType: "activeFile",
+            targetIdentifier: undefined,
+          }),
+          context,
+          service,
+          undefined,
+        ),
+      (error) =>
+        error instanceof McpError &&
+        error.code === BaseErrorCode.VALIDATION_ERROR &&
+        error.message ===
+          "expectedSha256 is supported only for an explicit filePath target.",
+    );
+    assert.deepEqual(
+      calls.map((call) => call.method),
+      ["getActiveFile"],
+    );
+    assert.deepEqual(writeCalls(calls), []);
+  }
+
+  {
+    const { service, calls } = createService();
+    const result = await processObsidianSearchReplace(
+      params({ expectedSha256: undefined }),
+      context,
+      service,
+      undefined,
+    );
+
+    assert.equal(result.success, true);
+    assert.equal(result.totalReplacementsMade, 1);
+    assert.equal(
+      calls.some((call) => call.method === "getFileDocumentMap"),
+      false,
+    );
+    assert.deepEqual(writeCalls(calls), [
+      {
+        method: "updateFileContent",
+        path: filePath,
+        content: modifiedContent,
+      },
+    ]);
+  }
+
+  console.log("Obsidian search/replace expectedSha256 tests passed.");
+} finally {
+  await rm(logsDir, { recursive: true, force: true });
+}

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -1,5 +1,6 @@
 import dotenv from "dotenv";
 import { existsSync, mkdirSync, readFileSync, statSync } from "fs";
+import os from "node:os";
 import path, { dirname, join } from "path";
 import { fileURLToPath } from "url";
 import { z } from "zod";
@@ -139,6 +140,11 @@ const EnvSchema = z
       .transform((val) => val.toLowerCase() === "true")
       .default("true"),
     MCP_EXTERNAL_ROOTS_FILE: z.string().optional(),
+    MCP_EXTERNAL_MOVE_ENABLED: z
+      .string()
+      .transform((val) => val.toLowerCase() === "true")
+      .default("false"),
+    MCP_EXTERNAL_MOVE_JOURNAL_PATH: z.string().optional(),
     // --- Public runtime safety ---
     MCP_WRITE_MODE: z.enum(["readonly", "guarded", "full"]).optional(),
     MCP_GUARDED_MAX_WRITE_CHARS: z.coerce
@@ -378,6 +384,16 @@ export const config = {
   obsidianStartupRetryDelayMs: env.OBSIDIAN_STARTUP_RETRY_DELAY_MS,
   obsidianStartupBlocking: env.OBSIDIAN_STARTUP_BLOCKING,
   externalRootsFile: env.MCP_EXTERNAL_ROOTS_FILE,
+  externalMoveEnabled: env.MCP_EXTERNAL_MOVE_ENABLED,
+  externalMoveJournalPath:
+    env.MCP_EXTERNAL_MOVE_JOURNAL_PATH ||
+    path.join(
+      process.env.LOCALAPPDATA ||
+        process.env.XDG_STATE_HOME ||
+        path.join(os.homedir(), ".local", "state"),
+      "optimike-obsidian-mcp",
+      "external-moves.sqlite",
+    ),
   mcpWriteMode:
     env.MCP_WRITE_MODE ||
     (env.OBSIDIAN_RUNTIME_MODE === "headless-guarded"

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -144,7 +144,20 @@ const EnvSchema = z
       .string()
       .transform((val) => val.toLowerCase() === "true")
       .default("false"),
-    MCP_EXTERNAL_MOVE_JOURNAL_PATH: z.string().optional(),
+    MCP_EXTERNAL_MOVE_JOURNAL_PATH: z
+      .string()
+      .refine(
+        (value) => path.isAbsolute(value),
+        "MCP_EXTERNAL_MOVE_JOURNAL_PATH must be absolute.",
+      )
+      .optional(),
+    MCP_EXTERNAL_MOVE_PROFILE_ID: z
+      .string()
+      .regex(
+        /^[a-z0-9]+(?:[._-][a-z0-9]+)*$/u,
+        "MCP_EXTERNAL_MOVE_PROFILE_ID must be a stable lowercase logical identifier.",
+      )
+      .optional(),
     // --- Public runtime safety ---
     MCP_WRITE_MODE: z.enum(["readonly", "guarded", "full"]).optional(),
     MCP_GUARDED_MAX_WRITE_CHARS: z.coerce
@@ -258,9 +271,7 @@ const parsedEnv = EnvSchema.safeParse(process.env);
 
 if (!parsedEnv.success) {
   const errorDetails = parsedEnv.error.flatten().fieldErrors;
-  if (process.stderr.isTTY) {
-    console.error("❌ Invalid environment variables:", errorDetails);
-  }
+  console.error("❌ Invalid environment variables:", errorDetails);
   throw new Error(
     `Invalid environment configuration. Please check your .env file or environment variables. Details: ${JSON.stringify(errorDetails)}`,
   );
@@ -327,11 +338,9 @@ const ensureDirectory = (
 const validatedLogsPath = ensureDirectory(env.LOGS_DIR, projectRoot, "logs");
 
 if (!validatedLogsPath) {
-  if (process.stderr.isTTY) {
-    console.error(
-      "FATAL: Logs directory configuration is invalid or could not be created. Please check permissions and path. Exiting.",
-    );
-  }
+  console.error(
+    "FATAL: Logs directory configuration is invalid or could not be created. Please check permissions and path. Exiting.",
+  );
   process.exit(1);
 }
 
@@ -385,6 +394,7 @@ export const config = {
   obsidianStartupBlocking: env.OBSIDIAN_STARTUP_BLOCKING,
   externalRootsFile: env.MCP_EXTERNAL_ROOTS_FILE,
   externalMoveEnabled: env.MCP_EXTERNAL_MOVE_ENABLED,
+  externalMoveProfileId: env.MCP_EXTERNAL_MOVE_PROFILE_ID,
   externalMoveJournalPath:
     env.MCP_EXTERNAL_MOVE_JOURNAL_PATH ||
     path.join(
@@ -436,6 +446,27 @@ export const config = {
   semanticSearchPrewarmText: env.SEMANTIC_SEARCH_PREWARM_TEXT,
   obsidianVaultPath: env.OBSIDIAN_VAULT,
 };
+
+/**
+ * Namespaces a durable external-move journal by backend/vault/root binding.
+ * Reusing a base path across local profiles therefore cannot mix their plans.
+ */
+export function profileExternalMoveJournalPath(
+  basePath: string,
+  bindingFingerprint: string,
+): string {
+  if (basePath === ":memory:") return basePath;
+  if (!/^[a-f0-9]{64}$/u.test(bindingFingerprint)) {
+    throw new Error("External move binding fingerprint must be SHA-256.");
+  }
+  const parsed = path.parse(basePath);
+  const extension = parsed.ext || ".sqlite";
+  const stem = parsed.ext ? parsed.name : parsed.base;
+  return path.join(
+    parsed.dir,
+    `${stem}.${bindingFingerprint.slice(0, 24)}${extension}`,
+  );
+}
 
 /**
  * The configured logging level for the application.

--- a/src/mcp-server/tools/externalRootsTools/registration.ts
+++ b/src/mcp-server/tools/externalRootsTools/registration.ts
@@ -6,7 +6,10 @@ import {
   ExternalRootsService,
 } from "../../../services/externalRootsService.js";
 import { externalTransferBroker } from "../../../services/externalTransferBroker.js";
-import { READ_ONLY_TOOL_ANNOTATIONS } from "../../toolAnnotations.js";
+import {
+  DESTRUCTIVE_TOOL_ANNOTATIONS,
+  READ_ONLY_TOOL_ANNOTATIONS,
+} from "../../toolAnnotations.js";
 
 export const ExternalRootPathSchema = z
   .object({
@@ -39,6 +42,38 @@ export const ExternalReadSchema = ExternalRootPathSchema.extend({
 export const ExternalHandoffSchema = ExternalRootPathSchema.extend({
   includeHash: z.boolean().default(true),
 });
+
+export const ExternalReferencesScanSchema = ExternalRootPathSchema.extend({
+  searchInPath: z
+    .string()
+    .default("")
+    .describe(
+      "Optional vault-relative directory in which to inventory references.",
+    ),
+});
+
+export const ExternalMovePlanSchema = z
+  .object({
+    rootId: z.string().min(1),
+    sourceRelativePath: z.string().min(1),
+    targetRelativePath: z.string().min(1),
+    searchInPath: z.string().default(""),
+    idempotencyKey: z.string().min(8).max(200),
+  })
+  .strict();
+
+export const ExternalMoveApplySchema = z
+  .object({
+    planId: z.string().uuid(),
+    idempotencyKey: z.string().min(8).max(200),
+  })
+  .strict();
+
+export const ExternalMoveStatusSchema = z
+  .object({ planId: z.string().uuid() })
+  .strict();
+
+export const ExternalMoveRollbackSchema = ExternalMoveApplySchema;
 
 function disabledError(): ExternalRootError {
   return new ExternalRootError(
@@ -271,4 +306,57 @@ export async function registerExternalRootsTools(
         ),
       )(),
   );
+
+  for (const definition of [
+    {
+      name: "external_references_scan",
+      description:
+        "Inventories canonical and ambiguous ÉLYSIA references to one external file. This stdio-only operation never mutates either surface.",
+      schema: ExternalReferencesScanSchema.shape,
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
+    },
+    {
+      name: "external_move_plan",
+      description:
+        "Builds a durable stdio-only plan for a same-root external file move and exact ÉLYSIA link repairs. Ambiguous references block apply.",
+      schema: ExternalMovePlanSchema.shape,
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
+    },
+    {
+      name: "external_move_status",
+      description:
+        "Returns the durable status and redacted receipt for one external move plan.",
+      schema: ExternalMoveStatusSchema.shape,
+      annotations: READ_ONLY_TOOL_ANNOTATIONS,
+    },
+    {
+      name: "external_move_apply",
+      description:
+        "Applies a previously verified same-root file move and its exact ÉLYSIA repairs. Requires stdio, MCP_WRITE_MODE=full, the move root capability, and MCP_EXTERNAL_MOVE_ENABLED=true.",
+      schema: ExternalMoveApplySchema.shape,
+      annotations: DESTRUCTIVE_TOOL_ANNOTATIONS,
+    },
+    {
+      name: "external_move_rollback",
+      description:
+        "Rolls back an applied external move and its ÉLYSIA repairs when every stored precondition still holds.",
+      schema: ExternalMoveRollbackSchema.shape,
+      annotations: DESTRUCTIVE_TOOL_ANNOTATIONS,
+    },
+  ] as const) {
+    server.tool(
+      definition.name,
+      definition.description,
+      definition.schema,
+      definition.annotations,
+      externalRootsResult(() =>
+        Promise.reject(
+          new ExternalRootError(
+            "capability_denied",
+            "External reference mutations and their plans are available only through the local stdio proxy.",
+          ),
+        ),
+      ),
+    );
+  }
 }

--- a/src/mcp-server/tools/externalRootsTools/registration.ts
+++ b/src/mcp-server/tools/externalRootsTools/registration.ts
@@ -43,21 +43,13 @@ export const ExternalHandoffSchema = ExternalRootPathSchema.extend({
   includeHash: z.boolean().default(true),
 });
 
-export const ExternalReferencesScanSchema = ExternalRootPathSchema.extend({
-  searchInPath: z
-    .string()
-    .default("")
-    .describe(
-      "Optional vault-relative directory in which to inventory references.",
-    ),
-});
+export const ExternalReferencesScanSchema = ExternalRootPathSchema;
 
 export const ExternalMovePlanSchema = z
   .object({
     rootId: z.string().min(1),
     sourceRelativePath: z.string().min(1),
     targetRelativePath: z.string().min(1),
-    searchInPath: z.string().default(""),
     idempotencyKey: z.string().min(8).max(200),
   })
   .strict();

--- a/src/mcp-server/tools/obsidianSearchReplaceTool/logic.ts
+++ b/src/mcp-server/tools/obsidianSearchReplaceTool/logic.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import path from "node:path"; // For file path fallback logic using POSIX separators
 import { z } from "zod";
 import {
@@ -113,6 +114,13 @@ const BaseObsidianSearchReplaceInputSchema = z.object({
     .default(false)
     .describe(
       "If true, returns the final content of the file in the response. Defaults to false.",
+    ),
+  expectedSha256: z
+    .string()
+    .regex(/^[a-f0-9]{64}$/u)
+    .optional()
+    .describe(
+      "Optional SHA-256 precondition for a filePath target. Requires Local REST document-map CAS.",
     ),
 });
 
@@ -372,6 +380,7 @@ export const processObsidianSearchReplace = async (
 
   // --- Step 1: Read Initial Content (with case-insensitive fallback for filePath) ---
   let originalContent: string;
+  let conditionalDocumentVersion: string | undefined;
   const readContext = { ...context, operation: "readFileContent" };
   try {
     if (targetType === "filePath") {
@@ -384,6 +393,14 @@ export const processObsidianSearchReplace = async (
         );
       }
       targetDescription = targetIdentifier; // Initial description
+      if (params.expectedSha256) {
+        conditionalDocumentVersion = (
+          await obsidianService.getFileDocumentMap(
+            targetIdentifier,
+            readContext,
+          )
+        ).version;
+      }
       try {
         // Attempt 1: Case-sensitive read
         logger.debug(
@@ -514,6 +531,39 @@ export const processObsidianSearchReplace = async (
       `${errorMessage}: ${error instanceof Error ? error.message : String(error)}`,
       readContext,
     );
+  }
+
+  if (params.expectedSha256) {
+    if (targetType !== "filePath" || !effectiveFilePath) {
+      throw new McpError(
+        BaseErrorCode.VALIDATION_ERROR,
+        "expectedSha256 is supported only for an explicit filePath target.",
+        context,
+      );
+    }
+    const actualSha256 = createHash("sha256")
+      .update(originalContent, "utf8")
+      .digest("hex");
+    if (actualSha256 !== params.expectedSha256) {
+      throw new McpError(
+        BaseErrorCode.CONFLICT,
+        "The note content does not match expectedSha256.",
+        context,
+      );
+    }
+    const versionAfterRead = (
+      await obsidianService.getFileDocumentMap(effectiveFilePath, context)
+    ).version;
+    if (
+      !conditionalDocumentVersion ||
+      versionAfterRead !== conditionalDocumentVersion
+    ) {
+      throw new McpError(
+        BaseErrorCode.CONFLICT,
+        "The note changed while the conditional replacement was being prepared.",
+        context,
+      );
+    }
   }
 
   // --- Step 2: Perform Sequential Replacements ---
@@ -733,11 +783,20 @@ export const processObsidianSearchReplace = async (
       );
       // Use the effectiveFilePath determined during the read phase for filePath targets
       if (targetType === "filePath") {
-        await obsidianService.updateFileContent(
-          effectiveFilePath!,
-          modifiedContent,
-          writeContext,
-        );
+        if (params.expectedSha256 && conditionalDocumentVersion) {
+          await obsidianService.replaceFileContentIfMatch(
+            effectiveFilePath!,
+            modifiedContent,
+            conditionalDocumentVersion,
+            writeContext,
+          );
+        } else {
+          await obsidianService.updateFileContent(
+            effectiveFilePath!,
+            modifiedContent,
+            writeContext,
+          );
+        }
         if (vaultCacheService) {
           await vaultCacheService.updateCacheForFile(
             effectiveFilePath!,

--- a/src/mcp-server/tools/obsidianSearchReplaceTool/logic.ts
+++ b/src/mcp-server/tools/obsidianSearchReplaceTool/logic.ts
@@ -1,4 +1,3 @@
-import { createHash } from "node:crypto";
 import path from "node:path"; // For file path fallback logic using POSIX separators
 import { z } from "zod";
 import {
@@ -120,7 +119,7 @@ const BaseObsidianSearchReplaceInputSchema = z.object({
     .regex(/^[a-f0-9]{64}$/u)
     .optional()
     .describe(
-      "Optional SHA-256 precondition for a filePath target. Requires Local REST document-map CAS.",
+      "Optional SHA-256 precondition for a filePath target in guarded headless modes. Live Local REST writes reject this precondition.",
     ),
 });
 
@@ -380,7 +379,6 @@ export const processObsidianSearchReplace = async (
 
   // --- Step 1: Read Initial Content (with case-insensitive fallback for filePath) ---
   let originalContent: string;
-  let conditionalDocumentVersion: string | undefined;
   const readContext = { ...context, operation: "readFileContent" };
   try {
     if (targetType === "filePath") {
@@ -393,14 +391,6 @@ export const processObsidianSearchReplace = async (
         );
       }
       targetDescription = targetIdentifier; // Initial description
-      if (params.expectedSha256) {
-        conditionalDocumentVersion = (
-          await obsidianService.getFileDocumentMap(
-            targetIdentifier,
-            readContext,
-          )
-        ).version;
-      }
       try {
         // Attempt 1: Case-sensitive read
         logger.debug(
@@ -541,29 +531,11 @@ export const processObsidianSearchReplace = async (
         context,
       );
     }
-    const actualSha256 = createHash("sha256")
-      .update(originalContent, "utf8")
-      .digest("hex");
-    if (actualSha256 !== params.expectedSha256) {
-      throw new McpError(
-        BaseErrorCode.CONFLICT,
-        "The note content does not match expectedSha256.",
-        context,
-      );
-    }
-    const versionAfterRead = (
-      await obsidianService.getFileDocumentMap(effectiveFilePath, context)
-    ).version;
-    if (
-      !conditionalDocumentVersion ||
-      versionAfterRead !== conditionalDocumentVersion
-    ) {
-      throw new McpError(
-        BaseErrorCode.CONFLICT,
-        "The note changed while the conditional replacement was being prepared.",
-        context,
-      );
-    }
+    throw new McpError(
+      BaseErrorCode.SERVICE_UNAVAILABLE,
+      "Atomic expectedSha256 writes are unavailable through the current Obsidian Local REST API. Use a copied or dedicated vault in headless-filesystem mode.",
+      context,
+    );
   }
 
   // --- Step 2: Perform Sequential Replacements ---
@@ -783,20 +755,11 @@ export const processObsidianSearchReplace = async (
       );
       // Use the effectiveFilePath determined during the read phase for filePath targets
       if (targetType === "filePath") {
-        if (params.expectedSha256 && conditionalDocumentVersion) {
-          await obsidianService.replaceFileContentIfMatch(
-            effectiveFilePath!,
-            modifiedContent,
-            conditionalDocumentVersion,
-            writeContext,
-          );
-        } else {
-          await obsidianService.updateFileContent(
-            effectiveFilePath!,
-            modifiedContent,
-            writeContext,
-          );
-        }
+        await obsidianService.updateFileContent(
+          effectiveFilePath!,
+          modifiedContent,
+          writeContext,
+        );
         if (vaultCacheService) {
           await vaultCacheService.updateCacheForFile(
             effectiveFilePath!,

--- a/src/services/externalReferences/backendVaultAdapter.ts
+++ b/src/services/externalReferences/backendVaultAdapter.ts
@@ -237,7 +237,11 @@ export class BackendVaultAdapter {
     }
   }
 
-  async searchPaths(query: string, searchInPath = ""): Promise<string[]> {
+  async searchPaths(
+    query: string,
+    searchInPath = "",
+    caseSensitive = true,
+  ): Promise<string[]> {
     const paths = new Set<string>();
     let page = 1;
     let totalPages = 1;
@@ -247,7 +251,7 @@ export class BackendVaultAdapter {
           query,
           searchInPath: searchInPath || undefined,
           useRegex: false,
-          caseSensitive: true,
+          caseSensitive,
           page,
           pageSize: 100,
           maxMatchesPerFile: 1,

--- a/src/services/externalReferences/backendVaultAdapter.ts
+++ b/src/services/externalReferences/backendVaultAdapter.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import path from "node:path";
 
 type ToolResult = {
   content?: Array<{ type?: string; text?: string }>;
@@ -10,13 +11,67 @@ export type BackendToolCaller = (
   args: Record<string, unknown>,
 ) => Promise<unknown>;
 
+export type BackendVaultAdapterOptions = {
+  backendEndpoint: string;
+  rootConfigFingerprint: string;
+  profileId?: string;
+};
+
+export type ExternalMoveBindingIdentity = {
+  schemaVersion: 1;
+  backendFingerprint: string;
+  vaultFingerprint: string;
+  rootConfigFingerprint: string;
+  bindingFingerprint: string;
+  vaultIdentitySource:
+    | "explicit_profile"
+    | "configured_vault"
+    | "shared_cache_fallback";
+  verifiable: boolean;
+};
+
+function sha256Json(value: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(value), "utf8")
+    .digest("hex");
+}
+
+function normalizedIdentityPath(value: string): string {
+  const resolved = path.resolve(value).replace(/\\/gu, "/");
+  return process.platform === "win32" ? resolved.toLowerCase() : resolved;
+}
+
+function nestedRecord(
+  value: unknown,
+  key: string,
+): Record<string, unknown> | undefined {
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    !(key in value) ||
+    typeof (value as Record<string, unknown>)[key] !== "object" ||
+    (value as Record<string, unknown>)[key] === null
+  ) {
+    return undefined;
+  }
+  return (value as Record<string, unknown>)[key] as Record<string, unknown>;
+}
+
 function parseToolJson(result: unknown): Record<string, unknown> {
   const toolResult = result as ToolResult;
   const text = toolResult.content?.find(
     (item) => item.type === "text" && typeof item.text === "string",
   )?.text;
   if (!text) throw new Error("The vault backend returned no JSON payload.");
-  const parsed = JSON.parse(text) as Record<string, unknown>;
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(text) as Record<string, unknown>;
+  } catch {
+    if (toolResult.isError) {
+      throw new Error(text);
+    }
+    throw new Error("The vault backend returned a non-JSON payload.");
+  }
   if (toolResult.isError) {
     throw new Error(
       typeof parsed.message === "string"
@@ -32,7 +87,155 @@ export function sha256Text(content: string): string {
 }
 
 export class BackendVaultAdapter {
-  constructor(private readonly callTool: BackendToolCaller) {}
+  private bindingIdentityPromise?: Promise<ExternalMoveBindingIdentity>;
+  private requireLiveInventory = false;
+
+  constructor(
+    private readonly callTool: BackendToolCaller,
+    private readonly options?: BackendVaultAdapterOptions,
+  ) {}
+
+  /**
+   * Returns a path-redacted backend/vault/root identity for move plans.
+   *
+   * The coordinator should persist this value and reject apply or rollback
+   * when the current binding differs. `verifiable: false` means the backend
+   * exposed only its shared-cache path; apply should require an explicit
+   * `MCP_EXTERNAL_MOVE_PROFILE_ID` in that case.
+   */
+  async getBindingIdentity(
+    refresh = false,
+  ): Promise<ExternalMoveBindingIdentity> {
+    if (!this.options) {
+      throw new Error(
+        "External move identity options are required for a profiled journal.",
+      );
+    }
+    if (refresh) this.bindingIdentityPromise = undefined;
+    this.bindingIdentityPromise ??= this.loadBindingIdentity();
+    return this.bindingIdentityPromise;
+  }
+
+  private async loadBindingIdentity(): Promise<ExternalMoveBindingIdentity> {
+    const options = this.options;
+    if (!options) {
+      throw new Error(
+        "External move identity options are required for a profiled journal.",
+      );
+    }
+    const status = parseToolJson(
+      await this.callTool("obsidian_runtime_status", {}),
+    );
+    const runtime = nestedRecord(status, "runtime");
+    const configFields = runtime
+      ? nestedRecord(runtime, "configFields")
+      : undefined;
+    const sharedCache = nestedRecord(status, "sharedCache");
+    const configuredVault =
+      configFields && typeof configFields.obsidianVaultPath === "string"
+        ? configFields.obsidianVaultPath
+        : undefined;
+    const sharedCachePath =
+      sharedCache && typeof sharedCache.dbPath === "string"
+        ? sharedCache.dbPath
+        : undefined;
+    const explicitProfile = options.profileId?.trim();
+
+    let vaultIdentitySource: ExternalMoveBindingIdentity["vaultIdentitySource"];
+    let vaultIdentityMaterial: string;
+    let verifiable: boolean;
+    if (explicitProfile) {
+      vaultIdentitySource = "explicit_profile";
+      vaultIdentityMaterial = configuredVault
+        ? `profile:${explicitProfile}|vault:${normalizedIdentityPath(configuredVault)}`
+        : `profile:${explicitProfile}`;
+      verifiable = true;
+    } else if (configuredVault) {
+      vaultIdentitySource = "configured_vault";
+      vaultIdentityMaterial = `vault:${normalizedIdentityPath(configuredVault)}`;
+      verifiable = true;
+    } else if (sharedCachePath) {
+      vaultIdentitySource = "shared_cache_fallback";
+      vaultIdentityMaterial = `cache:${normalizedIdentityPath(sharedCachePath)}`;
+      verifiable = false;
+    } else {
+      throw new Error(
+        "The backend did not expose a vault identity. Configure MCP_EXTERNAL_MOVE_PROFILE_ID.",
+      );
+    }
+
+    const backendFingerprint = sha256Json({
+      domain: "optimike.external-move.backend.v1",
+      runtimeMode: configFields?.obsidianRuntimeMode,
+      obsidianBaseUrl: configFields?.obsidianBaseUrl,
+      configuredVault: configuredVault
+        ? normalizedIdentityPath(configuredVault)
+        : undefined,
+      cacheSource: configFields?.obsidianCacheSource,
+      writeMode: configFields?.mcpWriteMode,
+      protectedFrontmatterKeys: configFields?.mcpProtectedFrontmatterKeys,
+    });
+    const vaultFingerprint = sha256Json({
+      domain: "optimike.external-move.vault.v1",
+      source: vaultIdentitySource,
+      identity: vaultIdentityMaterial,
+    });
+    const bindingFingerprint = sha256Json({
+      domain: "optimike.external-move.binding.v1",
+      backendFingerprint,
+      vaultFingerprint,
+      rootConfigFingerprint: options.rootConfigFingerprint,
+    });
+
+    return {
+      schemaVersion: 1,
+      backendFingerprint,
+      vaultFingerprint,
+      rootConfigFingerprint: options.rootConfigFingerprint,
+      bindingFingerprint,
+      vaultIdentitySource,
+      verifiable,
+    };
+  }
+
+  async refreshInventory(): Promise<void> {
+    const status = parseToolJson(
+      await this.callTool("obsidian_runtime_status", {}),
+    );
+    if (status.runtimeMode === "live" || status.runtimeMode === "hybrid") {
+      this.requireLiveInventory = true;
+      return;
+    }
+    this.requireLiveInventory = false;
+    const parsed = parseToolJson(
+      await this.callTool("obsidian_runtime_maintenance", {
+        action: "refresh_vault_cache",
+      }),
+    );
+    const sharedCache = nestedRecord(parsed, "sharedCache");
+    if (!sharedCache || sharedCache.status !== "ready") {
+      throw new Error(
+        "The vault cache did not provide a complete ready inventory.",
+      );
+    }
+  }
+
+  /**
+   * External reference repairs require a writer that can enforce the supplied
+   * content hash atomically. Current Local REST writes do not enforce that
+   * precondition, so only the guarded filesystem implementation on a copied or
+   * dedicated vault is eligible.
+   */
+  async assertConditionalWritesSupported(): Promise<void> {
+    const status = parseToolJson(
+      await this.callTool("obsidian_runtime_status", {}),
+    );
+    if (status.runtimeMode !== "headless-filesystem") {
+      throw new Error(
+        "External move apply requires headless-filesystem on a copied or dedicated vault. Current live Local REST writes do not provide atomic expectedSha256 enforcement.",
+      );
+    }
+  }
 
   async searchPaths(query: string, searchInPath = ""): Promise<string[]> {
     const paths = new Set<string>();
@@ -51,6 +254,16 @@ export class BackendVaultAdapter {
           responseMode: "compact",
         }),
       );
+      if (
+        this.requireLiveInventory &&
+        (typeof parsed.message !== "string" ||
+          !parsed.message.includes("API search successful") ||
+          parsed.message.includes("Falling back"))
+      ) {
+        throw new Error(
+          "A complete external-move inventory requires the live Obsidian API; cache fallback is not accepted.",
+        );
+      }
       const results = Array.isArray(parsed.results) ? parsed.results : [];
       for (const item of results) {
         if (
@@ -59,7 +272,7 @@ export class BackendVaultAdapter {
           "path" in item &&
           typeof item.path === "string"
         ) {
-          paths.add(item.path);
+          paths.add(item.path.replace(/^\/+/u, ""));
         }
       }
       totalPages =

--- a/src/services/externalReferences/backendVaultAdapter.ts
+++ b/src/services/externalReferences/backendVaultAdapter.ts
@@ -1,0 +1,118 @@
+import { createHash } from "node:crypto";
+
+type ToolResult = {
+  content?: Array<{ type?: string; text?: string }>;
+  isError?: boolean;
+};
+
+export type BackendToolCaller = (
+  name: string,
+  args: Record<string, unknown>,
+) => Promise<unknown>;
+
+function parseToolJson(result: unknown): Record<string, unknown> {
+  const toolResult = result as ToolResult;
+  const text = toolResult.content?.find(
+    (item) => item.type === "text" && typeof item.text === "string",
+  )?.text;
+  if (!text) throw new Error("The vault backend returned no JSON payload.");
+  const parsed = JSON.parse(text) as Record<string, unknown>;
+  if (toolResult.isError) {
+    throw new Error(
+      typeof parsed.message === "string"
+        ? parsed.message
+        : "The vault backend rejected the request.",
+    );
+  }
+  return parsed;
+}
+
+export function sha256Text(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+export class BackendVaultAdapter {
+  constructor(private readonly callTool: BackendToolCaller) {}
+
+  async searchPaths(query: string, searchInPath = ""): Promise<string[]> {
+    const paths = new Set<string>();
+    let page = 1;
+    let totalPages = 1;
+    do {
+      const parsed = parseToolJson(
+        await this.callTool("obsidian_global_search", {
+          query,
+          searchInPath: searchInPath || undefined,
+          useRegex: false,
+          caseSensitive: true,
+          page,
+          pageSize: 100,
+          maxMatchesPerFile: 1,
+          responseMode: "compact",
+        }),
+      );
+      const results = Array.isArray(parsed.results) ? parsed.results : [];
+      for (const item of results) {
+        if (
+          typeof item === "object" &&
+          item !== null &&
+          "path" in item &&
+          typeof item.path === "string"
+        ) {
+          paths.add(item.path);
+        }
+      }
+      totalPages =
+        typeof parsed.totalPages === "number" ? parsed.totalPages : page;
+      page += 1;
+    } while (page <= totalPages);
+    return [...paths].sort((a, b) => a.localeCompare(b));
+  }
+
+  async read(filePath: string): Promise<{
+    filePath: string;
+    content: string;
+    sha256: string;
+  }> {
+    const parsed = parseToolJson(
+      await this.callTool("obsidian_read_note", {
+        filePath,
+        format: "markdown",
+        includeStat: false,
+      }),
+    );
+    if (typeof parsed.content !== "string") {
+      throw new Error("The vault backend returned a non-Markdown note.");
+    }
+    return {
+      filePath,
+      content: parsed.content,
+      sha256: sha256Text(parsed.content),
+    };
+  }
+
+  async conditionalReplace(
+    filePath: string,
+    before: string,
+    after: string,
+    expectedSha256: string,
+  ): Promise<void> {
+    const parsed = parseToolJson(
+      await this.callTool("obsidian_search_replace", {
+        targetType: "filePath",
+        targetIdentifier: filePath,
+        replacements: [{ search: before, replace: after }],
+        useRegex: false,
+        caseSensitive: true,
+        replaceAll: false,
+        flexibleWhitespace: false,
+        wholeWord: false,
+        returnContent: false,
+        expectedSha256,
+      }),
+    );
+    if (parsed.success !== true) {
+      throw new Error("The conditional vault repair did not succeed.");
+    }
+  }
+}

--- a/src/services/externalReferences/canonicalReferenceParser.ts
+++ b/src/services/externalReferences/canonicalReferenceParser.ts
@@ -18,7 +18,7 @@ const TOKEN_PREFIX = "external-ref:";
 const ENCODED_SEPARATOR_PATTERN = /%(?:2f|5c)/iu;
 const PERCENT_ESCAPE_PATTERN = /%(?![0-9a-f]{2})/iu;
 const EXCLUDED_HEADING_PATTERN =
-  /^(?:historique|history|exemples?|examples?|changelog|journal des modifications|release notes?)\b/iu;
+  /^(?:historique|history|archives?|exemples?|examples?|changelog|journal des modifications|release notes?)\b/iu;
 
 export type ExternalReferenceClassification =
   | "reparable"

--- a/src/services/externalReferences/canonicalReferenceParser.ts
+++ b/src/services/externalReferences/canonicalReferenceParser.ts
@@ -1,0 +1,740 @@
+import { fileURLToPath } from "node:url";
+import type {
+  Content,
+  Heading,
+  InlineCode,
+  Link,
+  Parent,
+  PhrasingContent,
+  Root,
+} from "mdast";
+import type { Point, Position } from "unist";
+import { fromMarkdown } from "mdast-util-from-markdown";
+import { gfm } from "micromark-extension-gfm";
+import { gfmFromMarkdown } from "mdast-util-gfm";
+
+const ROOT_ID_PATTERN = /^[a-z0-9]+(?:[._-][a-z0-9]+)*$/u;
+const TOKEN_PREFIX = "external-ref:";
+const ENCODED_SEPARATOR_PATTERN = /%(?:2f|5c)/iu;
+const PERCENT_ESCAPE_PATTERN = /%(?![0-9a-f]{2})/iu;
+const EXCLUDED_HEADING_PATTERN =
+  /^(?:historique|history|exemples?|examples?|changelog|journal des modifications|release notes?)\b/iu;
+
+export type ExternalReferenceClassification =
+  | "reparable"
+  | "manualReview"
+  | "ignored";
+
+export interface SourcePoint {
+  line: number;
+  column: number;
+  offset: number;
+}
+
+export interface SourceRange {
+  start: SourcePoint;
+  end: SourcePoint;
+}
+
+export interface CanonicalExternalReferenceToken {
+  raw: string;
+  rootId: string;
+  relativePath: string;
+  encodedRelativePath: string;
+  range: SourceRange;
+}
+
+export interface ExternalFileLink {
+  url: string;
+  localPath: string;
+  range: SourceRange;
+  destinationRange: SourceRange;
+}
+
+export interface ExternalReferenceOccurrence {
+  classification: ExternalReferenceClassification;
+  reason:
+    | "canonical_pair"
+    | "excluded_section"
+    | "invalid_token"
+    | "invalid_file_uri"
+    | "missing_file_link"
+    | "missing_identity_token"
+    | "multiple_identity_tokens"
+    | "multiple_file_links"
+    | "basename_mismatch";
+  containerRange: SourceRange;
+  token?: CanonicalExternalReferenceToken;
+  fileLink?: ExternalFileLink;
+  detail?: string;
+}
+
+export interface ExternalReferenceScanResult {
+  occurrences: ExternalReferenceOccurrence[];
+  reparable: ExternalReferenceOccurrence[];
+  manualReview: ExternalReferenceOccurrence[];
+  ignored: ExternalReferenceOccurrence[];
+}
+
+export interface CanonicalExternalReferenceRepairTarget {
+  rootId: string;
+  relativePath: string;
+  fileUrl: string;
+}
+
+export interface CanonicalExternalReferenceTextEdit {
+  startOffset: number;
+  endOffset: number;
+  replacement: string;
+}
+
+interface ParsedToken {
+  token?: CanonicalExternalReferenceToken;
+  error?: string;
+  range: SourceRange;
+}
+
+interface ParsedLink {
+  link?: ExternalFileLink;
+  error?: string;
+  range: SourceRange;
+  url: string;
+}
+
+interface ExcludedRange {
+  start: number;
+  end: number;
+}
+
+function requirePoint(point: Point | undefined): SourcePoint {
+  if (
+    point?.offset === undefined ||
+    !Number.isInteger(point.line) ||
+    !Number.isInteger(point.column)
+  ) {
+    throw new Error("Markdown node is missing an exact source position.");
+  }
+  return {
+    line: point.line,
+    column: point.column,
+    offset: point.offset,
+  };
+}
+
+function requireRange(position: Position | undefined): SourceRange {
+  if (!position) {
+    throw new Error("Markdown node is missing an exact source range.");
+  }
+  return {
+    start: requirePoint(position.start),
+    end: requirePoint(position.end),
+  };
+}
+
+function pointAtOffset(source: string, offset: number): SourcePoint {
+  if (offset < 0 || offset > source.length) {
+    throw new Error("Source offset is outside the Markdown document.");
+  }
+  let line = 1;
+  let lineStart = 0;
+  for (let index = 0; index < offset; index += 1) {
+    if (source.charCodeAt(index) === 10) {
+      line += 1;
+      lineStart = index + 1;
+    }
+  }
+  return { line, column: offset - lineStart + 1, offset };
+}
+
+function sourceRangeFromOffsets(
+  source: string,
+  startOffset: number,
+  endOffset: number,
+): SourceRange {
+  return {
+    start: pointAtOffset(source, startOffset),
+    end: pointAtOffset(source, endOffset),
+  };
+}
+
+function normalizeHeading(value: string): string {
+  return value
+    .normalize("NFD")
+    .replace(/\p{M}+/gu, "")
+    .trim()
+    .toLowerCase();
+}
+
+function phrasingText(node: PhrasingContent): string {
+  if ("value" in node && typeof node.value === "string") {
+    return node.value;
+  }
+  if ("children" in node) {
+    return node.children.map(phrasingText).join("");
+  }
+  return "";
+}
+
+function headingText(heading: Heading): string {
+  return heading.children.map(phrasingText).join("");
+}
+
+function findFrontmatterRange(source: string): ExcludedRange | undefined {
+  const bomOffset = source.startsWith("\uFEFF") ? 1 : 0;
+  const firstLineEnd = source.indexOf("\n", bomOffset);
+  const firstLine =
+    firstLineEnd === -1
+      ? source.slice(bomOffset)
+      : source.slice(bomOffset, firstLineEnd).replace(/\r$/u, "");
+  if (firstLine !== "---") return undefined;
+
+  let cursor = firstLineEnd === -1 ? source.length : firstLineEnd + 1;
+  while (cursor < source.length) {
+    const lineEnd = source.indexOf("\n", cursor);
+    const end = lineEnd === -1 ? source.length : lineEnd;
+    const line = source.slice(cursor, end).replace(/\r$/u, "");
+    if (line === "---" || line === "...") {
+      return {
+        start: 0,
+        end: lineEnd === -1 ? source.length : lineEnd + 1,
+      };
+    }
+    cursor = lineEnd === -1 ? source.length : lineEnd + 1;
+  }
+  return undefined;
+}
+
+function findExcludedHeadingRanges(
+  root: Root,
+  sourceLength: number,
+): ExcludedRange[] {
+  const headings = root.children.filter(
+    (node): node is Heading => node.type === "heading",
+  );
+  const ranges: ExcludedRange[] = [];
+
+  for (let index = 0; index < headings.length; index += 1) {
+    const heading = headings[index];
+    if (
+      !EXCLUDED_HEADING_PATTERN.test(normalizeHeading(headingText(heading)))
+    ) {
+      continue;
+    }
+    const start = requireRange(heading.position).start.offset;
+    let end = sourceLength;
+    for (let next = index + 1; next < headings.length; next += 1) {
+      if (headings[next].depth <= heading.depth) {
+        end = requireRange(headings[next].position).start.offset;
+        break;
+      }
+    }
+    ranges.push({ start, end });
+  }
+  return ranges;
+}
+
+function isExcluded(
+  range: SourceRange,
+  excludedRanges: ExcludedRange[],
+): boolean {
+  return excludedRanges.some(
+    (excluded) =>
+      range.start.offset >= excluded.start && range.start.offset < excluded.end,
+  );
+}
+
+function parseCanonicalToken(node: InlineCode): ParsedToken {
+  const range = requireRange(node.position);
+  const raw = node.value;
+  if (!raw.startsWith(TOKEN_PREFIX)) {
+    return { range };
+  }
+
+  const identity = raw.slice(TOKEN_PREFIX.length);
+  const delimiterIndex = identity.indexOf("::");
+  if (
+    delimiterIndex <= 0 ||
+    identity.indexOf("::", delimiterIndex + 2) !== -1
+  ) {
+    return {
+      range,
+      error: "Expected external-ref:<rootId>::<encodedRelativePath>.",
+    };
+  }
+
+  const rootId = identity.slice(0, delimiterIndex);
+  const encodedRelativePath = identity.slice(delimiterIndex + 2);
+  if (!ROOT_ID_PATTERN.test(rootId)) {
+    return {
+      range,
+      error: "Root id is not a stable lowercase logical identifier.",
+    };
+  }
+  if (
+    encodedRelativePath.length === 0 ||
+    encodedRelativePath.startsWith("/") ||
+    encodedRelativePath.endsWith("/") ||
+    encodedRelativePath.includes("\\") ||
+    encodedRelativePath.includes("\0")
+  ) {
+    return {
+      range,
+      error: "Relative path must name one file below the logical root.",
+    };
+  }
+  if (
+    PERCENT_ESCAPE_PATTERN.test(encodedRelativePath) ||
+    ENCODED_SEPARATOR_PATTERN.test(encodedRelativePath)
+  ) {
+    return {
+      range,
+      error: "Relative path contains an invalid or encoded path separator.",
+    };
+  }
+
+  const encodedSegments = encodedRelativePath.split("/");
+  if (encodedSegments.some((segment) => segment.length === 0)) {
+    return { range, error: "Relative path contains an empty segment." };
+  }
+
+  const decodedSegments: string[] = [];
+  try {
+    for (const encodedSegment of encodedSegments) {
+      const decoded = decodeURIComponent(encodedSegment);
+      if (
+        decoded.length === 0 ||
+        decoded === "." ||
+        decoded === ".." ||
+        decoded.includes("/") ||
+        decoded.includes("\\") ||
+        decoded.includes("\0")
+      ) {
+        return {
+          range,
+          error: "Relative path contains traversal or a path separator.",
+        };
+      }
+      decodedSegments.push(decoded);
+    }
+  } catch {
+    return {
+      range,
+      error: "Relative path contains malformed percent encoding.",
+    };
+  }
+
+  const canonicalPath = decodedSegments.map(encodeURIComponent).join("/");
+  if (canonicalPath !== encodedRelativePath) {
+    return {
+      range,
+      error: `Relative path is not canonically encoded (expected ${canonicalPath}).`,
+    };
+  }
+
+  return {
+    range,
+    token: {
+      raw,
+      rootId,
+      relativePath: decodedSegments.join("/"),
+      encodedRelativePath,
+      range,
+    },
+  };
+}
+
+export function encodeCanonicalExternalReference(
+  rootId: string,
+  relativePath: string,
+): string {
+  if (!ROOT_ID_PATTERN.test(rootId)) {
+    throw new Error("Root id is not a stable lowercase logical identifier.");
+  }
+  if (
+    relativePath.length === 0 ||
+    relativePath.startsWith("/") ||
+    relativePath.endsWith("/") ||
+    relativePath.includes("\\") ||
+    relativePath.includes("\0")
+  ) {
+    throw new Error("Relative path must name one file below the logical root.");
+  }
+  const segments = relativePath.split("/");
+  for (const segment of segments) {
+    if (
+      segment.length === 0 ||
+      segment === "." ||
+      segment === ".." ||
+      segment.includes("/") ||
+      segment.includes("\\") ||
+      segment.includes("\0")
+    ) {
+      throw new Error("Relative path contains traversal or a path separator.");
+    }
+  }
+  return `${TOKEN_PREFIX}${rootId}::${segments.map(encodeURIComponent).join("/")}`;
+}
+
+function validateRawFileUri(rawUrl: string): string | undefined {
+  if (!rawUrl.toLowerCase().startsWith("file:")) {
+    return undefined;
+  }
+  if (
+    !/^file:\/\/\/(?!\/)/iu.test(rawUrl) ||
+    rawUrl.includes("\\") ||
+    rawUrl.includes("\0") ||
+    PERCENT_ESCAPE_PATTERN.test(rawUrl) ||
+    ENCODED_SEPARATOR_PATTERN.test(rawUrl)
+  ) {
+    throw new Error("File URI contains an invalid path encoding.");
+  }
+
+  const withoutQuery = rawUrl.split(/[?#]/u, 1)[0];
+  const pathPart = withoutQuery.replace(/^file:\/\/[^/]*\/?/iu, "");
+  for (const segment of pathPart.split("/")) {
+    if (segment.length === 0) continue;
+    const decoded = decodeURIComponent(segment);
+    if (
+      decoded === "." ||
+      decoded === ".." ||
+      decoded.includes("\\") ||
+      decoded.includes("\0")
+    ) {
+      throw new Error("File URI contains traversal or an unsafe segment.");
+    }
+  }
+  return rawUrl;
+}
+
+function findLinkDestinationRange(source: string, node: Link): SourceRange {
+  const range = requireRange(node.position);
+  const markdown = source.slice(range.start.offset, range.end.offset);
+  let relativeStart = -1;
+
+  if (markdown.startsWith("<") && markdown.endsWith(">")) {
+    relativeStart = markdown.indexOf(node.url, 1);
+  } else {
+    const opener = markdown.lastIndexOf("](");
+    if (opener !== -1) {
+      const destinationAreaStart = opener + 2;
+      relativeStart = markdown.indexOf(node.url, destinationAreaStart);
+    }
+  }
+  if (relativeStart === -1) {
+    throw new Error("Could not locate the exact Markdown link destination.");
+  }
+  const startOffset = range.start.offset + relativeStart;
+  return sourceRangeFromOffsets(
+    source,
+    startOffset,
+    startOffset + node.url.length,
+  );
+}
+
+function parseFileLink(source: string, node: Link): ParsedLink | undefined {
+  const range = requireRange(node.position);
+  if (!node.url.toLowerCase().startsWith("file:")) return undefined;
+
+  try {
+    validateRawFileUri(node.url);
+    const url = new URL(node.url);
+    if (url.protocol !== "file:") {
+      return undefined;
+    }
+    if (url.hostname !== "") {
+      throw new Error("Hosted and UNC file URIs are not supported.");
+    }
+    if (url.pathname.startsWith("//")) {
+      throw new Error("UNC file paths are not supported.");
+    }
+    if (url.search || url.hash) {
+      throw new Error("File URI query strings and fragments are ambiguous.");
+    }
+    if (url.pathname.endsWith("/")) {
+      throw new Error("Canonical references can target files only.");
+    }
+    const localPath = fileURLToPath(url);
+    const destinationRange = findLinkDestinationRange(source, node);
+    return {
+      range,
+      url: node.url,
+      link: { url: node.url, localPath, range, destinationRange },
+    };
+  } catch (error) {
+    return {
+      range,
+      url: node.url,
+      error: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+function basename(value: string): string {
+  const parts = value.replace(/\\/gu, "/").split("/");
+  return parts.at(-1) ?? "";
+}
+
+function visitParents(
+  node: Root | Content,
+  callback: (node: Parent) => void,
+): void {
+  if (!("children" in node)) return;
+  callback(node);
+  for (const child of node.children) {
+    visitParents(child, callback);
+  }
+}
+
+function scanContainer(
+  source: string,
+  container: Parent,
+  excludedRanges: ExcludedRange[],
+): ExternalReferenceOccurrence[] {
+  const containerRange = requireRange(container.position);
+  const tokens: ParsedToken[] = [];
+  const links: ParsedLink[] = [];
+
+  for (const child of container.children) {
+    if (child.type === "inlineCode") {
+      const parsed = parseCanonicalToken(child);
+      if (parsed.token || parsed.error) tokens.push(parsed);
+    } else if (child.type === "link") {
+      const parsed = parseFileLink(source, child);
+      if (parsed) links.push(parsed);
+    }
+  }
+  if (tokens.length === 0 && links.length === 0) return [];
+
+  if (isExcluded(containerRange, excludedRanges)) {
+    return [
+      {
+        classification: "ignored",
+        reason: "excluded_section",
+        containerRange,
+        token: tokens.length === 1 ? tokens[0].token : undefined,
+        fileLink: links.length === 1 ? links[0].link : undefined,
+      },
+    ];
+  }
+
+  if (tokens.length > 1) {
+    return [
+      {
+        classification: "manualReview",
+        reason: "multiple_identity_tokens",
+        containerRange,
+        detail: `Found ${tokens.length} external identity tokens.`,
+      },
+    ];
+  }
+  if (links.length > 1) {
+    return [
+      {
+        classification: "manualReview",
+        reason: "multiple_file_links",
+        containerRange,
+        token: tokens[0]?.token,
+        detail: `Found ${links.length} file links.`,
+      },
+    ];
+  }
+
+  const parsedToken = tokens[0];
+  const parsedLink = links[0];
+  if (parsedToken?.error) {
+    return [
+      {
+        classification: "manualReview",
+        reason: "invalid_token",
+        containerRange,
+        fileLink: parsedLink?.link,
+        detail: parsedToken.error,
+      },
+    ];
+  }
+  if (parsedLink?.error) {
+    return [
+      {
+        classification: "manualReview",
+        reason: "invalid_file_uri",
+        containerRange,
+        token: parsedToken?.token,
+        detail: parsedLink.error,
+      },
+    ];
+  }
+  if (!parsedToken?.token) {
+    return [
+      {
+        classification: "manualReview",
+        reason: "missing_identity_token",
+        containerRange,
+        fileLink: parsedLink?.link,
+      },
+    ];
+  }
+  if (!parsedLink?.link) {
+    return [
+      {
+        classification: "manualReview",
+        reason: "missing_file_link",
+        containerRange,
+        token: parsedToken.token,
+      },
+    ];
+  }
+  if (
+    basename(parsedToken.token.relativePath) !==
+    basename(parsedLink.link.localPath)
+  ) {
+    return [
+      {
+        classification: "manualReview",
+        reason: "basename_mismatch",
+        containerRange,
+        token: parsedToken.token,
+        fileLink: parsedLink.link,
+      },
+    ];
+  }
+
+  return [
+    {
+      classification: "reparable",
+      reason: "canonical_pair",
+      containerRange,
+      token: parsedToken.token,
+      fileLink: parsedLink.link,
+    },
+  ];
+}
+
+/**
+ * Scans Markdown without resolving a logical root to a physical directory.
+ *
+ * A result marked `reparable` is syntactically unambiguous only. The caller
+ * must still resolve the root, verify containment and revalidate the note
+ * before applying a repair.
+ */
+export function scanCanonicalExternalReferences(
+  source: string,
+): ExternalReferenceScanResult {
+  const root = fromMarkdown(source, {
+    extensions: [gfm()],
+    mdastExtensions: [gfmFromMarkdown()],
+  });
+  const excludedRanges = findExcludedHeadingRanges(root, source.length);
+  const frontmatterRange = findFrontmatterRange(source);
+  if (frontmatterRange) excludedRanges.push(frontmatterRange);
+
+  const occurrences: ExternalReferenceOccurrence[] = [];
+  visitParents(root, (node) => {
+    if (node.type !== "paragraph") return;
+    occurrences.push(...scanContainer(source, node, excludedRanges));
+  });
+
+  return {
+    occurrences,
+    reparable: occurrences.filter(
+      (occurrence) => occurrence.classification === "reparable",
+    ),
+    manualReview: occurrences.filter(
+      (occurrence) => occurrence.classification === "manualReview",
+    ),
+    ignored: occurrences.filter(
+      (occurrence) => occurrence.classification === "ignored",
+    ),
+  };
+}
+
+/**
+ * Builds exact, non-overlapping Markdown edits for an already reparable
+ * occurrence. This helper deliberately does not resolve a logical root.
+ * Callers must first prove that the old physical URI is the resolved
+ * rootId/relativePath target, then revalidate the note before applying edits.
+ */
+export function buildCanonicalExternalReferenceRepairEdits(
+  source: string,
+  occurrence: ExternalReferenceOccurrence,
+  target: CanonicalExternalReferenceRepairTarget,
+): CanonicalExternalReferenceTextEdit[] {
+  if (
+    occurrence.classification !== "reparable" ||
+    !occurrence.token ||
+    !occurrence.fileLink
+  ) {
+    throw new Error(
+      "Only a reparable canonical pair can produce repair edits.",
+    );
+  }
+  assertRangeMatchesSource(source, occurrence.token.range);
+  assertRangeMatchesSource(source, occurrence.fileLink.destinationRange);
+
+  const encodedToken = encodeCanonicalExternalReference(
+    target.rootId,
+    target.relativePath,
+  );
+  validateRawFileUri(target.fileUrl);
+  const targetUrl = new URL(target.fileUrl);
+  if (
+    targetUrl.protocol !== "file:" ||
+    targetUrl.hostname !== "" ||
+    targetUrl.search ||
+    targetUrl.hash ||
+    targetUrl.pathname.endsWith("/")
+  ) {
+    throw new Error("Repair target must be one local file URI without extras.");
+  }
+  const targetLocalPath = fileURLToPath(targetUrl);
+  if (basename(target.relativePath) !== basename(targetLocalPath)) {
+    throw new Error("Repair target token and file URI basenames do not match.");
+  }
+
+  return [
+    {
+      startOffset: occurrence.fileLink.destinationRange.start.offset,
+      endOffset: occurrence.fileLink.destinationRange.end.offset,
+      replacement: target.fileUrl,
+    },
+    {
+      startOffset: occurrence.token.range.start.offset,
+      endOffset: occurrence.token.range.end.offset,
+      replacement: `\`${encodedToken}\``,
+    },
+  ].sort((left, right) => right.startOffset - left.startOffset);
+}
+
+function assertRangeMatchesSource(source: string, range: SourceRange): void {
+  if (
+    range.start.offset < 0 ||
+    range.end.offset < range.start.offset ||
+    range.end.offset > source.length
+  ) {
+    throw new Error("Occurrence range no longer matches the Markdown source.");
+  }
+}
+
+export function applyCanonicalExternalReferenceRepair(
+  source: string,
+  occurrence: ExternalReferenceOccurrence,
+  target: CanonicalExternalReferenceRepairTarget,
+): string {
+  const edits = buildCanonicalExternalReferenceRepairEdits(
+    source,
+    occurrence,
+    target,
+  );
+  let updated = source;
+  for (const edit of edits) {
+    updated =
+      updated.slice(0, edit.startOffset) +
+      edit.replacement +
+      updated.slice(edit.endOffset);
+  }
+  return updated;
+}
+
+export const canonicalExternalReference = {
+  rootIdPattern: ROOT_ID_PATTERN,
+  tokenPrefix: TOKEN_PREFIX,
+};

--- a/src/services/externalReferences/externalMoveCoordinator.ts
+++ b/src/services/externalReferences/externalMoveCoordinator.ts
@@ -800,10 +800,11 @@ export class ExternalMoveCoordinator {
             occurrence.token?.rootId !== snapshot.rootId ||
             occurrence.token.relativePath !== snapshot.sourceRelativePath ||
             !occurrence.fileLink ||
-            !samePhysicalPath(
-              occurrence.fileLink.localPath,
-              location.absolutePath,
-            ),
+            (occurrence.fileLink.url !== oldFileUri &&
+              !samePhysicalPath(
+                occurrence.fileLink.localPath,
+                location.absolutePath,
+              )),
         )
       ) {
         manualReview.push({

--- a/src/services/externalReferences/externalMoveCoordinator.ts
+++ b/src/services/externalReferences/externalMoveCoordinator.ts
@@ -1,0 +1,529 @@
+import path from "node:path";
+import {
+  ExternalRootError,
+  type ExternalMoveSnapshot,
+  ExternalRootsService,
+} from "../externalRootsService.js";
+import { assertWriteAllowed } from "../writePolicy.js";
+import { config } from "../../config/index.js";
+import { BackendVaultAdapter, sha256Text } from "./backendVaultAdapter.js";
+import {
+  ExternalMoveJournal,
+  type ExternalMovePlan,
+  type ExternalNoteRepair,
+} from "./externalMoveJournal.js";
+import {
+  encodeCanonicalExternalReference,
+  scanCanonicalExternalReferences,
+  type ExternalReferenceOccurrence,
+} from "./canonicalReferenceParser.js";
+
+export function externalReferenceToken(
+  rootId: string,
+  relativePath: string,
+): string {
+  return encodeCanonicalExternalReference(rootId, relativePath);
+}
+
+function occurrenceMentionsSource(
+  occurrence: ExternalReferenceOccurrence,
+  rootId: string,
+  relativePath: string,
+  oldFileUri: string,
+  sourceAbsolutePath: string,
+): boolean {
+  const samePhysicalPath =
+    occurrence.fileLink &&
+    path.normalize(occurrence.fileLink.localPath).toLowerCase() ===
+      path.normalize(sourceAbsolutePath).toLowerCase();
+  return (
+    (occurrence.token?.rootId === rootId &&
+      occurrence.token.relativePath === relativePath) ||
+    occurrence.fileLink?.url === oldFileUri ||
+    Boolean(samePhysicalPath)
+  );
+}
+
+function replaceOccurrence(
+  content: string,
+  occurrence: ExternalReferenceOccurrence,
+  sourceToken: string,
+  targetToken: string,
+  oldFileUri: string,
+  newFileUri: string,
+): string {
+  const start = occurrence.containerRange.start.offset;
+  const end = occurrence.containerRange.end.offset;
+  const original = content.slice(start, end);
+  const uriCount = original.split(oldFileUri).length - 1;
+  const tokenCount = original.split(sourceToken).length - 1;
+  if (uriCount !== 1 || tokenCount !== 1) {
+    throw new ExternalRootError(
+      "non_verifiable",
+      "A canonical external reference is no longer uniquely repairable.",
+    );
+  }
+  const replacement = original
+    .replace(oldFileUri, newFileUri)
+    .replace(sourceToken, targetToken);
+  return content.slice(0, start) + replacement + content.slice(end);
+}
+
+function publicPlan(plan: ExternalMovePlan): Record<string, unknown> {
+  return {
+    planId: plan.planId,
+    idempotencyKey: plan.idempotencyKey,
+    createdAt: plan.createdAt,
+    updatedAt: plan.updatedAt,
+    status: plan.status,
+    rootId: plan.snapshot.rootId,
+    sourceRelativePath: plan.snapshot.sourceRelativePath,
+    targetRelativePath: plan.snapshot.targetRelativePath,
+    sourceSha256: plan.snapshot.sha256,
+    sourceSize: plan.snapshot.size,
+    repairs: plan.repairs.map((repair) => ({
+      filePath: repair.filePath,
+      expectedSha256: repair.expectedSha256,
+    })),
+    manualReview: plan.manualReview,
+    readyToApply: plan.manualReview.length === 0,
+    failure: plan.failure,
+  };
+}
+
+function protectedFrontmatterLines(content: string): Map<string, string> {
+  const lines = content.split(/\r?\n/u);
+  if (lines[0]?.replace(/^\uFEFF/u, "") !== "---") return new Map();
+  const result = new Map<string, string>();
+  for (let index = 1; index < lines.length; index += 1) {
+    if (lines[index] === "---" || lines[index] === "...") break;
+    const match = /^(création|modification):(.*)$/u.exec(lines[index]);
+    if (match) result.set(match[1], lines[index]);
+  }
+  return result;
+}
+
+function normalizeProtectedFrontmatter(content: string): string {
+  const lines = content.split(/\r?\n/u);
+  if (lines[0]?.replace(/^\uFEFF/u, "") !== "---") return content;
+  for (let index = 1; index < lines.length; index += 1) {
+    if (lines[index] === "---" || lines[index] === "...") break;
+    if (/^(création|modification):/u.test(lines[index])) {
+      lines.splice(index, 1);
+      index -= 1;
+    }
+  }
+  return lines.join(content.includes("\r\n") ? "\r\n" : "\n");
+}
+
+function preserveCurrentProtectedFrontmatter(
+  template: string,
+  current: string,
+): string {
+  const currentLines = protectedFrontmatterLines(current);
+  if (currentLines.size === 0) return template;
+  const lines = template.split(/\r?\n/u);
+  if (lines[0]?.replace(/^\uFEFF/u, "") !== "---") return template;
+  for (let index = 1; index < lines.length; index += 1) {
+    if (lines[index] === "---" || lines[index] === "...") {
+      for (const [key, value] of currentLines) {
+        if (!lines.some((line) => line.startsWith(`${key}:`))) {
+          lines.splice(index, 0, value);
+          index += 1;
+        }
+      }
+      break;
+    }
+    const match = /^(création|modification):/u.exec(lines[index]);
+    if (match && currentLines.has(match[1])) {
+      lines[index] = currentLines.get(match[1])!;
+    }
+  }
+  return lines.join(template.includes("\r\n") ? "\r\n" : "\n");
+}
+
+export class ExternalMoveCoordinator {
+  constructor(
+    private readonly roots: ExternalRootsService,
+    private readonly vault: BackendVaultAdapter,
+    private readonly journal: ExternalMoveJournal,
+  ) {}
+
+  async scan(
+    rootId: string,
+    relativePath: string,
+    searchInPath = "",
+  ): Promise<Record<string, unknown>> {
+    const snapshot = await this.roots.inspectMoveSource(rootId, relativePath);
+    return this.inventory(snapshot, searchInPath);
+  }
+
+  async plan(input: {
+    rootId: string;
+    sourceRelativePath: string;
+    targetRelativePath: string;
+    searchInPath?: string;
+    idempotencyKey: string;
+  }): Promise<Record<string, unknown>> {
+    const existing = this.journal.getByIdempotencyKey(input.idempotencyKey);
+    if (existing) {
+      const sameRequest =
+        existing.snapshot.rootId === input.rootId &&
+        existing.snapshot.sourceRelativePath === input.sourceRelativePath &&
+        existing.snapshot.targetRelativePath === input.targetRelativePath;
+      if (!sameRequest) {
+        throw new ExternalRootError(
+          "precondition_failed",
+          "The idempotency key is already bound to another external move.",
+        );
+      }
+      return publicPlan(existing);
+    }
+
+    const snapshot = await this.roots.planMove(
+      input.rootId,
+      input.sourceRelativePath,
+      input.targetRelativePath,
+    );
+    const locations = await this.roots.getPrivateMoveLocations(snapshot);
+    const sourceToken = externalReferenceToken(
+      snapshot.rootId,
+      snapshot.sourceRelativePath,
+    );
+    const targetToken = externalReferenceToken(
+      snapshot.rootId,
+      snapshot.targetRelativePath,
+    );
+    const inventory = await this.inventoryInternal(
+      snapshot,
+      input.searchInPath ?? "",
+      locations.sourceFileUri,
+      locations.targetFileUri,
+      sourceToken,
+      targetToken,
+    );
+    const plan = this.journal.create({
+      idempotencyKey: input.idempotencyKey,
+      snapshot,
+      sourceToken,
+      targetToken,
+      oldFileUri: locations.sourceFileUri,
+      newFileUri: locations.targetFileUri,
+      repairs: inventory.repairs,
+      manualReview: inventory.manualReview,
+    });
+    return publicPlan(plan);
+  }
+
+  status(planId: string): Record<string, unknown> {
+    const plan = this.journal.get(planId);
+    if (!plan) {
+      throw new ExternalRootError("not_found", "Unknown external move plan.");
+    }
+    return publicPlan(plan);
+  }
+
+  async apply(
+    planId: string,
+    idempotencyKey: string,
+  ): Promise<Record<string, unknown>> {
+    const plan = this.requirePlan(planId, idempotencyKey);
+    if (plan.status === "applied") return publicPlan(plan);
+    if (plan.status !== "planned" && plan.status !== "rolled_back") {
+      throw new ExternalRootError(
+        "precondition_failed",
+        `External move plan is ${plan.status}, not applicable.`,
+      );
+    }
+    if (!config.externalMoveEnabled) {
+      throw new ExternalRootError(
+        "capability_denied",
+        "External move apply is disabled by MCP_EXTERNAL_MOVE_ENABLED.",
+      );
+    }
+    assertWriteAllowed({
+      operation: "external_move_apply",
+      action: "apply",
+      destructive: true,
+    });
+    if (plan.manualReview.length > 0) {
+      throw new ExternalRootError(
+        "precondition_failed",
+        "Ambiguous or historical references require manual review before apply.",
+      );
+    }
+
+    for (const repair of plan.repairs) {
+      const current = await this.vault.read(repair.filePath);
+      if (current.sha256 !== repair.expectedSha256) {
+        throw new ExternalRootError(
+          "precondition_failed",
+          `ÉLYSIA note changed after planning: ${repair.filePath}`,
+        );
+      }
+    }
+
+    this.journal.transition(
+      plan.planId,
+      ["planned", "rolled_back"],
+      "applying",
+    );
+    const appliedRepairs: ExternalNoteRepair[] = [];
+    let fileMoved = false;
+    try {
+      await this.roots.applyMove(plan.snapshot);
+      fileMoved = true;
+      for (const repair of plan.repairs) {
+        await this.vault.conditionalReplace(
+          repair.filePath,
+          repair.before,
+          repair.after,
+          repair.expectedSha256,
+        );
+        appliedRepairs.push(repair);
+      }
+      const committed = this.journal.update(plan.planId, "applied");
+      return publicPlan(committed);
+    } catch (error) {
+      for (const repair of appliedRepairs.reverse()) {
+        await this.rollbackNoteRepair(repair).catch(() => undefined);
+      }
+      if (fileMoved) {
+        await this.roots.rollbackMove(plan.snapshot).catch(() => undefined);
+      }
+      this.journal.update(
+        plan.planId,
+        "failed",
+        error instanceof Error ? error.message : "Apply failed.",
+      );
+      throw error;
+    }
+  }
+
+  async rollback(
+    planId: string,
+    idempotencyKey: string,
+  ): Promise<Record<string, unknown>> {
+    const plan = this.requirePlan(planId, idempotencyKey);
+    if (plan.status === "rolled_back") return publicPlan(plan);
+    if (plan.status !== "applied") {
+      throw new ExternalRootError(
+        "precondition_failed",
+        `External move plan is ${plan.status}, not rollbackable.`,
+      );
+    }
+    if (!config.externalMoveEnabled) {
+      throw new ExternalRootError(
+        "capability_denied",
+        "External move rollback is disabled by MCP_EXTERNAL_MOVE_ENABLED.",
+      );
+    }
+    assertWriteAllowed({
+      operation: "external_move_rollback",
+      action: "rollback",
+      destructive: true,
+    });
+    const rollbackContents = new Map<
+      string,
+      { current: string; restored: string }
+    >();
+    for (const repair of plan.repairs) {
+      const current = await this.vault.read(repair.filePath);
+      if (
+        normalizeProtectedFrontmatter(current.content) !==
+        normalizeProtectedFrontmatter(repair.after)
+      ) {
+        throw new ExternalRootError(
+          "precondition_failed",
+          `ÉLYSIA note changed after the move: ${repair.filePath}`,
+        );
+      }
+      rollbackContents.set(repair.filePath, {
+        current: current.content,
+        restored: preserveCurrentProtectedFrontmatter(
+          repair.before,
+          current.content,
+        ),
+      });
+    }
+    this.journal.transition(plan.planId, ["applied"], "rolling_back");
+    await this.roots.rollbackMove(plan.snapshot);
+    for (const repair of [...plan.repairs].reverse()) {
+      const rollback = rollbackContents.get(repair.filePath)!;
+      await this.vault.conditionalReplace(
+        repair.filePath,
+        rollback.current,
+        rollback.restored,
+        sha256Text(rollback.current),
+      );
+    }
+    return publicPlan(this.journal.update(plan.planId, "rolled_back"));
+  }
+
+  private requirePlan(
+    planId: string,
+    idempotencyKey: string,
+  ): ExternalMovePlan {
+    const plan = this.journal.get(planId);
+    if (!plan || plan.idempotencyKey !== idempotencyKey) {
+      throw new ExternalRootError(
+        "precondition_failed",
+        "External move plan and idempotency key do not match.",
+      );
+    }
+    return plan;
+  }
+
+  private async rollbackNoteRepair(repair: ExternalNoteRepair): Promise<void> {
+    const current = await this.vault.read(repair.filePath);
+    if (
+      normalizeProtectedFrontmatter(current.content) !==
+      normalizeProtectedFrontmatter(repair.after)
+    ) {
+      throw new ExternalRootError(
+        "precondition_failed",
+        `ÉLYSIA note changed during rollback: ${repair.filePath}`,
+      );
+    }
+    await this.vault.conditionalReplace(
+      repair.filePath,
+      current.content,
+      preserveCurrentProtectedFrontmatter(repair.before, current.content),
+      current.sha256,
+    );
+  }
+
+  private async inventory(
+    snapshot: ExternalMoveSnapshot,
+    searchInPath: string,
+  ): Promise<Record<string, unknown>> {
+    const location = await this.roots.getPrivateReferenceLocation(
+      snapshot.rootId,
+      snapshot.sourceRelativePath,
+    );
+    const sourceToken = externalReferenceToken(
+      snapshot.rootId,
+      snapshot.sourceRelativePath,
+    );
+    const inventory = await this.inventoryInternal(
+      snapshot,
+      searchInPath,
+      location.fileUri,
+      location.fileUri,
+      sourceToken,
+      sourceToken,
+    );
+    return {
+      rootId: snapshot.rootId,
+      relativePath: snapshot.sourceRelativePath,
+      sourceSha256: snapshot.sha256,
+      reparable: inventory.repairs.map((item) => ({
+        filePath: item.filePath,
+        expectedSha256: item.expectedSha256,
+      })),
+      manualReview: inventory.manualReview,
+      completeForCanonicalContract: true,
+    };
+  }
+
+  private async inventoryInternal(
+    snapshot: ExternalMoveSnapshot,
+    searchInPath: string,
+    oldFileUri: string,
+    newFileUri: string,
+    sourceToken: string,
+    targetToken: string,
+  ): Promise<{
+    repairs: ExternalNoteRepair[];
+    manualReview: Array<{ filePath: string; reason: string }>;
+  }> {
+    const location = await this.roots.getPrivateReferenceLocation(
+      snapshot.rootId,
+      snapshot.sourceRelativePath,
+    );
+    const candidatePaths = new Set<string>();
+    for (const query of [
+      sourceToken,
+      oldFileUri,
+      location.absolutePath,
+      path.basename(location.absolutePath),
+    ]) {
+      for (const filePath of await this.vault.searchPaths(
+        query,
+        searchInPath,
+      )) {
+        candidatePaths.add(filePath);
+      }
+    }
+
+    const repairs: ExternalNoteRepair[] = [];
+    const manualReview: Array<{ filePath: string; reason: string }> = [];
+    for (const filePath of [...candidatePaths].sort((a, b) =>
+      a.localeCompare(b),
+    )) {
+      const note = await this.vault.read(filePath);
+      const scan = scanCanonicalExternalReferences(note.content);
+      const mentioned = scan.occurrences.filter((occurrence) =>
+        occurrenceMentionsSource(
+          occurrence,
+          snapshot.rootId,
+          snapshot.sourceRelativePath,
+          oldFileUri,
+          location.absolutePath,
+        ),
+      );
+      if (mentioned.length === 0) {
+        if (
+          note.content.includes(oldFileUri) ||
+          note.content
+            .toLowerCase()
+            .includes(location.absolutePath.toLowerCase())
+        ) {
+          manualReview.push({
+            filePath,
+            reason:
+              "Legacy or unsupported occurrence contains the physical path.",
+          });
+        }
+        continue;
+      }
+      if (
+        mentioned.some(
+          (occurrence) =>
+            occurrence.classification !== "reparable" ||
+            occurrence.token?.rootId !== snapshot.rootId ||
+            occurrence.token.relativePath !== snapshot.sourceRelativePath ||
+            occurrence.fileLink?.url !== oldFileUri,
+        )
+      ) {
+        manualReview.push({
+          filePath,
+          reason:
+            "Reference is ambiguous, historical, or not an exact canonical pair.",
+        });
+        continue;
+      }
+      let after = note.content;
+      const descending = [...mentioned].sort(
+        (a, b) => b.containerRange.start.offset - a.containerRange.start.offset,
+      );
+      for (const occurrence of descending) {
+        after = replaceOccurrence(
+          after,
+          occurrence,
+          sourceToken,
+          targetToken,
+          oldFileUri,
+          newFileUri,
+        );
+      }
+      repairs.push({
+        filePath,
+        expectedSha256: note.sha256,
+        before: note.content,
+        after,
+      });
+    }
+    return { repairs, manualReview };
+  }
+}

--- a/src/services/externalReferences/externalMoveCoordinator.ts
+++ b/src/services/externalReferences/externalMoveCoordinator.ts
@@ -747,13 +747,17 @@ export class ExternalMoveCoordinator {
       snapshot.sourceRelativePath,
     );
     const candidatePaths = new Set<string>();
-    for (const query of [
-      sourceToken,
-      oldFileUri,
-      location.absolutePath,
-      path.basename(location.absolutePath),
+    for (const candidate of [
+      { query: sourceToken, caseSensitive: true },
+      { query: oldFileUri, caseSensitive: false },
+      { query: location.absolutePath, caseSensitive: false },
+      { query: path.basename(location.absolutePath), caseSensitive: false },
     ]) {
-      for (const filePath of await this.vault.searchPaths(query)) {
+      for (const filePath of await this.vault.searchPaths(
+        candidate.query,
+        "",
+        candidate.caseSensitive,
+      )) {
         candidatePaths.add(filePath);
       }
     }

--- a/src/services/externalReferences/externalMoveCoordinator.ts
+++ b/src/services/externalReferences/externalMoveCoordinator.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import path from "node:path";
 import {
   ExternalRootError,
@@ -25,6 +26,14 @@ export function externalReferenceToken(
   return encodeCanonicalExternalReference(rootId, relativePath);
 }
 
+function samePhysicalPath(left: string, right: string): boolean {
+  const normalizedLeft = path.normalize(left);
+  const normalizedRight = path.normalize(right);
+  return process.platform === "win32"
+    ? normalizedLeft.toLowerCase() === normalizedRight.toLowerCase()
+    : normalizedLeft === normalizedRight;
+}
+
 function occurrenceMentionsSource(
   occurrence: ExternalReferenceOccurrence,
   rootId: string,
@@ -32,15 +41,14 @@ function occurrenceMentionsSource(
   oldFileUri: string,
   sourceAbsolutePath: string,
 ): boolean {
-  const samePhysicalPath =
+  const physicalPathMatches =
     occurrence.fileLink &&
-    path.normalize(occurrence.fileLink.localPath).toLowerCase() ===
-      path.normalize(sourceAbsolutePath).toLowerCase();
+    samePhysicalPath(occurrence.fileLink.localPath, sourceAbsolutePath);
   return (
     (occurrence.token?.rootId === rootId &&
       occurrence.token.relativePath === relativePath) ||
     occurrence.fileLink?.url === oldFileUri ||
-    Boolean(samePhysicalPath)
+    Boolean(physicalPathMatches)
   );
 }
 
@@ -49,13 +57,20 @@ function replaceOccurrence(
   occurrence: ExternalReferenceOccurrence,
   sourceToken: string,
   targetToken: string,
-  oldFileUri: string,
+  _oldFileUri: string,
   newFileUri: string,
 ): string {
   const start = occurrence.containerRange.start.offset;
   const end = occurrence.containerRange.end.offset;
   const original = content.slice(start, end);
-  const uriCount = original.split(oldFileUri).length - 1;
+  const sourceFileUri = occurrence.fileLink?.url;
+  if (!sourceFileUri) {
+    throw new ExternalRootError(
+      "non_verifiable",
+      "A canonical external reference no longer has a file locator.",
+    );
+  }
+  const uriCount = original.split(sourceFileUri).length - 1;
   const tokenCount = original.split(sourceToken).length - 1;
   if (uriCount !== 1 || tokenCount !== 1) {
     throw new ExternalRootError(
@@ -64,12 +79,15 @@ function replaceOccurrence(
     );
   }
   const replacement = original
-    .replace(oldFileUri, newFileUri)
+    .replace(sourceFileUri, newFileUri)
     .replace(sourceToken, targetToken);
   return content.slice(0, start) + replacement + content.slice(end);
 }
 
 function publicPlan(plan: ExternalMovePlan): Record<string, unknown> {
+  const recoveryRequired =
+    plan.status === "recovery_required" ||
+    (plan.recoveryErrors?.length ?? 0) > 0;
   return {
     planId: plan.planId,
     idempotencyKey: plan.idempotencyKey,
@@ -81,14 +99,92 @@ function publicPlan(plan: ExternalMovePlan): Record<string, unknown> {
     targetRelativePath: plan.snapshot.targetRelativePath,
     sourceSha256: plan.snapshot.sha256,
     sourceSize: plan.snapshot.size,
+    inventoryDigest: plan.inventoryDigest,
+    bindingFingerprint: plan.bindingIdentity?.bindingFingerprint,
+    bindingVerifiable: plan.bindingIdentity?.verifiable ?? false,
     repairs: plan.repairs.map((repair) => ({
       filePath: repair.filePath,
       expectedSha256: repair.expectedSha256,
     })),
     manualReview: plan.manualReview,
     readyToApply: plan.manualReview.length === 0,
+    recoveryRequired,
+    recoveryErrors: plan.recoveryErrors ?? [],
+    appliedRepairCount: plan.appliedRepairPaths?.length ?? 0,
+    restoredRepairCount: plan.restoredRepairPaths?.length ?? 0,
+    nextAction:
+      plan.status === "planned" || plan.status === "rolled_back"
+        ? "apply"
+        : plan.status === "applied"
+          ? "rollback"
+          : plan.status === "failed_compensated"
+            ? "rollback"
+            : recoveryRequired ||
+                [
+                  "applying",
+                  "applying_file",
+                  "file_moved",
+                  "applying_repairs",
+                  "rolling_back",
+                  "rolling_back_repairs",
+                  "rolling_back_file",
+                  "failed",
+                ].includes(plan.status)
+              ? "rollback"
+              : "none",
     failure: plan.failure,
   };
+}
+
+type Inventory = {
+  repairs: ExternalNoteRepair[];
+  manualReview: Array<{ filePath: string; reason: string }>;
+  candidatePaths: string[];
+};
+
+type FilePlacement = "source" | "target" | "both" | "missing_or_changed";
+
+function inventoryDigest(inventory: Inventory): string {
+  const payload = {
+    candidatePaths: [...inventory.candidatePaths].sort((left, right) =>
+      left.localeCompare(right),
+    ),
+    repairs: inventory.repairs
+      .map((repair) => ({
+        filePath: repair.filePath,
+        expectedSha256: repair.expectedSha256,
+        afterSha256: sha256Text(repair.after),
+      }))
+      .sort((left, right) => left.filePath.localeCompare(right.filePath)),
+    manualReview: inventory.manualReview
+      .map((item) => ({ filePath: item.filePath, reason: item.reason }))
+      .sort(
+        (left, right) =>
+          left.filePath.localeCompare(right.filePath) ||
+          left.reason.localeCompare(right.reason),
+      ),
+  };
+  return createHash("sha256")
+    .update(JSON.stringify(payload), "utf8")
+    .digest("hex");
+}
+
+function snapshotsMatch(
+  left: ExternalMoveSnapshot,
+  right: ExternalMoveSnapshot,
+): boolean {
+  return (
+    left.rootId === right.rootId &&
+    left.sourceRelativePath === right.sourceRelativePath &&
+    left.targetRelativePath === right.targetRelativePath &&
+    left.size === right.size &&
+    left.modifiedAt === right.modifiedAt &&
+    left.sha256 === right.sha256
+  );
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
 }
 
 function protectedFrontmatterLines(content: string): Map<string, string> {
@@ -152,17 +248,16 @@ export class ExternalMoveCoordinator {
   async scan(
     rootId: string,
     relativePath: string,
-    searchInPath = "",
   ): Promise<Record<string, unknown>> {
+    await this.vault.refreshInventory();
     const snapshot = await this.roots.inspectMoveSource(rootId, relativePath);
-    return this.inventory(snapshot, searchInPath);
+    return this.inventory(snapshot);
   }
 
   async plan(input: {
     rootId: string;
     sourceRelativePath: string;
     targetRelativePath: string;
-    searchInPath?: string;
     idempotencyKey: string;
   }): Promise<Record<string, unknown>> {
     const existing = this.journal.getByIdempotencyKey(input.idempotencyKey);
@@ -194,23 +289,36 @@ export class ExternalMoveCoordinator {
       snapshot.rootId,
       snapshot.targetRelativePath,
     );
+    const bindingIdentity = await this.vault.getBindingIdentity(true);
+    if (!bindingIdentity.verifiable) {
+      throw new ExternalRootError(
+        "non_verifiable",
+        "External move planning requires a verifiable vault identity. Configure MCP_EXTERNAL_MOVE_PROFILE_ID.",
+      );
+    }
+    await this.vault.refreshInventory();
     const inventory = await this.inventoryInternal(
       snapshot,
-      input.searchInPath ?? "",
       locations.sourceFileUri,
       locations.targetFileUri,
       sourceToken,
       targetToken,
     );
+    const digest = inventoryDigest(inventory);
     const plan = this.journal.create({
       idempotencyKey: input.idempotencyKey,
       snapshot,
+      bindingIdentity,
       sourceToken,
       targetToken,
       oldFileUri: locations.sourceFileUri,
       newFileUri: locations.targetFileUri,
       repairs: inventory.repairs,
       manualReview: inventory.manualReview,
+      inventoryDigest: digest,
+      appliedRepairPaths: [],
+      restoredRepairPaths: [],
+      recoveryErrors: [],
     });
     return publicPlan(plan);
   }
@@ -227,7 +335,7 @@ export class ExternalMoveCoordinator {
     planId: string,
     idempotencyKey: string,
   ): Promise<Record<string, unknown>> {
-    const plan = this.requirePlan(planId, idempotencyKey);
+    let plan = this.requirePlan(planId, idempotencyKey);
     if (plan.status === "applied") return publicPlan(plan);
     if (plan.status !== "planned" && plan.status !== "rolled_back") {
       throw new ExternalRootError(
@@ -253,26 +361,64 @@ export class ExternalMoveCoordinator {
       );
     }
 
-    for (const repair of plan.repairs) {
-      const current = await this.vault.read(repair.filePath);
-      if (current.sha256 !== repair.expectedSha256) {
-        throw new ExternalRootError(
-          "precondition_failed",
-          `ÉLYSIA note changed after planning: ${repair.filePath}`,
-        );
-      }
+    if (!plan.inventoryDigest) {
+      throw new ExternalRootError(
+        "precondition_failed",
+        "This plan predates inventory digests. Create a new plan with a new idempotency key.",
+      );
     }
+    await this.assertCurrentBinding(plan);
 
-    this.journal.transition(
+    const currentSnapshot = await this.roots.planMove(
+      plan.snapshot.rootId,
+      plan.snapshot.sourceRelativePath,
+      plan.snapshot.targetRelativePath,
+    );
+    if (!snapshotsMatch(currentSnapshot, plan.snapshot)) {
+      throw new ExternalRootError(
+        "precondition_failed",
+        "The external source changed after planning.",
+      );
+    }
+    const locations = await this.roots.getPrivateMoveLocations(currentSnapshot);
+    await this.vault.refreshInventory();
+    const currentInventory = await this.inventoryInternal(
+      currentSnapshot,
+      locations.sourceFileUri,
+      locations.targetFileUri,
+      plan.sourceToken,
+      plan.targetToken,
+    );
+    if (inventoryDigest(currentInventory) !== plan.inventoryDigest) {
+      throw new ExternalRootError(
+        "precondition_failed",
+        "The complete ÉLYSIA reference inventory changed after planning.",
+      );
+    }
+    await this.vault.assertConditionalWritesSupported();
+
+    plan = this.journal.transition(
       plan.planId,
       ["planned", "rolled_back"],
-      "applying",
+      "applying_file",
+      {
+        appliedRepairPaths: [],
+        restoredRepairPaths: [],
+        recoveryErrors: [],
+      },
     );
-    const appliedRepairs: ExternalNoteRepair[] = [];
-    let fileMoved = false;
     try {
       await this.roots.applyMove(plan.snapshot);
-      fileMoved = true;
+      plan = this.journal.transition(
+        plan.planId,
+        ["applying_file"],
+        "file_moved",
+      );
+      plan = this.journal.transition(
+        plan.planId,
+        ["file_moved"],
+        "applying_repairs",
+      );
       for (const repair of plan.repairs) {
         await this.vault.conditionalReplace(
           repair.filePath,
@@ -280,23 +426,27 @@ export class ExternalMoveCoordinator {
           repair.after,
           repair.expectedSha256,
         );
-        appliedRepairs.push(repair);
+        plan = this.journal.recordAppliedRepair(plan.planId, repair.filePath);
       }
       const committed = this.journal.update(plan.planId, "applied");
       return publicPlan(committed);
     } catch (error) {
-      for (const repair of appliedRepairs.reverse()) {
-        await this.rollbackNoteRepair(repair).catch(() => undefined);
+      const compensation = await this.compensateApply(plan.planId, error);
+      if (compensation.length > 0) {
+        throw new ExternalRootError(
+          "non_verifiable",
+          `External move apply failed and recovery is required: ${compensation.join(" | ")}`,
+        );
       }
-      if (fileMoved) {
-        await this.roots.rollbackMove(plan.snapshot).catch(() => undefined);
+      if (error instanceof ExternalRootError) {
+        throw new ExternalRootError(
+          error.code,
+          `${error.message} All partial effects were compensated and journaled.`,
+        );
       }
-      this.journal.update(
-        plan.planId,
-        "failed",
-        error instanceof Error ? error.message : "Apply failed.",
+      throw new Error(
+        `${errorMessage(error)} All partial effects were compensated and journaled.`,
       );
-      throw error;
     }
   }
 
@@ -304,9 +454,23 @@ export class ExternalMoveCoordinator {
     planId: string,
     idempotencyKey: string,
   ): Promise<Record<string, unknown>> {
-    const plan = this.requirePlan(planId, idempotencyKey);
+    let plan = this.requirePlan(planId, idempotencyKey);
     if (plan.status === "rolled_back") return publicPlan(plan);
-    if (plan.status !== "applied") {
+    const recoverableStatuses: ExternalMovePlan["status"][] = [
+      "planned",
+      "failed_compensated",
+      "applied",
+      "applying",
+      "applying_file",
+      "file_moved",
+      "applying_repairs",
+      "rolling_back",
+      "rolling_back_repairs",
+      "rolling_back_file",
+      "failed",
+      "recovery_required",
+    ];
+    if (!recoverableStatuses.includes(plan.status)) {
       throw new ExternalRootError(
         "precondition_failed",
         `External move plan is ${plan.status}, not rollbackable.`,
@@ -323,41 +487,63 @@ export class ExternalMoveCoordinator {
       action: "rollback",
       destructive: true,
     });
-    const rollbackContents = new Map<
-      string,
-      { current: string; restored: string }
-    >();
-    for (const repair of plan.repairs) {
-      const current = await this.vault.read(repair.filePath);
-      if (
-        normalizeProtectedFrontmatter(current.content) !==
-        normalizeProtectedFrontmatter(repair.after)
-      ) {
-        throw new ExternalRootError(
-          "precondition_failed",
-          `ÉLYSIA note changed after the move: ${repair.filePath}`,
-        );
-      }
-      rollbackContents.set(repair.filePath, {
-        current: current.content,
-        restored: preserveCurrentProtectedFrontmatter(
-          repair.before,
-          current.content,
-        ),
-      });
-    }
-    this.journal.transition(plan.planId, ["applied"], "rolling_back");
-    await this.roots.rollbackMove(plan.snapshot);
-    for (const repair of [...plan.repairs].reverse()) {
-      const rollback = rollbackContents.get(repair.filePath)!;
-      await this.vault.conditionalReplace(
-        repair.filePath,
-        rollback.current,
-        rollback.restored,
-        sha256Text(rollback.current),
+    await this.assertCurrentBinding(plan);
+    if (plan.status === "planned" || plan.status === "failed_compensated") {
+      return publicPlan(
+        this.journal.transition(plan.planId, [plan.status], "rolled_back", {
+          recoveryErrors: [],
+        }),
       );
     }
-    return publicPlan(this.journal.update(plan.planId, "rolled_back"));
+    await this.vault.assertConditionalWritesSupported();
+    try {
+      const placement = await this.inspectFilePlacement(plan.snapshot);
+      if (placement === "both" || placement === "missing_or_changed") {
+        throw new ExternalRootError(
+          "non_verifiable",
+          `External file placement is ${placement}; automatic rollback is unsafe.`,
+        );
+      }
+      const rollbackContents = await this.prepareRollbackContents(plan);
+      plan = this.journal.transition(
+        plan.planId,
+        recoverableStatuses,
+        "rolling_back_repairs",
+        { recoveryErrors: [] },
+      );
+      for (const repair of [...plan.repairs].reverse()) {
+        const rollback = rollbackContents.get(repair.filePath);
+        if (rollback) {
+          await this.vault.conditionalReplace(
+            repair.filePath,
+            rollback.current,
+            rollback.restored,
+            sha256Text(rollback.current),
+          );
+        }
+        plan = this.journal.recordRestoredRepair(plan.planId, repair.filePath);
+      }
+      plan = this.journal.transition(
+        plan.planId,
+        ["rolling_back_repairs"],
+        "rolling_back_file",
+      );
+      if ((await this.inspectFilePlacement(plan.snapshot)) === "target") {
+        await this.roots.rollbackMove(plan.snapshot);
+      }
+      return publicPlan(this.journal.update(plan.planId, "rolled_back"));
+    } catch (error) {
+      const message = errorMessage(error);
+      const current = this.journal.get(plan.planId) ?? plan;
+      const partial = current.status !== "applied";
+      this.journal.update(
+        current.planId,
+        partial ? "recovery_required" : current.status,
+        message,
+        { recoveryErrors: [message] },
+      );
+      throw error;
+    }
   }
 
   private requirePlan(
@@ -374,28 +560,151 @@ export class ExternalMoveCoordinator {
     return plan;
   }
 
-  private async rollbackNoteRepair(repair: ExternalNoteRepair): Promise<void> {
-    const current = await this.vault.read(repair.filePath);
+  private async assertCurrentBinding(plan: ExternalMovePlan): Promise<void> {
+    if (!plan.bindingIdentity?.verifiable) {
+      throw new ExternalRootError(
+        "non_verifiable",
+        "The move plan has no verifiable backend/vault/root binding.",
+      );
+    }
+    const current = await this.vault.getBindingIdentity(true);
     if (
-      normalizeProtectedFrontmatter(current.content) !==
-      normalizeProtectedFrontmatter(repair.after)
+      !current.verifiable ||
+      current.bindingFingerprint !== plan.bindingIdentity.bindingFingerprint
     ) {
       throw new ExternalRootError(
         "precondition_failed",
-        `ÉLYSIA note changed during rollback: ${repair.filePath}`,
+        "The backend, vault, or external-root configuration changed after planning.",
       );
     }
-    await this.vault.conditionalReplace(
-      repair.filePath,
-      current.content,
-      preserveCurrentProtectedFrontmatter(repair.before, current.content),
-      current.sha256,
+  }
+
+  private async inspectFilePlacement(
+    snapshot: ExternalMoveSnapshot,
+  ): Promise<FilePlacement> {
+    const matches = async (
+      relativePath: string,
+      targetRelativePath: string,
+    ): Promise<boolean> => {
+      try {
+        const current = await this.roots.inspectMoveSource(
+          snapshot.rootId,
+          relativePath,
+          targetRelativePath,
+        );
+        return (
+          current.size === snapshot.size && current.sha256 === snapshot.sha256
+        );
+      } catch (error) {
+        if (error instanceof ExternalRootError && error.code === "not_found") {
+          return false;
+        }
+        throw error;
+      }
+    };
+    const source = await matches(
+      snapshot.sourceRelativePath,
+      snapshot.targetRelativePath,
     );
+    const target = await matches(
+      snapshot.targetRelativePath,
+      snapshot.sourceRelativePath,
+    );
+    if (source && target) return "both";
+    if (source) return "source";
+    if (target) return "target";
+    return "missing_or_changed";
+  }
+
+  private async prepareRollbackContents(
+    plan: ExternalMovePlan,
+  ): Promise<Map<string, { current: string; restored: string }>> {
+    const contents = new Map<string, { current: string; restored: string }>();
+    for (const repair of plan.repairs) {
+      const current = await this.vault.read(repair.filePath);
+      const normalized = normalizeProtectedFrontmatter(current.content);
+      if (normalized === normalizeProtectedFrontmatter(repair.before)) {
+        continue;
+      }
+      if (normalized !== normalizeProtectedFrontmatter(repair.after)) {
+        throw new ExternalRootError(
+          "precondition_failed",
+          `ÉLYSIA note changed outside protected runtime frontmatter: ${repair.filePath}`,
+        );
+      }
+      contents.set(repair.filePath, {
+        current: current.content,
+        restored: preserveCurrentProtectedFrontmatter(
+          repair.before,
+          current.content,
+        ),
+      });
+    }
+    return contents;
+  }
+
+  private async compensateApply(
+    planId: string,
+    originalError: unknown,
+  ): Promise<string[]> {
+    const errors: string[] = [];
+    let plan = this.journal.get(planId);
+    if (!plan) return ["The transaction journal entry disappeared."];
+    try {
+      const placement = await this.inspectFilePlacement(plan.snapshot);
+      if (placement === "both" || placement === "missing_or_changed") {
+        throw new Error(`External file placement is ${placement}.`);
+      }
+      const rollbackContents = await this.prepareRollbackContents(plan);
+      plan = this.journal.transition(
+        plan.planId,
+        [plan.status],
+        "rolling_back_repairs",
+        { recoveryErrors: [] },
+      );
+      for (const repair of [...plan.repairs].reverse()) {
+        const rollback = rollbackContents.get(repair.filePath);
+        if (rollback) {
+          await this.vault.conditionalReplace(
+            repair.filePath,
+            rollback.current,
+            rollback.restored,
+            sha256Text(rollback.current),
+          );
+        }
+        plan = this.journal.recordRestoredRepair(plan.planId, repair.filePath);
+      }
+      plan = this.journal.transition(
+        plan.planId,
+        ["rolling_back_repairs"],
+        "rolling_back_file",
+      );
+      if ((await this.inspectFilePlacement(plan.snapshot)) === "target") {
+        await this.roots.rollbackMove(plan.snapshot);
+      }
+      this.journal.update(
+        plan.planId,
+        "failed_compensated",
+        errorMessage(originalError),
+        { recoveryErrors: [] },
+      );
+    } catch (compensationError) {
+      errors.push(errorMessage(compensationError));
+      const current = this.journal.get(planId);
+      if (current) {
+        this.journal.update(
+          current.planId,
+          "recovery_required",
+          errorMessage(originalError),
+          { recoveryErrors: errors },
+        );
+      }
+    }
+    return errors;
   }
 
   private async inventory(
     snapshot: ExternalMoveSnapshot,
-    searchInPath: string,
   ): Promise<Record<string, unknown>> {
     const location = await this.roots.getPrivateReferenceLocation(
       snapshot.rootId,
@@ -407,7 +716,6 @@ export class ExternalMoveCoordinator {
     );
     const inventory = await this.inventoryInternal(
       snapshot,
-      searchInPath,
       location.fileUri,
       location.fileUri,
       sourceToken,
@@ -417,6 +725,7 @@ export class ExternalMoveCoordinator {
       rootId: snapshot.rootId,
       relativePath: snapshot.sourceRelativePath,
       sourceSha256: snapshot.sha256,
+      inventoryDigest: inventoryDigest(inventory),
       reparable: inventory.repairs.map((item) => ({
         filePath: item.filePath,
         expectedSha256: item.expectedSha256,
@@ -428,15 +737,11 @@ export class ExternalMoveCoordinator {
 
   private async inventoryInternal(
     snapshot: ExternalMoveSnapshot,
-    searchInPath: string,
     oldFileUri: string,
     newFileUri: string,
     sourceToken: string,
     targetToken: string,
-  ): Promise<{
-    repairs: ExternalNoteRepair[];
-    manualReview: Array<{ filePath: string; reason: string }>;
-  }> {
+  ): Promise<Inventory> {
     const location = await this.roots.getPrivateReferenceLocation(
       snapshot.rootId,
       snapshot.sourceRelativePath,
@@ -448,10 +753,7 @@ export class ExternalMoveCoordinator {
       location.absolutePath,
       path.basename(location.absolutePath),
     ]) {
-      for (const filePath of await this.vault.searchPaths(
-        query,
-        searchInPath,
-      )) {
+      for (const filePath of await this.vault.searchPaths(query)) {
         candidatePaths.add(filePath);
       }
     }
@@ -493,7 +795,11 @@ export class ExternalMoveCoordinator {
             occurrence.classification !== "reparable" ||
             occurrence.token?.rootId !== snapshot.rootId ||
             occurrence.token.relativePath !== snapshot.sourceRelativePath ||
-            occurrence.fileLink?.url !== oldFileUri,
+            !occurrence.fileLink ||
+            !samePhysicalPath(
+              occurrence.fileLink.localPath,
+              location.absolutePath,
+            ),
         )
       ) {
         manualReview.push({
@@ -524,6 +830,12 @@ export class ExternalMoveCoordinator {
         after,
       });
     }
-    return { repairs, manualReview };
+    return {
+      repairs,
+      manualReview,
+      candidatePaths: [...candidatePaths].sort((left, right) =>
+        left.localeCompare(right),
+      ),
+    };
   }
 }

--- a/src/services/externalReferences/externalMoveJournal.ts
+++ b/src/services/externalReferences/externalMoveJournal.ts
@@ -1,0 +1,177 @@
+import { randomUUID } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import type { ExternalMoveSnapshot } from "../externalRootsService.js";
+
+export type ExternalNoteRepair = {
+  filePath: string;
+  expectedSha256: string;
+  before: string;
+  after: string;
+};
+
+export type ExternalMovePlanStatus =
+  | "planned"
+  | "applying"
+  | "applied"
+  | "rolling_back"
+  | "rolled_back"
+  | "failed";
+
+export type ExternalMovePlan = {
+  planId: string;
+  idempotencyKey: string;
+  createdAt: string;
+  updatedAt: string;
+  status: ExternalMovePlanStatus;
+  snapshot: ExternalMoveSnapshot;
+  sourceToken: string;
+  targetToken: string;
+  oldFileUri: string;
+  newFileUri: string;
+  repairs: ExternalNoteRepair[];
+  manualReview: Array<{ filePath: string; reason: string }>;
+  failure?: string;
+};
+
+export class ExternalMoveJournal {
+  private readonly db: DatabaseSync;
+
+  constructor(databasePath: string) {
+    mkdirSync(path.dirname(databasePath), { recursive: true, mode: 0o700 });
+    this.db = new DatabaseSync(databasePath);
+    this.db.exec("PRAGMA journal_mode=WAL");
+    this.db.exec("PRAGMA synchronous=FULL");
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS external_move_plans (
+        plan_id TEXT PRIMARY KEY,
+        idempotency_key TEXT NOT NULL UNIQUE,
+        status TEXT NOT NULL,
+        payload_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `);
+    for (const privatePath of [
+      databasePath,
+      `${databasePath}-wal`,
+      `${databasePath}-shm`,
+    ]) {
+      if (existsSync(privatePath)) {
+        try {
+          chmodSync(privatePath, 0o600);
+        } catch {
+          // Windows ACLs remain authoritative when POSIX modes are unavailable.
+        }
+      }
+    }
+  }
+
+  create(
+    input: Omit<
+      ExternalMovePlan,
+      "planId" | "createdAt" | "updatedAt" | "status"
+    >,
+  ): ExternalMovePlan {
+    const existing = this.getByIdempotencyKey(input.idempotencyKey);
+    if (existing) return existing;
+    const now = new Date().toISOString();
+    const plan: ExternalMovePlan = {
+      ...input,
+      planId: randomUUID(),
+      createdAt: now,
+      updatedAt: now,
+      status: "planned",
+    };
+    this.db
+      .prepare(
+        `INSERT INTO external_move_plans
+         (plan_id, idempotency_key, status, payload_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        plan.planId,
+        plan.idempotencyKey,
+        plan.status,
+        JSON.stringify(plan),
+        plan.createdAt,
+        plan.updatedAt,
+      );
+    return plan;
+  }
+
+  get(planId: string): ExternalMovePlan | undefined {
+    const row = this.db
+      .prepare("SELECT payload_json FROM external_move_plans WHERE plan_id = ?")
+      .get(planId) as { payload_json: string } | undefined;
+    return row ? (JSON.parse(row.payload_json) as ExternalMovePlan) : undefined;
+  }
+
+  getByIdempotencyKey(key: string): ExternalMovePlan | undefined {
+    const row = this.db
+      .prepare(
+        "SELECT payload_json FROM external_move_plans WHERE idempotency_key = ?",
+      )
+      .get(key) as { payload_json: string } | undefined;
+    return row ? (JSON.parse(row.payload_json) as ExternalMovePlan) : undefined;
+  }
+
+  update(
+    planId: string,
+    status: ExternalMovePlanStatus,
+    failure?: string,
+  ): ExternalMovePlan {
+    const current = this.get(planId);
+    if (!current) throw new Error("Unknown external move plan.");
+    const updated: ExternalMovePlan = {
+      ...current,
+      status,
+      updatedAt: new Date().toISOString(),
+      failure,
+    };
+    this.db
+      .prepare(
+        `UPDATE external_move_plans
+         SET status = ?, payload_json = ?, updated_at = ?
+         WHERE plan_id = ?`,
+      )
+      .run(status, JSON.stringify(updated), updated.updatedAt, planId);
+    return updated;
+  }
+
+  transition(
+    planId: string,
+    expectedStatuses: ExternalMovePlanStatus[],
+    nextStatus: ExternalMovePlanStatus,
+  ): ExternalMovePlan {
+    const current = this.get(planId);
+    if (!current || !expectedStatuses.includes(current.status)) {
+      throw new Error("External move plan state changed concurrently.");
+    }
+    const updated: ExternalMovePlan = {
+      ...current,
+      status: nextStatus,
+      updatedAt: new Date().toISOString(),
+      failure: undefined,
+    };
+    const placeholders = expectedStatuses.map(() => "?").join(", ");
+    const result = this.db
+      .prepare(
+        `UPDATE external_move_plans
+         SET status = ?, payload_json = ?, updated_at = ?
+         WHERE plan_id = ? AND status IN (${placeholders})`,
+      )
+      .run(
+        nextStatus,
+        JSON.stringify(updated),
+        updated.updatedAt,
+        planId,
+        ...expectedStatuses,
+      );
+    if (Number(result.changes) !== 1) {
+      throw new Error("External move plan state changed concurrently.");
+    }
+    return updated;
+  }
+}

--- a/src/services/externalReferences/externalMoveJournal.ts
+++ b/src/services/externalReferences/externalMoveJournal.ts
@@ -3,6 +3,7 @@ import { chmodSync, existsSync, mkdirSync } from "node:fs";
 import path from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import type { ExternalMoveSnapshot } from "../externalRootsService.js";
+import type { ExternalMoveBindingIdentity } from "./backendVaultAdapter.js";
 
 export type ExternalNoteRepair = {
   filePath: string;
@@ -13,10 +14,19 @@ export type ExternalNoteRepair = {
 
 export type ExternalMovePlanStatus =
   | "planned"
-  | "applying"
+  | "applying_file"
+  | "file_moved"
+  | "applying_repairs"
   | "applied"
-  | "rolling_back"
+  | "rolling_back_repairs"
+  | "rolling_back_file"
   | "rolled_back"
+  | "failed_compensated"
+  | "recovery_required"
+  // Legacy states are retained so an existing private journal can be
+  // recovered instead of becoming unreadable after an upgrade.
+  | "applying"
+  | "rolling_back"
   | "failed";
 
 export type ExternalMovePlan = {
@@ -26,14 +36,26 @@ export type ExternalMovePlan = {
   updatedAt: string;
   status: ExternalMovePlanStatus;
   snapshot: ExternalMoveSnapshot;
+  bindingIdentity: ExternalMoveBindingIdentity;
   sourceToken: string;
   targetToken: string;
   oldFileUri: string;
   newFileUri: string;
   repairs: ExternalNoteRepair[];
   manualReview: Array<{ filePath: string; reason: string }>;
+  inventoryDigest: string;
+  appliedRepairPaths: string[];
+  restoredRepairPaths: string[];
+  recoveryErrors: string[];
   failure?: string;
 };
+
+type ExternalMovePlanPatch = Partial<
+  Pick<
+    ExternalMovePlan,
+    "failure" | "appliedRepairPaths" | "restoredRepairPaths" | "recoveryErrors"
+  >
+>;
 
 export class ExternalMoveJournal {
   private readonly db: DatabaseSync;
@@ -79,6 +101,9 @@ export class ExternalMoveJournal {
     const now = new Date().toISOString();
     const plan: ExternalMovePlan = {
       ...input,
+      appliedRepairPaths: [...input.appliedRepairPaths],
+      restoredRepairPaths: [...input.restoredRepairPaths],
+      recoveryErrors: [...input.recoveryErrors],
       planId: randomUUID(),
       createdAt: now,
       updatedAt: now,
@@ -121,39 +146,72 @@ export class ExternalMoveJournal {
     planId: string,
     status: ExternalMovePlanStatus,
     failure?: string,
+    patch: ExternalMovePlanPatch = {},
   ): ExternalMovePlan {
     const current = this.get(planId);
     if (!current) throw new Error("Unknown external move plan.");
-    const updated: ExternalMovePlan = {
-      ...current,
-      status,
-      updatedAt: new Date().toISOString(),
+    return this.persist(current, [current.status], status, {
+      ...patch,
       failure,
-    };
-    this.db
-      .prepare(
-        `UPDATE external_move_plans
-         SET status = ?, payload_json = ?, updated_at = ?
-         WHERE plan_id = ?`,
-      )
-      .run(status, JSON.stringify(updated), updated.updatedAt, planId);
-    return updated;
+    });
   }
 
   transition(
     planId: string,
     expectedStatuses: ExternalMovePlanStatus[],
     nextStatus: ExternalMovePlanStatus,
+    patch: ExternalMovePlanPatch = {},
   ): ExternalMovePlan {
     const current = this.get(planId);
     if (!current || !expectedStatuses.includes(current.status)) {
       throw new Error("External move plan state changed concurrently.");
     }
+    return this.persist(current, expectedStatuses, nextStatus, {
+      recoveryErrors: [],
+      failure: undefined,
+      ...patch,
+    });
+  }
+
+  recordAppliedRepair(planId: string, filePath: string): ExternalMovePlan {
+    const current = this.get(planId);
+    if (!current) throw new Error("Unknown external move plan.");
+    const appliedRepairPaths = [
+      ...new Set([...(current.appliedRepairPaths ?? []), filePath]),
+    ].sort((left, right) => left.localeCompare(right));
+    return this.persist(current, ["applying_repairs"], "applying_repairs", {
+      appliedRepairPaths,
+    });
+  }
+
+  recordRestoredRepair(planId: string, filePath: string): ExternalMovePlan {
+    const current = this.get(planId);
+    if (!current) throw new Error("Unknown external move plan.");
+    const restoredRepairPaths = [
+      ...new Set([...(current.restoredRepairPaths ?? []), filePath]),
+    ].sort((left, right) => left.localeCompare(right));
+    return this.persist(
+      current,
+      ["rolling_back_repairs"],
+      "rolling_back_repairs",
+      { restoredRepairPaths },
+    );
+  }
+
+  private persist(
+    current: ExternalMovePlan,
+    expectedStatuses: ExternalMovePlanStatus[],
+    nextStatus: ExternalMovePlanStatus,
+    patch: ExternalMovePlanPatch,
+  ): ExternalMovePlan {
     const updated: ExternalMovePlan = {
       ...current,
+      appliedRepairPaths: current.appliedRepairPaths ?? [],
+      restoredRepairPaths: current.restoredRepairPaths ?? [],
+      recoveryErrors: current.recoveryErrors ?? [],
+      ...patch,
       status: nextStatus,
       updatedAt: new Date().toISOString(),
-      failure: undefined,
     };
     const placeholders = expectedStatuses.map(() => "?").join(", ");
     const result = this.db
@@ -166,7 +224,7 @@ export class ExternalMoveJournal {
         nextStatus,
         JSON.stringify(updated),
         updated.updatedAt,
-        planId,
+        current.planId,
         ...expectedStatuses,
       );
     if (Number(result.changes) !== 1) {

--- a/src/services/externalReferences/index.ts
+++ b/src/services/externalReferences/index.ts
@@ -1,0 +1,1 @@
+export * from "./canonicalReferenceParser.js";

--- a/src/services/externalRootsService.ts
+++ b/src/services/externalRootsService.ts
@@ -161,6 +161,13 @@ export type ExternalMoveSnapshot = {
   sha256: string;
 };
 
+type ExternalMoveIdentity = {
+  dev: bigint;
+  ino: bigint;
+};
+
+type SafeMovePathState = "absent" | "matching" | "mismatch";
+
 const textExtensions = new Set([
   ".txt",
   ".md",
@@ -563,49 +570,7 @@ export class ExternalRootsService {
         "Only regular external files can be moved.",
       );
     }
-    this.assertAllowed(runtime, targetRelativePath);
-    const rootPath = await this.canonicalRoot(runtime);
-    const targetPath = path.join(rootPath, ...targetRelativePath.split("/"));
-    if (!isInsideRoot(rootPath, targetPath)) {
-      throw new ExternalRootError(
-        "path_outside_root",
-        "The target path is outside the configured external root.",
-      );
-    }
-    const parentPath = path.dirname(targetPath);
-    const parentRealPath = await realpath(parentPath).catch(() => undefined);
-    if (!parentRealPath || !isInsideRoot(rootPath, parentRealPath)) {
-      throw new ExternalRootError(
-        "not_a_directory",
-        "The target parent directory must already exist inside the root.",
-      );
-    }
-    const parentStat = await lstat(parentRealPath);
-    if (!parentStat.isDirectory() || parentStat.isSymbolicLink()) {
-      throw new ExternalRootError(
-        "path_link_unsupported",
-        "The target parent must be a real directory, not a link or junction.",
-      );
-    }
-    try {
-      await lstat(targetPath);
-      throw new ExternalRootError(
-        "target_exists",
-        "The external move target already exists.",
-      );
-    } catch (error) {
-      if (error instanceof ExternalRootError) throw error;
-      const code =
-        typeof error === "object" && error && "code" in error
-          ? String(error.code)
-          : "";
-      if (code !== "ENOENT") {
-        throw new ExternalRootError(
-          "non_verifiable",
-          "The external move target could not be verified.",
-        );
-      }
-    }
+    await this.resolveNewTarget(runtime, targetRelativePath);
 
     return this.inspectMoveSource(
       rootId,
@@ -655,36 +620,55 @@ export class ExternalRootsService {
       );
     }
     const runtime = this.requireCapability(snapshot.rootId, "move");
-    const rootPath = await this.canonicalRoot(runtime);
     const sourcePath = await this.resolvePath(
       runtime,
       snapshot.sourceRelativePath,
     );
-    const targetPath = path.join(
-      rootPath,
-      ...snapshot.targetRelativePath.split("/"),
+    const targetPath = await this.resolveNewTarget(
+      runtime,
+      snapshot.targetRelativePath,
     );
+    let linkedIdentity: ExternalMoveIdentity | undefined;
     try {
       // link() is no-clobber and keeps the operation on one filesystem. The
       // source is removed only after the target identity is verified.
       await link(sourcePath, targetPath);
-      const sourceStat = await stat(sourcePath, { bigint: true });
-      const targetStat = await stat(targetPath, { bigint: true });
+      const sourceStat = await lstat(sourcePath, { bigint: true });
+      const targetStat = await lstat(targetPath, { bigint: true });
+      linkedIdentity = { dev: targetStat.dev, ino: targetStat.ino };
+      const rootPath = await this.canonicalRoot(runtime);
+      const canonicalTarget = await realpath(targetPath);
       if (
+        !sourceStat.isFile() ||
+        !targetStat.isFile() ||
+        sourceStat.isSymbolicLink() ||
+        targetStat.isSymbolicLink() ||
         sourceStat.dev !== targetStat.dev ||
-        sourceStat.ino !== targetStat.ino
+        sourceStat.ino !== targetStat.ino ||
+        !isInsideRoot(rootPath, canonicalTarget)
       ) {
         throw new ExternalRootError(
           "non_verifiable",
           "The external move target is not the verified source object.",
         );
       }
-      await unlink(sourcePath);
-    } catch (error) {
-      if (error instanceof ExternalRootError) {
-        await unlink(targetPath).catch(() => undefined);
-        throw error;
+      const linkedState = await this.safeMovePathState(
+        runtime,
+        snapshot.targetRelativePath,
+        snapshot,
+      );
+      if (linkedState !== "matching") {
+        throw new ExternalRootError(
+          "precondition_failed",
+          "The linked external move target does not match the planned source.",
+        );
       }
+      await this.unlinkIfIdentity(
+        runtime,
+        snapshot.sourceRelativePath,
+        linkedIdentity,
+      );
+    } catch (error) {
       const code =
         typeof error === "object" && error && "code" in error
           ? String(error.code)
@@ -695,7 +679,21 @@ export class ExternalRootsService {
           "The external move target already exists.",
         );
       }
-      await unlink(targetPath).catch(() => undefined);
+      if (linkedIdentity) {
+        try {
+          await this.unlinkIfIdentity(
+            runtime,
+            snapshot.targetRelativePath,
+            linkedIdentity,
+          );
+        } catch {
+          throw new ExternalRootError(
+            "non_verifiable",
+            "The external move failed and its linked target could not be cleaned safely.",
+          );
+        }
+      }
+      if (error instanceof ExternalRootError) throw error;
       throw new ExternalRootError(
         code === "EXDEV" || code === "ENOTSUP"
           ? "unsupported"
@@ -707,49 +705,139 @@ export class ExternalRootsService {
 
   async rollbackMove(snapshot: ExternalMoveSnapshot): Promise<void> {
     const runtime = this.requireCapability(snapshot.rootId, "move");
-    const rootPath = await this.canonicalRoot(runtime);
-    const sourcePath = path.join(
-      rootPath,
-      ...snapshot.sourceRelativePath.split("/"),
+    const sourceRelativePath = normalizeRelativePath(
+      snapshot.sourceRelativePath,
     );
-    const targetPath = await this.resolvePath(
-      runtime,
+    const targetRelativePath = normalizeRelativePath(
       snapshot.targetRelativePath,
     );
-    try {
-      await lstat(sourcePath);
+    const sourceState = await this.safeMovePathState(
+      runtime,
+      sourceRelativePath,
+      snapshot,
+    );
+    if (sourceState !== "absent") {
       throw new ExternalRootError(
         "target_exists",
         "The original external source path is already occupied.",
       );
+    }
+    const targetState = await this.safeMovePathState(
+      runtime,
+      targetRelativePath,
+      snapshot,
+    );
+    if (targetState !== "matching") {
+      throw new ExternalRootError(
+        targetState === "absent" ? "not_found" : "precondition_failed",
+        "The moved external file is absent or changed and cannot be rolled back safely.",
+      );
+    }
+    const sourcePath = await this.resolveNewTarget(runtime, sourceRelativePath);
+    const targetPath = await this.resolvePath(runtime, targetRelativePath);
+    let restoredIdentity: ExternalMoveIdentity | undefined;
+    try {
+      await link(targetPath, sourcePath);
+      const targetStat = await lstat(targetPath, { bigint: true });
+      const sourceStat = await lstat(sourcePath, { bigint: true });
+      restoredIdentity = { dev: sourceStat.dev, ino: sourceStat.ino };
+      const rootPath = await this.canonicalRoot(runtime);
+      const canonicalSource = await realpath(sourcePath);
+      if (
+        !targetStat.isFile() ||
+        !sourceStat.isFile() ||
+        targetStat.isSymbolicLink() ||
+        sourceStat.isSymbolicLink() ||
+        targetStat.dev !== sourceStat.dev ||
+        targetStat.ino !== sourceStat.ino ||
+        !isInsideRoot(rootPath, canonicalSource)
+      ) {
+        throw new ExternalRootError(
+          "non_verifiable",
+          "The rollback source is not the verified moved object.",
+        );
+      }
+      await this.unlinkIfIdentity(
+        runtime,
+        targetRelativePath,
+        restoredIdentity,
+      );
     } catch (error) {
+      if (restoredIdentity) {
+        const targetStateAfterFailure = await this.safeMovePathState(
+          runtime,
+          targetRelativePath,
+          snapshot,
+        );
+        if (targetStateAfterFailure === "matching") {
+          await this.unlinkIfIdentity(
+            runtime,
+            sourceRelativePath,
+            restoredIdentity,
+          ).catch(() => undefined);
+        }
+      }
       if (error instanceof ExternalRootError) throw error;
       const code =
         typeof error === "object" && error && "code" in error
           ? String(error.code)
           : "";
-      if (code !== "ENOENT") {
-        throw new ExternalRootError(
-          "non_verifiable",
-          "The original external source path could not be verified.",
-        );
-      }
-    }
-    const verified = await this.readVerifiedBuffer(
-      runtime,
-      snapshot.targetRelativePath,
-    );
-    if (
-      verified.buffer.length !== snapshot.size ||
-      sha256(verified.buffer) !== snapshot.sha256
-    ) {
       throw new ExternalRootError(
-        "precondition_failed",
-        "The moved external file changed and cannot be rolled back safely.",
+        code === "EEXIST" ? "target_exists" : "non_verifiable",
+        "The external move rollback could not be completed safely.",
       );
     }
-    await link(targetPath, sourcePath);
-    await unlink(targetPath);
+  }
+
+  async recoverMoveToSource(snapshot: ExternalMoveSnapshot): Promise<void> {
+    const runtime = this.requireCapability(snapshot.rootId, "move");
+    const sourceRelativePath = normalizeRelativePath(
+      snapshot.sourceRelativePath,
+    );
+    const targetRelativePath = normalizeRelativePath(
+      snapshot.targetRelativePath,
+    );
+    const source = await this.safeMovePathState(
+      runtime,
+      sourceRelativePath,
+      snapshot,
+    );
+    const target = await this.safeMovePathState(
+      runtime,
+      targetRelativePath,
+      snapshot,
+    );
+    if (source === "matching" && target === "absent") return;
+    if (source === "absent" && target === "matching") {
+      await this.rollbackMove(snapshot);
+      return;
+    }
+    if (source === "matching" && target === "matching") {
+      const sourcePath = await this.resolvePath(runtime, sourceRelativePath);
+      const targetPath = await this.resolvePath(runtime, targetRelativePath);
+      const sourceStat = await lstat(sourcePath, { bigint: true });
+      const targetStat = await lstat(targetPath, { bigint: true });
+      if (
+        sourceStat.isSymbolicLink() ||
+        targetStat.isSymbolicLink() ||
+        sourceStat.dev !== targetStat.dev ||
+        sourceStat.ino !== targetStat.ino
+      ) {
+        throw new ExternalRootError(
+          "non_verifiable",
+          "Source and target do not identify the same recovery object.",
+        );
+      }
+      await this.unlinkIfIdentity(runtime, targetRelativePath, {
+        dev: targetStat.dev,
+        ino: targetStat.ino,
+      });
+      return;
+    }
+    throw new ExternalRootError(
+      "non_verifiable",
+      "The external move cannot be recovered automatically.",
+    );
   }
 
   async getPrivateReferenceLocation(
@@ -769,14 +857,13 @@ export class ExternalRootsService {
     snapshot: ExternalMoveSnapshot,
   ): Promise<{ sourceFileUri: string; targetFileUri: string }> {
     const runtime = this.requireCapability(snapshot.rootId, "move");
-    const rootPath = await this.canonicalRoot(runtime);
     const sourcePath = await this.resolvePath(
       runtime,
-      snapshot.sourceRelativePath,
+      normalizeRelativePath(snapshot.sourceRelativePath),
     );
-    const targetPath = path.join(
-      rootPath,
-      ...snapshot.targetRelativePath.split("/"),
+    const targetPath = await this.resolveNewTarget(
+      runtime,
+      normalizeRelativePath(snapshot.targetRelativePath),
     );
     return {
       sourceFileUri: pathToFileURL(sourcePath).href,
@@ -1054,6 +1141,195 @@ export class ExternalRootsService {
         `External root '${runtime.config.id}' is unavailable.`,
       );
     }
+  }
+
+  private async resolveNewTarget(
+    runtime: RootRuntime,
+    requestedRelativePath: string,
+  ): Promise<string> {
+    const relativePath = normalizeRelativePath(requestedRelativePath);
+    if (!relativePath) {
+      throw new ExternalRootError(
+        "path_invalid",
+        "The external move target must identify a file.",
+      );
+    }
+    this.assertAllowed(runtime, relativePath);
+    const rootPath = await this.canonicalRoot(runtime);
+    const segments = relativePath.split("/");
+    const filename = segments.pop()!;
+    let parentPath = rootPath;
+
+    for (const segment of segments) {
+      parentPath = path.join(parentPath, segment);
+      let parentStat;
+      try {
+        parentStat = await lstat(parentPath, { bigint: true });
+      } catch (error) {
+        const code =
+          typeof error === "object" && error && "code" in error
+            ? String(error.code)
+            : "";
+        throw new ExternalRootError(
+          code === "ENOENT" ? "not_a_directory" : "non_verifiable",
+          "Every external move target parent must already exist as a real directory.",
+        );
+      }
+      if (parentStat.isSymbolicLink()) {
+        throw new ExternalRootError(
+          "path_link_unsupported",
+          "Symbolic links and junctions are not supported in external move parents.",
+        );
+      }
+      if (!parentStat.isDirectory()) {
+        throw new ExternalRootError(
+          "not_a_directory",
+          "Every external move target parent must be a directory.",
+        );
+      }
+      const canonicalParent = await realpath(parentPath);
+      if (!isInsideRoot(rootPath, canonicalParent)) {
+        throw new ExternalRootError(
+          "path_outside_root",
+          "The external move target parent resolves outside the configured root.",
+        );
+      }
+      parentPath = canonicalParent;
+    }
+
+    const parentBefore = await lstat(parentPath, { bigint: true });
+    if (parentBefore.isSymbolicLink() || !parentBefore.isDirectory()) {
+      throw new ExternalRootError(
+        "path_link_unsupported",
+        "The external move target parent must remain a real directory.",
+      );
+    }
+    const canonicalParent = await realpath(parentPath);
+    if (!isInsideRoot(rootPath, canonicalParent)) {
+      throw new ExternalRootError(
+        "path_outside_root",
+        "The external move target parent resolves outside the configured root.",
+      );
+    }
+    const targetPath = path.join(canonicalParent, filename);
+    if (!isInsideRoot(rootPath, targetPath)) {
+      throw new ExternalRootError(
+        "path_outside_root",
+        "The external move target is outside the configured root.",
+      );
+    }
+
+    try {
+      const targetStat = await lstat(targetPath);
+      if (targetStat.isSymbolicLink()) {
+        throw new ExternalRootError(
+          "path_link_unsupported",
+          "The external move target cannot be a symbolic link or junction.",
+        );
+      }
+      throw new ExternalRootError(
+        "target_exists",
+        "The external move target already exists.",
+      );
+    } catch (error) {
+      if (error instanceof ExternalRootError) throw error;
+      const code =
+        typeof error === "object" && error && "code" in error
+          ? String(error.code)
+          : "";
+      if (code !== "ENOENT") {
+        throw new ExternalRootError(
+          code === "EACCES" || code === "EPERM"
+            ? "inaccessible"
+            : "non_verifiable",
+          "The external move target could not be verified.",
+        );
+      }
+    }
+
+    const parentAfter = await lstat(canonicalParent, { bigint: true });
+    if (
+      parentAfter.isSymbolicLink() ||
+      !parentAfter.isDirectory() ||
+      parentAfter.dev !== parentBefore.dev ||
+      parentAfter.ino !== parentBefore.ino
+    ) {
+      throw new ExternalRootError(
+        "non_verifiable",
+        "The external move target parent changed while it was being verified.",
+      );
+    }
+    return targetPath;
+  }
+
+  private async unlinkIfIdentity(
+    runtime: RootRuntime,
+    requestedRelativePath: string,
+    expected: ExternalMoveIdentity,
+  ): Promise<void> {
+    const relativePath = normalizeRelativePath(requestedRelativePath);
+    let absolutePath: string;
+    try {
+      absolutePath = await this.resolvePath(runtime, relativePath);
+    } catch (error) {
+      if (error instanceof ExternalRootError && error.code === "not_found") {
+        return;
+      }
+      throw error;
+    }
+    const current = await lstat(absolutePath, { bigint: true });
+    if (
+      !current.isFile() ||
+      current.isSymbolicLink() ||
+      current.dev !== expected.dev ||
+      current.ino !== expected.ino
+    ) {
+      throw new ExternalRootError(
+        "precondition_failed",
+        "The external path identity changed before cleanup.",
+      );
+    }
+    await unlink(absolutePath);
+  }
+
+  private async safeMovePathState(
+    runtime: RootRuntime,
+    requestedRelativePath: string,
+    snapshot: ExternalMoveSnapshot,
+  ): Promise<SafeMovePathState> {
+    const relativePath = normalizeRelativePath(requestedRelativePath);
+    try {
+      await this.resolveNewTarget(runtime, relativePath);
+      return "absent";
+    } catch (error) {
+      if (
+        !(error instanceof ExternalRootError) ||
+        error.code !== "target_exists"
+      ) {
+        throw error;
+      }
+    }
+
+    let absolutePath: string;
+    try {
+      absolutePath = await this.resolvePath(runtime, relativePath);
+    } catch (error) {
+      if (
+        error instanceof ExternalRootError &&
+        (error.code === "not_a_file" || error.code === "not_found")
+      ) {
+        return error.code === "not_found" ? "absent" : "mismatch";
+      }
+      throw error;
+    }
+    const current = await lstat(absolutePath);
+    if (!current.isFile() || current.isSymbolicLink()) return "mismatch";
+    const verified = await this.readVerifiedBuffer(runtime, relativePath);
+    return verified.buffer.length === snapshot.size &&
+      verified.modifiedAt === snapshot.modifiedAt &&
+      sha256(verified.buffer) === snapshot.sha256
+      ? "matching"
+      : "mismatch";
   }
 
   private async resolvePath(

--- a/src/services/externalRootsService.ts
+++ b/src/services/externalRootsService.ts
@@ -2,6 +2,7 @@ import { createHash, randomUUID } from "node:crypto";
 import { rmSync } from "node:fs";
 import {
   type FileHandle,
+  link,
   lstat,
   mkdtemp,
   open,
@@ -11,16 +12,19 @@ import {
   rename,
   rm,
   stat,
+  unlink,
   writeFile,
 } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { z } from "zod";
 
 export const ExternalRootCapabilitySchema = z.enum([
   "visible",
   "readable",
   "handoff",
+  "move",
 ]);
 
 const ExternalRootLimitsSchema = z
@@ -116,6 +120,8 @@ export type ExternalRootErrorCode =
   | "not_found"
   | "not_a_file"
   | "not_a_directory"
+  | "target_exists"
+  | "precondition_failed"
   | "too_large"
   | "unsupported"
   | "encrypted"
@@ -144,6 +150,15 @@ export type ExternalEntry = {
   type: "file" | "directory" | "link";
   size?: number;
   modifiedAt?: string;
+};
+
+export type ExternalMoveSnapshot = {
+  rootId: string;
+  sourceRelativePath: string;
+  targetRelativePath: string;
+  size: number;
+  modifiedAt: string;
+  sha256: string;
 };
 
 const textExtensions = new Set([
@@ -517,6 +532,256 @@ export class ExternalRootsService {
       }
       return response;
     });
+  }
+
+  async planMove(
+    rootId: string,
+    requestedSourcePath: string,
+    requestedTargetPath: string,
+  ): Promise<ExternalMoveSnapshot> {
+    const runtime = this.requireCapability(rootId, "move");
+    const sourceRelativePath = normalizeRelativePath(requestedSourcePath);
+    const targetRelativePath = normalizeRelativePath(requestedTargetPath);
+    if (!sourceRelativePath || !targetRelativePath) {
+      throw new ExternalRootError(
+        "path_invalid",
+        "External move paths must identify regular files.",
+      );
+    }
+    if (sourceRelativePath === targetRelativePath) {
+      throw new ExternalRootError(
+        "path_invalid",
+        "External move source and target must be different.",
+      );
+    }
+
+    const sourcePath = await this.resolvePath(runtime, sourceRelativePath);
+    const sourceStat = await stat(sourcePath, { bigint: true });
+    if (!sourceStat.isFile()) {
+      throw new ExternalRootError(
+        "not_a_file",
+        "Only regular external files can be moved.",
+      );
+    }
+    this.assertAllowed(runtime, targetRelativePath);
+    const rootPath = await this.canonicalRoot(runtime);
+    const targetPath = path.join(rootPath, ...targetRelativePath.split("/"));
+    if (!isInsideRoot(rootPath, targetPath)) {
+      throw new ExternalRootError(
+        "path_outside_root",
+        "The target path is outside the configured external root.",
+      );
+    }
+    const parentPath = path.dirname(targetPath);
+    const parentRealPath = await realpath(parentPath).catch(() => undefined);
+    if (!parentRealPath || !isInsideRoot(rootPath, parentRealPath)) {
+      throw new ExternalRootError(
+        "not_a_directory",
+        "The target parent directory must already exist inside the root.",
+      );
+    }
+    const parentStat = await lstat(parentRealPath);
+    if (!parentStat.isDirectory() || parentStat.isSymbolicLink()) {
+      throw new ExternalRootError(
+        "path_link_unsupported",
+        "The target parent must be a real directory, not a link or junction.",
+      );
+    }
+    try {
+      await lstat(targetPath);
+      throw new ExternalRootError(
+        "target_exists",
+        "The external move target already exists.",
+      );
+    } catch (error) {
+      if (error instanceof ExternalRootError) throw error;
+      const code =
+        typeof error === "object" && error && "code" in error
+          ? String(error.code)
+          : "";
+      if (code !== "ENOENT") {
+        throw new ExternalRootError(
+          "non_verifiable",
+          "The external move target could not be verified.",
+        );
+      }
+    }
+
+    return this.inspectMoveSource(
+      rootId,
+      sourceRelativePath,
+      targetRelativePath,
+    );
+  }
+
+  async inspectMoveSource(
+    rootId: string,
+    requestedSourcePath: string,
+    targetRelativePath = "",
+  ): Promise<ExternalMoveSnapshot> {
+    const runtime = this.requireCapability(rootId, "move");
+    const sourceRelativePath = normalizeRelativePath(requestedSourcePath);
+    if (!sourceRelativePath) {
+      throw new ExternalRootError(
+        "path_invalid",
+        "The external source must identify a regular file.",
+      );
+    }
+    const verified = await this.readVerifiedBuffer(runtime, sourceRelativePath);
+    return {
+      rootId,
+      sourceRelativePath,
+      targetRelativePath,
+      size: verified.buffer.length,
+      modifiedAt: verified.modifiedAt,
+      sha256: sha256(verified.buffer),
+    };
+  }
+
+  async applyMove(snapshot: ExternalMoveSnapshot): Promise<void> {
+    const current = await this.planMove(
+      snapshot.rootId,
+      snapshot.sourceRelativePath,
+      snapshot.targetRelativePath,
+    );
+    if (
+      current.size !== snapshot.size ||
+      current.modifiedAt !== snapshot.modifiedAt ||
+      current.sha256 !== snapshot.sha256
+    ) {
+      throw new ExternalRootError(
+        "precondition_failed",
+        "The external source changed after the move was planned.",
+      );
+    }
+    const runtime = this.requireCapability(snapshot.rootId, "move");
+    const rootPath = await this.canonicalRoot(runtime);
+    const sourcePath = await this.resolvePath(
+      runtime,
+      snapshot.sourceRelativePath,
+    );
+    const targetPath = path.join(
+      rootPath,
+      ...snapshot.targetRelativePath.split("/"),
+    );
+    try {
+      // link() is no-clobber and keeps the operation on one filesystem. The
+      // source is removed only after the target identity is verified.
+      await link(sourcePath, targetPath);
+      const sourceStat = await stat(sourcePath, { bigint: true });
+      const targetStat = await stat(targetPath, { bigint: true });
+      if (
+        sourceStat.dev !== targetStat.dev ||
+        sourceStat.ino !== targetStat.ino
+      ) {
+        throw new ExternalRootError(
+          "non_verifiable",
+          "The external move target is not the verified source object.",
+        );
+      }
+      await unlink(sourcePath);
+    } catch (error) {
+      if (error instanceof ExternalRootError) {
+        await unlink(targetPath).catch(() => undefined);
+        throw error;
+      }
+      const code =
+        typeof error === "object" && error && "code" in error
+          ? String(error.code)
+          : "";
+      if (code === "EEXIST") {
+        throw new ExternalRootError(
+          "target_exists",
+          "The external move target already exists.",
+        );
+      }
+      await unlink(targetPath).catch(() => undefined);
+      throw new ExternalRootError(
+        code === "EXDEV" || code === "ENOTSUP"
+          ? "unsupported"
+          : "non_verifiable",
+        "The filesystem cannot complete a verified no-clobber move.",
+      );
+    }
+  }
+
+  async rollbackMove(snapshot: ExternalMoveSnapshot): Promise<void> {
+    const runtime = this.requireCapability(snapshot.rootId, "move");
+    const rootPath = await this.canonicalRoot(runtime);
+    const sourcePath = path.join(
+      rootPath,
+      ...snapshot.sourceRelativePath.split("/"),
+    );
+    const targetPath = await this.resolvePath(
+      runtime,
+      snapshot.targetRelativePath,
+    );
+    try {
+      await lstat(sourcePath);
+      throw new ExternalRootError(
+        "target_exists",
+        "The original external source path is already occupied.",
+      );
+    } catch (error) {
+      if (error instanceof ExternalRootError) throw error;
+      const code =
+        typeof error === "object" && error && "code" in error
+          ? String(error.code)
+          : "";
+      if (code !== "ENOENT") {
+        throw new ExternalRootError(
+          "non_verifiable",
+          "The original external source path could not be verified.",
+        );
+      }
+    }
+    const verified = await this.readVerifiedBuffer(
+      runtime,
+      snapshot.targetRelativePath,
+    );
+    if (
+      verified.buffer.length !== snapshot.size ||
+      sha256(verified.buffer) !== snapshot.sha256
+    ) {
+      throw new ExternalRootError(
+        "precondition_failed",
+        "The moved external file changed and cannot be rolled back safely.",
+      );
+    }
+    await link(targetPath, sourcePath);
+    await unlink(targetPath);
+  }
+
+  async getPrivateReferenceLocation(
+    rootId: string,
+    requestedPath: string,
+  ): Promise<{ absolutePath: string; fileUri: string }> {
+    const runtime = this.requireCapability(rootId, "move");
+    const relativePath = normalizeRelativePath(requestedPath);
+    const absolutePath = await this.resolvePath(runtime, relativePath);
+    return {
+      absolutePath,
+      fileUri: pathToFileURL(absolutePath).href,
+    };
+  }
+
+  async getPrivateMoveLocations(
+    snapshot: ExternalMoveSnapshot,
+  ): Promise<{ sourceFileUri: string; targetFileUri: string }> {
+    const runtime = this.requireCapability(snapshot.rootId, "move");
+    const rootPath = await this.canonicalRoot(runtime);
+    const sourcePath = await this.resolvePath(
+      runtime,
+      snapshot.sourceRelativePath,
+    );
+    const targetPath = path.join(
+      rootPath,
+      ...snapshot.targetRelativePath.split("/"),
+    );
+    return {
+      sourceFileUri: pathToFileURL(sourcePath).href,
+      targetFileUri: pathToFileURL(targetPath).href,
+    };
   }
 
   private async withHandoffLock<T>(operation: () => Promise<T>): Promise<T> {

--- a/src/services/externalRootsService.ts
+++ b/src/services/externalRootsService.ts
@@ -846,7 +846,15 @@ export class ExternalRootsService {
   ): Promise<{ absolutePath: string; fileUri: string }> {
     const runtime = this.requireCapability(rootId, "move");
     const relativePath = normalizeRelativePath(requestedPath);
-    const absolutePath = await this.resolvePath(runtime, relativePath);
+    // Validate against the canonical confined object, but keep the configured
+    // root spelling for the user-facing locator. Windows realpath() may expand
+    // aliases or change drive/path casing even though both names identify the
+    // same configured root.
+    await this.resolvePath(runtime, relativePath);
+    const absolutePath = path.resolve(
+      runtime.config.path,
+      ...relativePath.split("/"),
+    );
     return {
       absolutePath,
       fileUri: pathToFileURL(absolutePath).href,
@@ -857,13 +865,21 @@ export class ExternalRootsService {
     snapshot: ExternalMoveSnapshot,
   ): Promise<{ sourceFileUri: string; targetFileUri: string }> {
     const runtime = this.requireCapability(snapshot.rootId, "move");
-    const sourcePath = await this.resolvePath(
+    await this.resolvePath(
       runtime,
       normalizeRelativePath(snapshot.sourceRelativePath),
     );
-    const targetPath = await this.resolveNewTarget(
+    await this.resolveNewTarget(
       runtime,
       normalizeRelativePath(snapshot.targetRelativePath),
+    );
+    const sourcePath = path.resolve(
+      runtime.config.path,
+      ...normalizeRelativePath(snapshot.sourceRelativePath).split("/"),
+    );
+    const targetPath = path.resolve(
+      runtime.config.path,
+      ...normalizeRelativePath(snapshot.targetRelativePath).split("/"),
     );
     return {
       sourceFileUri: pathToFileURL(sourcePath).href,

--- a/src/services/obsidianRestAPI/methods/vaultMethods.ts
+++ b/src/services/obsidianRestAPI/methods/vaultMethods.ts
@@ -6,12 +6,14 @@
 
 import { RequestContext } from "../../../utils/index.js";
 import {
+  DocumentMap,
   NoteJson,
   FileListResponse,
   NoteStat,
   RequestFunction,
 } from "../types.js";
 import { encodeVaultPath } from "../../../utils/obsidian/obsidianApiUtils.js";
+import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
 
 /**
  * Gets the content of a specific file in the vault.
@@ -38,6 +40,94 @@ export async function getFileContent(
     },
     context,
     "getFileContent",
+  );
+}
+
+/**
+ * Gets the markdown-patch 2.x document map for a vault file.
+ *
+ * The returned version token can be supplied to
+ * {@link replaceFileContentIfMatch} for an atomic read-modify-write cycle.
+ */
+export async function getFileDocumentMap(
+  _request: RequestFunction,
+  filePath: string,
+  context: RequestContext,
+): Promise<DocumentMap> {
+  const encodedPath = encodeVaultPath(filePath);
+  const documentMap = await _request<DocumentMap>(
+    {
+      method: "GET",
+      url: `/vault${encodedPath}`,
+      headers: {
+        Accept: "application/vnd.olrapi.document-map+json",
+      },
+    },
+    context,
+    "getFileDocumentMap",
+  );
+
+  if (
+    !documentMap ||
+    typeof documentMap.version !== "string" ||
+    documentMap.version.trim().length === 0
+  ) {
+    throw new McpError(
+      BaseErrorCode.SERVICE_UNAVAILABLE,
+      "Obsidian Local REST API did not return a document version. Conditional writes require markdown-patch 2.x support.",
+      { filePath },
+    );
+  }
+
+  return documentMap;
+}
+
+/**
+ * Replaces an existing vault file only if its document version still matches.
+ *
+ * This uses markdown-patch 2.x raw-content mode. A stale version is returned by
+ * Local REST API as HTTP 412 and mapped by the service to CONFLICT.
+ *
+ * Empty content is rejected deliberately: raw-content mode treats an empty
+ * body as a missing payload rather than an instruction to clear the note.
+ */
+export async function replaceFileContentIfMatch(
+  _request: RequestFunction,
+  filePath: string,
+  content: string,
+  expectedVersion: string,
+  context: RequestContext,
+): Promise<void> {
+  const normalizedVersion = expectedVersion.trim();
+  if (!normalizedVersion) {
+    throw new McpError(
+      BaseErrorCode.VALIDATION_ERROR,
+      "A non-empty document version is required for a conditional write.",
+      { filePath },
+    );
+  }
+  if (content.length === 0) {
+    throw new McpError(
+      BaseErrorCode.VALIDATION_ERROR,
+      "Conditional raw-content replacement cannot use an empty payload.",
+      { filePath },
+    );
+  }
+
+  const encodedPath = encodeVaultPath(filePath);
+  await _request<void>(
+    {
+      method: "PATCH",
+      url: `/vault${encodedPath}`,
+      headers: {
+        "Content-Type": "text/markdown",
+        Operation: "replace",
+        "If-Match": normalizedVersion,
+      },
+      data: content,
+    },
+    context,
+    "replaceFileContentIfMatch",
   );
 }
 

--- a/src/services/obsidianRestAPI/methods/vaultMethods.ts
+++ b/src/services/obsidianRestAPI/methods/vaultMethods.ts
@@ -5,15 +5,8 @@
  */
 
 import { RequestContext } from "../../../utils/index.js";
-import {
-  DocumentMap,
-  NoteJson,
-  FileListResponse,
-  NoteStat,
-  RequestFunction,
-} from "../types.js";
+import { NoteJson, FileListResponse, NoteStat, RequestFunction } from "../types.js";
 import { encodeVaultPath } from "../../../utils/obsidian/obsidianApiUtils.js";
-import { BaseErrorCode, McpError } from "../../../types-global/errors.js";
 
 /**
  * Gets the content of a specific file in the vault.
@@ -40,94 +33,6 @@ export async function getFileContent(
     },
     context,
     "getFileContent",
-  );
-}
-
-/**
- * Gets the markdown-patch 2.x document map for a vault file.
- *
- * The returned version token can be supplied to
- * {@link replaceFileContentIfMatch} for an atomic read-modify-write cycle.
- */
-export async function getFileDocumentMap(
-  _request: RequestFunction,
-  filePath: string,
-  context: RequestContext,
-): Promise<DocumentMap> {
-  const encodedPath = encodeVaultPath(filePath);
-  const documentMap = await _request<DocumentMap>(
-    {
-      method: "GET",
-      url: `/vault${encodedPath}`,
-      headers: {
-        Accept: "application/vnd.olrapi.document-map+json",
-      },
-    },
-    context,
-    "getFileDocumentMap",
-  );
-
-  if (
-    !documentMap ||
-    typeof documentMap.version !== "string" ||
-    documentMap.version.trim().length === 0
-  ) {
-    throw new McpError(
-      BaseErrorCode.SERVICE_UNAVAILABLE,
-      "Obsidian Local REST API did not return a document version. Conditional writes require markdown-patch 2.x support.",
-      { filePath },
-    );
-  }
-
-  return documentMap;
-}
-
-/**
- * Replaces an existing vault file only if its document version still matches.
- *
- * This uses markdown-patch 2.x raw-content mode. A stale version is returned by
- * Local REST API as HTTP 412 and mapped by the service to CONFLICT.
- *
- * Empty content is rejected deliberately: raw-content mode treats an empty
- * body as a missing payload rather than an instruction to clear the note.
- */
-export async function replaceFileContentIfMatch(
-  _request: RequestFunction,
-  filePath: string,
-  content: string,
-  expectedVersion: string,
-  context: RequestContext,
-): Promise<void> {
-  const normalizedVersion = expectedVersion.trim();
-  if (!normalizedVersion) {
-    throw new McpError(
-      BaseErrorCode.VALIDATION_ERROR,
-      "A non-empty document version is required for a conditional write.",
-      { filePath },
-    );
-  }
-  if (content.length === 0) {
-    throw new McpError(
-      BaseErrorCode.VALIDATION_ERROR,
-      "Conditional raw-content replacement cannot use an empty payload.",
-      { filePath },
-    );
-  }
-
-  const encodedPath = encodeVaultPath(filePath);
-  await _request<void>(
-    {
-      method: "PATCH",
-      url: `/vault${encodedPath}`,
-      headers: {
-        "Content-Type": "text/markdown",
-        Operation: "replace",
-        "If-Match": normalizedVersion,
-      },
-      data: content,
-    },
-    context,
-    "replaceFileContentIfMatch",
   );
 }
 

--- a/src/services/obsidianRestAPI/service.ts
+++ b/src/services/obsidianRestAPI/service.ts
@@ -37,6 +37,7 @@ import {
   BaseUpsertRequest,
   BaseUpsertResponse,
   ComplexSearchResult,
+  DocumentMap,
   NoteJson,
   NoteStat,
   ObsidianCommand,
@@ -159,6 +160,11 @@ export class ObsidianRestApiService {
                 errorCode = BaseErrorCode.VALIDATION_ERROR; // Method not allowed often implies incorrect usage
                 errorMessage = `Obsidian API Method Not Allowed: ${requestConfig.method} on ${requestConfig.url}`;
                 break;
+              case 412:
+                errorCode = BaseErrorCode.CONFLICT;
+                errorMessage =
+                  "Obsidian API Precondition Failed: the note changed after it was read.";
+                break;
               case 503:
                 errorCode = BaseErrorCode.SERVICE_UNAVAILABLE;
                 errorMessage = "Obsidian API Service Unavailable.";
@@ -243,6 +249,38 @@ export class ObsidianRestApiService {
       this._request.bind(this),
       filePath,
       format,
+      context,
+    );
+  }
+
+  /**
+   * Gets the markdown-patch 2.x document map and optimistic-concurrency token.
+   */
+  async getFileDocumentMap(
+    filePath: string,
+    context: RequestContext,
+  ): Promise<DocumentMap> {
+    return vaultMethods.getFileDocumentMap(
+      this._request.bind(this),
+      filePath,
+      context,
+    );
+  }
+
+  /**
+   * Replaces an existing file only when its document version is unchanged.
+   */
+  async replaceFileContentIfMatch(
+    filePath: string,
+    content: string,
+    expectedVersion: string,
+    context: RequestContext,
+  ): Promise<void> {
+    return vaultMethods.replaceFileContentIfMatch(
+      this._request.bind(this),
+      filePath,
+      content,
+      expectedVersion,
       context,
     );
   }
@@ -430,11 +468,7 @@ export class ObsidianRestApiService {
     payload: BaseCreateRequest,
     context: RequestContext,
   ): Promise<BaseCreateResponse> {
-    return basesMethods.createBase(
-      this._request.bind(this),
-      payload,
-      context,
-    );
+    return basesMethods.createBase(this._request.bind(this), payload, context);
   }
 
   /**

--- a/src/services/obsidianRestAPI/service.ts
+++ b/src/services/obsidianRestAPI/service.ts
@@ -37,7 +37,6 @@ import {
   BaseUpsertRequest,
   BaseUpsertResponse,
   ComplexSearchResult,
-  DocumentMap,
   NoteJson,
   NoteStat,
   ObsidianCommand,
@@ -249,38 +248,6 @@ export class ObsidianRestApiService {
       this._request.bind(this),
       filePath,
       format,
-      context,
-    );
-  }
-
-  /**
-   * Gets the markdown-patch 2.x document map and optimistic-concurrency token.
-   */
-  async getFileDocumentMap(
-    filePath: string,
-    context: RequestContext,
-  ): Promise<DocumentMap> {
-    return vaultMethods.getFileDocumentMap(
-      this._request.bind(this),
-      filePath,
-      context,
-    );
-  }
-
-  /**
-   * Replaces an existing file only when its document version is unchanged.
-   */
-  async replaceFileContentIfMatch(
-    filePath: string,
-    content: string,
-    expectedVersion: string,
-    context: RequestContext,
-  ): Promise<void> {
-    return vaultMethods.replaceFileContentIfMatch(
-      this._request.bind(this),
-      filePath,
-      content,
-      expectedVersion,
       context,
     );
   }

--- a/src/services/obsidianRestAPI/types.ts
+++ b/src/services/obsidianRestAPI/types.ts
@@ -47,6 +47,25 @@ export interface NoteJson {
 }
 
 /**
+ * Recursive heading tree returned by markdown-patch 2.x document maps.
+ */
+export interface DocumentHeadingTree {
+  [heading: string]: DocumentHeadingTree;
+}
+
+/**
+ * Document map returned by Obsidian Local REST API 5.x and later.
+ *
+ * The version is a content-hash token suitable for optimistic concurrency.
+ */
+export interface DocumentMap {
+  headings: DocumentHeadingTree;
+  blocks: string[];
+  frontmatterFields: string[];
+  version: string;
+}
+
+/**
  * Response structure for listing files in a directory.
  */
 export interface FileListResponse {

--- a/src/services/obsidianRestAPI/types.ts
+++ b/src/services/obsidianRestAPI/types.ts
@@ -47,25 +47,6 @@ export interface NoteJson {
 }
 
 /**
- * Recursive heading tree returned by markdown-patch 2.x document maps.
- */
-export interface DocumentHeadingTree {
-  [heading: string]: DocumentHeadingTree;
-}
-
-/**
- * Document map returned by Obsidian Local REST API 5.x and later.
- *
- * The version is a content-hash token suitable for optimistic concurrency.
- */
-export interface DocumentMap {
-  headings: DocumentHeadingTree;
-  blocks: string[];
-  frontmatterFields: string[];
-  version: string;
-}
-
-/**
  * Response structure for listing files in a directory.
  */
 export interface FileListResponse {

--- a/src/services/writePolicy.ts
+++ b/src/services/writePolicy.ts
@@ -20,7 +20,9 @@ export type WriteOperation =
   | "operon_update_task"
   | "operon_transition_task"
   | "operon_convert_task"
-  | "operon_relocate_task";
+  | "operon_relocate_task"
+  | "external_move_apply"
+  | "external_move_rollback";
 
 type GuardCheck = {
   operation: WriteOperation;

--- a/src/stdio-proxy.ts
+++ b/src/stdio-proxy.ts
@@ -15,15 +15,24 @@ import {
 import {
   ExternalHandoffSchema,
   ExternalListSchema,
+  ExternalMoveApplySchema,
+  ExternalMovePlanSchema,
+  ExternalMoveRollbackSchema,
+  ExternalMoveStatusSchema,
   ExternalReadSchema,
+  ExternalReferencesScanSchema,
   ExternalStatSchema,
   externalRootsResult,
 } from "./mcp-server/tools/externalRootsTools/registration.js";
+import { config } from "./config/index.js";
 import { ensureLocalBackendRunning } from "./runtime/localBackend.js";
 import {
   ExternalRootError,
   ExternalRootsService,
 } from "./services/externalRootsService.js";
+import { BackendVaultAdapter } from "./services/externalReferences/backendVaultAdapter.js";
+import { ExternalMoveCoordinator } from "./services/externalReferences/externalMoveCoordinator.js";
+import { ExternalMoveJournal } from "./services/externalReferences/externalMoveJournal.js";
 
 type PackageInfo = { name?: string; version?: string };
 type BackendClient = {
@@ -53,6 +62,7 @@ const proxyServer = new Server(
 
 let backend: BackendClient | undefined;
 let externalRootsService: ExternalRootsService | undefined;
+let externalMoveCoordinator: ExternalMoveCoordinator | undefined;
 
 function disabledExternalRoots(): Promise<never> {
   return Promise.reject(
@@ -182,6 +192,23 @@ async function start() {
     : undefined;
 
   await ensureBackendConnected();
+  if (externalRootsService) {
+    const vault = new BackendVaultAdapter((name, args) =>
+      withBackendRetry(
+        `external reference backend adapter: ${name}`,
+        (client) =>
+          client.callTool(
+            { name, arguments: args },
+            CompatibilityCallToolResultSchema,
+          ),
+      ),
+    );
+    externalMoveCoordinator = new ExternalMoveCoordinator(
+      externalRootsService,
+      vault,
+      new ExternalMoveJournal(config.externalMoveJournalPath),
+    );
+  }
 
   proxyServer.setRequestHandler(ListToolsRequestSchema, async (request) =>
     withBackendRetry("listTools", (client) => client.listTools(request.params)),
@@ -191,8 +218,19 @@ async function start() {
     if (request.params.name === "external_runtime_status") {
       return externalRootsResult(async () => ({
         enabled: Boolean(externalRootsService),
-        mode: "read-only",
+        mode:
+          config.externalMoveEnabled && config.mcpWriteMode === "full"
+            ? "read-write-opt-in"
+            : "read-only",
         localHandoffAllowed: true,
+        externalMove: {
+          available:
+            Boolean(externalMoveCoordinator) &&
+            config.externalMoveEnabled &&
+            config.mcpWriteMode === "full",
+          transport: "stdio-only",
+          requiresRootCapability: "move",
+        },
         roots: externalRootsService
           ? await externalRootsService.listRoots()
           : [],
@@ -288,6 +326,101 @@ async function start() {
               parsed.data.rootId,
               parsed.data.relativePath,
               parsed.data.includeHash,
+            )
+          : disabledExternalRoots(),
+      )();
+    }
+
+    if (request.params.name === "external_references_scan") {
+      const parsed = ExternalReferencesScanSchema.safeParse(
+        request.params.arguments ?? {},
+      );
+      if (!parsed.success) {
+        return invalidExternalArguments(
+          request.params.name,
+          parsed.error.message,
+        );
+      }
+      return externalRootsResult(() =>
+        externalMoveCoordinator
+          ? externalMoveCoordinator.scan(
+              parsed.data.rootId,
+              parsed.data.relativePath,
+              parsed.data.searchInPath,
+            )
+          : disabledExternalRoots(),
+      )();
+    }
+
+    if (request.params.name === "external_move_plan") {
+      const parsed = ExternalMovePlanSchema.safeParse(
+        request.params.arguments ?? {},
+      );
+      if (!parsed.success) {
+        return invalidExternalArguments(
+          request.params.name,
+          parsed.error.message,
+        );
+      }
+      return externalRootsResult(() =>
+        externalMoveCoordinator
+          ? externalMoveCoordinator.plan(parsed.data)
+          : disabledExternalRoots(),
+      )();
+    }
+
+    if (request.params.name === "external_move_status") {
+      const parsed = ExternalMoveStatusSchema.safeParse(
+        request.params.arguments ?? {},
+      );
+      if (!parsed.success) {
+        return invalidExternalArguments(
+          request.params.name,
+          parsed.error.message,
+        );
+      }
+      return externalRootsResult(async () =>
+        externalMoveCoordinator
+          ? externalMoveCoordinator.status(parsed.data.planId)
+          : disabledExternalRoots(),
+      )();
+    }
+
+    if (request.params.name === "external_move_apply") {
+      const parsed = ExternalMoveApplySchema.safeParse(
+        request.params.arguments ?? {},
+      );
+      if (!parsed.success) {
+        return invalidExternalArguments(
+          request.params.name,
+          parsed.error.message,
+        );
+      }
+      return externalRootsResult(() =>
+        externalMoveCoordinator
+          ? externalMoveCoordinator.apply(
+              parsed.data.planId,
+              parsed.data.idempotencyKey,
+            )
+          : disabledExternalRoots(),
+      )();
+    }
+
+    if (request.params.name === "external_move_rollback") {
+      const parsed = ExternalMoveRollbackSchema.safeParse(
+        request.params.arguments ?? {},
+      );
+      if (!parsed.success) {
+        return invalidExternalArguments(
+          request.params.name,
+          parsed.error.message,
+        );
+      }
+      return externalRootsResult(() =>
+        externalMoveCoordinator
+          ? externalMoveCoordinator.rollback(
+              parsed.data.planId,
+              parsed.data.idempotencyKey,
             )
           : disabledExternalRoots(),
       )();

--- a/src/stdio-proxy.ts
+++ b/src/stdio-proxy.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
@@ -24,13 +25,14 @@ import {
   ExternalStatSchema,
   externalRootsResult,
 } from "./mcp-server/tools/externalRootsTools/registration.js";
-import { config } from "./config/index.js";
+import { config, profileExternalMoveJournalPath } from "./config/index.js";
 import { ensureLocalBackendRunning } from "./runtime/localBackend.js";
 import {
   ExternalRootError,
   ExternalRootsService,
 } from "./services/externalRootsService.js";
 import { BackendVaultAdapter } from "./services/externalReferences/backendVaultAdapter.js";
+import type { ExternalMoveBindingIdentity } from "./services/externalReferences/backendVaultAdapter.js";
 import { ExternalMoveCoordinator } from "./services/externalReferences/externalMoveCoordinator.js";
 import { ExternalMoveJournal } from "./services/externalReferences/externalMoveJournal.js";
 
@@ -63,6 +65,29 @@ const proxyServer = new Server(
 let backend: BackendClient | undefined;
 let externalRootsService: ExternalRootsService | undefined;
 let externalMoveCoordinator: ExternalMoveCoordinator | undefined;
+let externalMoveBindingIdentity: ExternalMoveBindingIdentity | undefined;
+
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalJson(item)).join(",")}]`;
+  }
+  if (typeof value === "object" && value !== null) {
+    const record = value as Record<string, unknown>;
+    return `{${Object.keys(record)
+      .sort((left, right) => left.localeCompare(right))
+      .map((key) => `${JSON.stringify(key)}:${canonicalJson(record[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
+function rootConfigFingerprint(filePath: string): string {
+  const parsed = JSON.parse(readFileSync(filePath, "utf8")) as unknown;
+  return createHash("sha256")
+    .update("optimike.external-move.roots.v1\0", "utf8")
+    .update(canonicalJson(parsed), "utf8")
+    .digest("hex");
+}
 
 function disabledExternalRoots(): Promise<never> {
   return Promise.reject(
@@ -193,20 +218,34 @@ async function start() {
 
   await ensureBackendConnected();
   if (externalRootsService) {
-    const vault = new BackendVaultAdapter((name, args) =>
-      withBackendRetry(
-        `external reference backend adapter: ${name}`,
-        (client) =>
-          client.callTool(
-            { name, arguments: args },
-            CompatibilityCallToolResultSchema,
-          ),
-      ),
+    const rootsFingerprint = rootConfigFingerprint(
+      process.env.MCP_EXTERNAL_ROOTS_FILE!,
+    );
+    const vault = new BackendVaultAdapter(
+      (name, args) =>
+        withBackendRetry(
+          `external reference backend adapter: ${name}`,
+          (client) =>
+            client.callTool(
+              { name, arguments: args },
+              CompatibilityCallToolResultSchema,
+            ),
+        ),
+      {
+        backendEndpoint: backendUrl.toString(),
+        rootConfigFingerprint: rootsFingerprint,
+        profileId: config.externalMoveProfileId,
+      },
+    );
+    externalMoveBindingIdentity = await vault.getBindingIdentity();
+    const profiledJournalPath = profileExternalMoveJournalPath(
+      config.externalMoveJournalPath,
+      externalMoveBindingIdentity.bindingFingerprint,
     );
     externalMoveCoordinator = new ExternalMoveCoordinator(
       externalRootsService,
       vault,
-      new ExternalMoveJournal(config.externalMoveJournalPath),
+      new ExternalMoveJournal(profiledJournalPath),
     );
   }
 
@@ -226,10 +265,14 @@ async function start() {
         externalMove: {
           available:
             Boolean(externalMoveCoordinator) &&
+            externalMoveBindingIdentity?.verifiable === true &&
             config.externalMoveEnabled &&
             config.mcpWriteMode === "full",
           transport: "stdio-only",
           requiresRootCapability: "move",
+          identityVerified: externalMoveBindingIdentity?.verifiable ?? false,
+          identitySource: externalMoveBindingIdentity?.vaultIdentitySource,
+          profileFingerprint: externalMoveBindingIdentity?.bindingFingerprint,
         },
         roots: externalRootsService
           ? await externalRootsService.listRoots()
@@ -346,7 +389,6 @@ async function start() {
           ? externalMoveCoordinator.scan(
               parsed.data.rootId,
               parsed.data.relativePath,
-              parsed.data.searchInPath,
             )
           : disabledExternalRoots(),
       )();


### PR DESCRIPTION
## Summary

- add canonical `external-ref:<rootId>::<encoded-relative-path>` identities beside clickable `file:///` links
- add stdio-only scan, plan, status, apply and rollback tools for same-root external file moves
- repair exact ÉLYSIA references with Local REST document-map CAS (`If-Match`)
- keep HTTP mutation denied and retain explicit triple opt-in (`full` write mode, feature flag, root `move` capability)
- add durable private SQLite plans, idempotency and rollback preimages
- publish equivalent English/French ADR, setup, routing, runtime and security documentation

## Safety boundary

Files only; same logical root and filesystem; target absent; parent exists; no overwrite, directory move, create, replace, upload, delete or sync. Legacy, historical or ambiguous references block apply.

## Validation

- `npm run test:external-roots`
- `npm run test:runtime`
- `npm run test:tool-annotations`
- `npm run test:package`
- `npm run test:docs`
- `npm audit --omit=dev --audit-level=high`
- real non-sensitive B: pilot: plan/apply/repair/status/rollback, SHA-256 preserved

The real pilot also caught Obsidian-managed `création`/`modification` drift. Rollback now preserves those current values while rejecting any other note change.