### PR TITLE
fix: preserve CAS and recover interrupted external moves

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "smoke:operon-rich-mutations": "node scripts/smoke-operon-rich-mutations.mjs",
     "test:profiles": "node scripts/test-elysia-task-profile.mjs",
     "test:tool-annotations": "node scripts/test-tool-annotations.mjs",
-    "test:external-roots": "npm run build && node scripts/test-external-reference-parser.mjs && node scripts/test-external-move-integrity.mjs && node scripts/test-obsidian-cas.mjs && node scripts/test-obsidian-search-replace-cas.mjs && node scripts/test-external-roots.mjs && node scripts/test-stdio-proxy-external-roots.mjs && node scripts/test-http-external-handoff.mjs",
+    "test:external-roots": "npm run build && node scripts/test-external-reference-parser.mjs && node scripts/test-external-move-integrity.mjs && node scripts/test-backend-vault-adapter-cas.mjs && node scripts/test-obsidian-cas.mjs && node scripts/test-obsidian-search-replace-cas.mjs && node scripts/test-external-roots.mjs && node scripts/test-stdio-proxy-external-roots.mjs && node scripts/test-http-external-handoff.mjs",
     "test:external-roots:proxy": "npm run build && node scripts/test-stdio-proxy-external-roots.mjs",
     "test:http-external-handoff": "npm run build && node scripts/test-http-external-handoff.mjs",
     "smoke:external-roots": "npm run build && node scripts/smoke-external-roots.mjs",

--- a/scripts/test-backend-vault-adapter-cas.mjs
+++ b/scripts/test-backend-vault-adapter-cas.mjs
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+
+const { BackendVaultAdapter } = await import(
+  "../dist/services/externalReferences/backendVaultAdapter.js"
+);
+
+const before = "# Pilot\n\nOld reference\n";
+const after = "# Pilot\n\nNew reference\n";
+const expectedHash = createHash("sha256")
+  .update(before, "utf8")
+  .digest("hex");
+const resultingHash = createHash("sha256")
+  .update(after, "utf8")
+  .digest("hex");
+
+function result(payload) {
+  return {
+    content: [{ type: "text", text: JSON.stringify(payload) }],
+    isError: false,
+  };
+}
+
+{
+  const calls = [];
+  const adapter = new BackendVaultAdapter(async (name, args) => {
+    calls.push({ name, args });
+    return result({
+      success: true,
+      replacementsApplied: 1,
+      stats: { hash: resultingHash },
+    });
+  });
+
+  await adapter.conditionalReplace(
+    "Efforts/Projets/Pilot.md",
+    before,
+    after,
+    expectedHash,
+  );
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].name, "obsidian_search_replace");
+  assert.equal(calls[0].args.expectedHash, expectedHash);
+  assert.equal("expectedSha256" in calls[0].args, false);
+}
+
+for (const payload of [
+  {
+    success: true,
+    replacementsApplied: 0,
+    stats: { hash: resultingHash },
+  },
+  {
+    success: true,
+    replacementsApplied: 1,
+    stats: { hash: expectedHash },
+  },
+]) {
+  const adapter = new BackendVaultAdapter(async () => result(payload));
+  await assert.rejects(
+    () =>
+      adapter.conditionalReplace(
+        "Efforts/Projets/Pilot.md",
+        before,
+        after,
+        expectedHash,
+      ),
+    /conditional vault repair did not succeed/u,
+  );
+}
+
+console.log(
+  "Backend vault adapter CAS forwarding and repair proof tests passed.",
+);

--- a/scripts/test-external-move-integrity.mjs
+++ b/scripts/test-external-move-integrity.mjs
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
 import {
   access,
+  link,
   mkdir,
   mkdtemp,
   readFile,
@@ -534,6 +535,55 @@ try {
   assert.equal(await readFile(recoverySource, "utf8"), "recovery");
   assert.equal(await exists(recoveryTarget), false);
   assert.equal(recoveryVault.notes.get(recoveryNotePath), recoveryNote);
+
+  // A crash after the no-clobber hard link but before source unlink leaves
+  // both paths on the same inode. Rollback must recover that verified window.
+  const linkedRecoverySource = path.join(rootPath, "linked-recovery.txt");
+  const linkedRecoveryTarget = path.join(
+    archivePath,
+    "linked-recovery.txt",
+  );
+  await writeFile(linkedRecoverySource, "linked recovery", "utf8");
+  const linkedRecoveryUri = pathToFileURL(linkedRecoverySource).href;
+  const linkedRecoveryNotePath = "Efforts/Projets/Linked recovery.md";
+  const linkedRecoveryNote =
+    `[Linked recovery](${linkedRecoveryUri}) ` +
+    "`external-ref:pilot.move::linked-recovery.txt`\n";
+  const linkedRecoveryVault = new FakeVault({
+    [linkedRecoveryNotePath]: linkedRecoveryNote,
+  });
+  const linkedRecoveryJournal = new ExternalMoveJournal(":memory:");
+  const linkedRecoveryCoordinator = new ExternalMoveCoordinator(
+    service,
+    linkedRecoveryVault,
+    linkedRecoveryJournal,
+  );
+  const linkedRecoveryPlan = await linkedRecoveryCoordinator.plan({
+    rootId: "pilot.move",
+    sourceRelativePath: "linked-recovery.txt",
+    targetRelativePath: "archive/linked-recovery.txt",
+    idempotencyKey: "coordinator-linked-recovery",
+  });
+  await link(linkedRecoverySource, linkedRecoveryTarget);
+  linkedRecoveryJournal.transition(
+    linkedRecoveryPlan.planId,
+    ["planned"],
+    "applying_file",
+  );
+  const linkedRecovered = await linkedRecoveryCoordinator.rollback(
+    linkedRecoveryPlan.planId,
+    "coordinator-linked-recovery",
+  );
+  assert.equal(linkedRecovered.status, "rolled_back");
+  assert.equal(
+    await readFile(linkedRecoverySource, "utf8"),
+    "linked recovery",
+  );
+  assert.equal(await exists(linkedRecoveryTarget), false);
+  assert.equal(
+    linkedRecoveryVault.notes.get(linkedRecoveryNotePath),
+    linkedRecoveryNote,
+  );
 
   // Legacy physical paths are inventoried case-insensitively and block apply.
   const legacyCaseSource = path.join(rootPath, "legacy-case.txt");

--- a/src/services/externalReferences/backendVaultAdapter.ts
+++ b/src/services/externalReferences/backendVaultAdapter.ts
@@ -325,10 +325,14 @@ export class BackendVaultAdapter {
         flexibleWhitespace: false,
         wholeWord: false,
         returnContent: false,
-        expectedSha256,
+        expectedHash: expectedSha256,
       }),
     );
-    if (parsed.success !== true) {
+    if (
+      parsed.success !== true ||
+      parsed.replacementsApplied !== 1 ||
+      nestedRecord(parsed, "stats")?.hash !== sha256Text(after)
+    ) {
       throw new Error("The conditional vault repair did not succeed.");
     }
   }

--- a/src/services/externalReferences/externalMoveCoordinator.ts
+++ b/src/services/externalReferences/externalMoveCoordinator.ts
@@ -497,8 +497,12 @@ export class ExternalMoveCoordinator {
     }
     await this.vault.assertConditionalWritesSupported();
     try {
-      const placement = await this.inspectFilePlacement(plan.snapshot);
-      if (placement === "both" || placement === "missing_or_changed") {
+      let placement = await this.inspectFilePlacement(plan.snapshot);
+      if (placement === "both") {
+        await this.roots.recoverMoveToSource(plan.snapshot);
+        placement = await this.inspectFilePlacement(plan.snapshot);
+      }
+      if (placement === "missing_or_changed" || placement === "both") {
         throw new ExternalRootError(
           "non_verifiable",
           `External file placement is ${placement}; automatic rollback is unsafe.`,


### PR DESCRIPTION
## Summary

- forward the external-reference repair CAS through the headless backend's `expectedHash` field
- require exactly one applied replacement and the expected post-write hash
- recover the verified hard-link crash window during `external_move_rollback`
- add focused regression tests for both late Codex review findings

## Verification

- `npm run test:external-roots`
- `npm run test:runtime`
- `npm run test:docs`
- `npm run build:bridges && npm run test:package`
- `npm run audit:production`

All pass locally on Windows. Production audit reports 0 vulnerabilities.