### PR TITLE
Document and prove external repair compensation

### DIFF
--- a/docs/adr/ADR-External-Reference-Integrity.fr.md
+++ b/docs/adr/ADR-External-Reference-Integrity.fr.md
@@ -31,6 +31,13 @@ Ajouter un workflow réservé au stdio local :
 5. `external_move_rollback` restaure les deux surfaces si toutes les
    préconditions tiennent encore.
 
+La réparation des références fait volontairement partie de
+`external_move_plan` et `external_move_apply` ; il n’existe pas d’outils
+séparés `external_links_repair_plan` ou `external_links_repair_apply`. Le move
+du fichier et les réparations exactes de notes constituent une seule transaction
+compensatoire : un client ne peut pas appliquer une surface en laissant
+silencieusement l’autre incohérente.
+
 Le scan et le plan sont en lecture seule. L’apply et le rollback exigent les
 trois autorisations positives :
 
@@ -63,11 +70,24 @@ segments vides, séparateurs encodés, hôtes UNC, fragments et query strings.
 Le token n’autorise pas l’accès filesystem et n’est pas un protocole URI
 personnalisé. La racine configurée reste l’unique frontière d’autorisation.
 
+Le token sérialisé ne contient que l’identité logique stable. Lors du scan et du
+plan, l’enregistrement complet porte aussi le SHA-256 source, la classification
+de l’occurrence et le chemin de la note source. Le hash et le chemin de note
+sont des preuves mutables, pas l’identité durable ; ils ne sont donc pas
+intégrés au token.
+
 Seule une paire exacte token/lien dans un paragraphe Markdown actif est
 réparable automatiquement. Chemins nus, tokens orphelins, paires incohérentes,
 liens candidats multiples, syntaxes non supportées et références sous des
 headings d’historique, archive, exemple, release notes ou changelog exigent une
 revue manuelle. Toute occurrence en revue manuelle bloque l’apply.
+
+Le scanner utilise un AST Markdown. Les blocs de code fenced ne sont pas
+parcourus et le frontmatter YAML est exclu. Un chemin libre, une propriété YAML
+ou un chemin simplement placé sous une rubrique d’artefacts n’est pas promu en
+référence canonique. Les chemins physiques pertinents et les autres formes non
+supportées sont signalés pour revue manuelle et ne sont jamais réécrits par
+supposition.
 
 ## Transaction filesystem
 
@@ -145,5 +165,6 @@ Ces capacités exigent une valeur ÉLYSIA démontrée et une décision séparée
 
 La régression doit couvrir parsing canonique, références exclues ou ambiguës,
 collision cible, source modifiée, note modifiée, move sans écrasement,
-compensation, rollback, journal résilient au redémarrage, refus HTTP et
+échec après une partie des réparations de notes, compensation, rollback, les
+deux états durables entourant la frontière hard-link/unlink, refus HTTP et
 non-divulgation des chemins, sous Windows et Linux lorsque pertinent.

--- a/docs/adr/ADR-External-Reference-Integrity.md
+++ b/docs/adr/ADR-External-Reference-Integrity.md
@@ -28,6 +28,12 @@ Add a local-stdio-only workflow:
 5. `external_move_rollback` restores both surfaces when every precondition still
    holds.
 
+Reference repair is deliberately part of `external_move_plan` and
+`external_move_apply`; there are no separate `external_links_repair_plan` or
+`external_links_repair_apply` tools. The file move and its exact note repairs
+form one compensating transaction, so a client cannot apply one surface while
+silently leaving the other behind.
+
 Planning and scanning are read-only. Apply and rollback require all three
 positive gates:
 
@@ -60,11 +66,22 @@ fragments and query strings are rejected.
 The token does not authorize filesystem access and is not a custom URI scheme.
 The configured root remains the sole authorization boundary.
 
+The serialized token contains only the stable logical identity. At scan and plan
+time, the complete reference record also carries the source SHA-256, occurrence
+classification and source note path. Hashes and note paths are mutable evidence,
+not durable identity, so they are not embedded in the token.
+
 Only an exact token/link pair in an active Markdown paragraph is automatically
 repairable. Bare paths, unmatched tokens, mismatched pairs, multiple candidate
 links, unsupported syntax, and references under history, archive, example,
 release-note or changelog headings require manual review. Any manual-review
 occurrence blocks apply.
+
+The scanner uses a Markdown AST. Fenced code is not traversed and YAML
+frontmatter is excluded. A free-form path, a YAML property, or a path merely
+placed under an artifacts heading is not promoted to a canonical reference.
+Relevant physical-path occurrences and other unsupported forms are reported for
+manual review and are never rewritten by guessing.
 
 ## Filesystem transaction
 
@@ -139,5 +156,6 @@ These capabilities require demonstrated ÉLYSIA value and a separate decision.
 
 The regression suite must cover canonical parsing, excluded/ambiguous
 references, target collision, changed sources, changed notes, no-clobber move,
-compensation, rollback, restart-safe journal state, HTTP denial and path
+failure after a subset of note repairs, compensation, rollback, both durable
+restart states around the hard-link/unlink boundary, HTTP denial and path
 redaction on Windows and Linux where applicable.

--- a/docs/external-roots-setup.fr.md
+++ b/docs/external-roots-setup.fr.md
@@ -370,6 +370,14 @@ L’unique mutation external-root est une transaction stdio locale sur un fichie
 régulier. Elle sert à préserver les références ÉLYSIA, pas à remplacer les
 outils filesystem.
 
+Le modèle durable de référence est assemblé au scan/plan avec `rootId`, chemin
+relatif à la racine, SHA-256 source, classification de l’occurrence et chemin de
+la note source. Le token Markdown sérialise uniquement le `rootId` et le chemin
+relatif stables. La planification et l’apply des réparations sont intégrés à
+`external_move_plan` et `external_move_apply` ; l’absence volontaire d’outils
+séparés `external_links_repair_*` maintient le fichier et les notes dans une
+seule transaction compensatoire.
+
 ### Ajouter l’identité stable à côté du lien cliquable
 
 ```md
@@ -386,6 +394,12 @@ Seule une paire exacte token/lien dans le même paragraphe Markdown actif peut
 orphelins, candidats multiples, syntaxe non supportée et sections
 d’historique/exemple/archive/release passent en revue manuelle. Une seule
 occurrence en revue manuelle bloque l’apply.
+
+Le parser Markdown ne parcourt pas les blocs de code fenced et exclut le
+frontmatter YAML. Un chemin libre, une propriété YAML ou un chemin sous une
+rubrique d’artefacts sans paire canonique n’est jamais réparé automatiquement.
+S’il désigne physiquement le fichier déplacé, il reste en revue manuelle et
+bloque l’apply.
 
 ### Activer explicitement le pilote
 
@@ -445,6 +459,11 @@ note complète : l’apply live échoue donc fermé avant de déplacer le fichie
 externe. Le journal SQLite local persiste l’état du plan et les préimages des
 notes pour la compensation. Le traiter comme une donnée locale sensible : ne jamais le
 committer ni le partager.
+
+Si l’apply échoue après une ou plusieurs réparations, le coordinateur restaure
+les notes déjà modifiées puis replace le fichier vérifié à sa source. Après une
+interruption de processus, le rollback récupère aussi l’état durable post-move
+et la fenêtre vérifiée où source et cible sont deux hard-links du même objet.
 
 Le HTTP direct refuse scan, plan, status, apply et rollback. Les tickets HTTP
 restent des handoffs en lecture seule.

--- a/docs/external-roots-setup.md
+++ b/docs/external-roots-setup.md
@@ -359,6 +359,14 @@ The only external-root mutation is a local stdio transaction for one regular
 file. It is designed to preserve ÉLYSIA references, not to replace filesystem
 tools.
 
+The durable reference model is assembled at scan/plan time from `rootId`,
+root-relative path, source SHA-256, occurrence classification and source note
+path. The Markdown token serializes only the stable `rootId` plus relative path.
+Repair planning and apply are embedded in `external_move_plan` and
+`external_move_apply`; separate `external_links_repair_*` tools are
+intentionally absent so the file and note surfaces remain one compensating
+transaction.
+
 ### Add the stable identity next to the clickable link
 
 ```md
@@ -375,6 +383,11 @@ repaired automatically. Bare physical paths, mismatched or orphan tokens,
 multiple candidates, unsupported syntax and historical/example/archive/release
 sections are classified for manual review. One manual-review occurrence blocks
 apply.
+
+The Markdown parser does not traverse fenced code and excludes YAML frontmatter.
+A free-form path, a YAML property or a path under an artifacts heading without
+the canonical pair is never auto-repaired. If it physically refers to the moved
+file, it remains manual review and blocks apply.
 
 ### Enable the pilot explicitly
 
@@ -432,6 +445,11 @@ returns an ETag but does not enforce `If-Match` on whole-note writes, so live
 apply fails closed before moving the external file. The machine-local SQLite
 journal persists plan state and note preimages for compensation. Treat that
 journal as sensitive local data and never commit or share it.
+
+If apply fails after one or more note repairs, the coordinator restores the
+already-modified notes and moves the verified file back to its source. After a
+process interruption, rollback also recovers the durable post-move state and the
+verified window where source and target are hard links to the same object.
 
 Direct HTTP refuses scan, plan, status, apply and rollback. HTTP tickets remain
 read-only handoffs.

--- a/docs/obsidian_mcp_tools_spec.md
+++ b/docs/obsidian_mcp_tools_spec.md
@@ -150,6 +150,19 @@ machine-local JSON configuration.
 - `external_move_rollback`: restore an applied move and its note repairs while
   every stored precondition still holds.
 
+The reference record assembled by scan and plan contains the logical `rootId`,
+root-relative path, source SHA-256, occurrence classification and source note
+path. Only `rootId` plus relative path are serialized in the stable
+`external-ref:` token. Exact repairs are intentionally embedded in
+`external_move_plan` and `external_move_apply`; no standalone link-repair apply
+surface exists.
+
+Automatic repair accepts one exact Markdown `file:///` link paired with one
+adjacent inline `external-ref:` token. YAML frontmatter, fenced code, historical
+or example sections, free-form paths and unsupported declarations are never
+auto-repaired. Relevant unsupported or ambiguous physical-path occurrences are
+returned for manual review and block apply.
+
 The core MCP does not parse PDF or Office files. Handoff requires both
 `readable` and `handoff`. HTTP ticket delivery is disabled by default and must be
 explicitly enabled with `MCP_HTTP_HANDOFF_ENABLED=true` on a non-development

--- a/scripts/test-external-move-integrity.mjs
+++ b/scripts/test-external-move-integrity.mjs
@@ -86,6 +86,8 @@ class FakeVault {
     this.notes = new Map(Object.entries(entries));
     this.bindingFingerprint = "test-binding";
     this.conditionalWritesSupported = true;
+    this.conditionalReplaceCalls = 0;
+    this.failConditionalReplaceAt = undefined;
   }
 
   async getBindingIdentity() {
@@ -130,6 +132,10 @@ class FakeVault {
   }
 
   async conditionalReplace(filePath, before, after, expectedSha256) {
+    this.conditionalReplaceCalls += 1;
+    if (this.conditionalReplaceCalls === this.failConditionalReplaceAt) {
+      throw new Error(`Injected conditional repair failure for ${filePath}.`);
+    }
     const current = await this.read(filePath);
     if (current.sha256 !== expectedSha256 || current.content !== before) {
       throw new ExternalRootError(
@@ -386,12 +392,55 @@ try {
   assert.equal(await readFile(casSource, "utf8"), "CAS");
   assert.equal(await exists(casTarget), false);
 
+  // If one of several note repairs fails after an earlier repair succeeded,
+  // apply compensates the repaired note and restores the external file.
+  const compensationSource = path.join(rootPath, "compensation.txt");
+  const compensationTarget = path.join(archivePath, "compensation.txt");
+  await writeFile(compensationSource, "compensation", "utf8");
+  const compensationUri = pathToFileURL(compensationSource).href;
+  const compensationReference =
+    `[Compensation](${compensationUri}) ` +
+    "`external-ref:pilot.move::compensation.txt`\n";
+  const compensationNotes = {
+    "Efforts/Projets/Compensation A.md": compensationReference,
+    "Efforts/Projets/Compensation B.md": compensationReference,
+  };
+  const compensationVault = new FakeVault(compensationNotes);
+  const compensationCoordinator = new ExternalMoveCoordinator(
+    service,
+    compensationVault,
+    new ExternalMoveJournal(":memory:"),
+  );
+  const compensationPlan = await compensationCoordinator.plan({
+    rootId: "pilot.move",
+    sourceRelativePath: "compensation.txt",
+    targetRelativePath: "archive/compensation.txt",
+    idempotencyKey: "coordinator-compensation",
+  });
+  assert.equal(compensationPlan.repairs.length, 2);
+  compensationVault.failConditionalReplaceAt = 2;
+  await assert.rejects(
+    () =>
+      compensationCoordinator.apply(
+        compensationPlan.planId,
+        "coordinator-compensation",
+      ),
+    /All partial effects were compensated and journaled/u,
+  );
+  assert.equal(
+    compensationCoordinator.status(compensationPlan.planId).status,
+    "failed_compensated",
+  );
+  assert.equal(await readFile(compensationSource, "utf8"), "compensation");
+  assert.equal(await exists(compensationTarget), false);
+  assert.deepEqual(
+    Object.fromEntries(compensationVault.notes),
+    compensationNotes,
+  );
+
   // An unsupported vault writer is rejected before the external file moves.
   const unsupportedSource = path.join(rootPath, "unsupported-writer.txt");
-  const unsupportedTarget = path.join(
-    archivePath,
-    "unsupported-writer.txt",
-  );
+  const unsupportedTarget = path.join(archivePath, "unsupported-writer.txt");
   await writeFile(unsupportedSource, "unsupported writer", "utf8");
   const unsupportedUri = pathToFileURL(unsupportedSource).href;
   const unsupportedVault = new FakeVault({
@@ -419,10 +468,7 @@ try {
       ),
     /Conditional note writes are unavailable/u,
   );
-  assert.equal(
-    await readFile(unsupportedSource, "utf8"),
-    "unsupported writer",
-  );
+  assert.equal(await readFile(unsupportedSource, "utf8"), "unsupported writer");
   assert.equal(await exists(unsupportedTarget), false);
 
   // Apply rescans the complete vault. A new canonical reference created after
@@ -539,10 +585,7 @@ try {
   // A crash after the no-clobber hard link but before source unlink leaves
   // both paths on the same inode. Rollback must recover that verified window.
   const linkedRecoverySource = path.join(rootPath, "linked-recovery.txt");
-  const linkedRecoveryTarget = path.join(
-    archivePath,
-    "linked-recovery.txt",
-  );
+  const linkedRecoveryTarget = path.join(archivePath, "linked-recovery.txt");
   await writeFile(linkedRecoverySource, "linked recovery", "utf8");
   const linkedRecoveryUri = pathToFileURL(linkedRecoverySource).href;
   const linkedRecoveryNotePath = "Efforts/Projets/Linked recovery.md";
@@ -575,10 +618,7 @@ try {
     "coordinator-linked-recovery",
   );
   assert.equal(linkedRecovered.status, "rolled_back");
-  assert.equal(
-    await readFile(linkedRecoverySource, "utf8"),
-    "linked recovery",
-  );
+  assert.equal(await readFile(linkedRecoverySource, "utf8"), "linked recovery");
   assert.equal(await exists(linkedRecoveryTarget), false);
   assert.equal(
     linkedRecoveryVault.notes.get(linkedRecoveryNotePath),
@@ -589,8 +629,7 @@ try {
   const legacyCaseSource = path.join(rootPath, "legacy-case.txt");
   await writeFile(legacyCaseSource, "legacy case", "utf8");
   const legacyCaseVault = new FakeVault({
-    "Efforts/Projets/Legacy case.md":
-      `Legacy location: ${legacyCaseSource.toUpperCase()}\n`,
+    "Efforts/Projets/Legacy case.md": `Legacy location: ${legacyCaseSource.toUpperCase()}\n`,
   });
   const legacyCaseCoordinator = new ExternalMoveCoordinator(
     service,


### PR DESCRIPTION
## Résumé
- documente le modèle complet de référence externe et la forme durable minimale du token
- explicite que la réparation est intégrée à `external_move_plan/apply`, sans outils `external_links_repair_*` séparés
- borne l’auto-réparation à la paire Markdown canonique, hors blocs de code et frontmatter YAML
- ajoute une preuve de transaction compensatoire quand la deuxième réparation de note échoue

## Vérifications
- `npm run build`
- `node scripts/test-external-move-integrity.mjs`
- `npm run test:external-roots`
- `npm run test:docs`
- `npm run audit:production` (0 vulnérabilité)
- Prettier ciblé et `git diff --check`