### PR TITLE
docs(operon): align bilingual MCP and CLI guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Bilingual Operon MCP contract and CLI audit documenting the complete 23-tool
+  surface, the governed MCP-versus-CLI boundary, stock 3.1.1 capability limits,
+  and the completed relationship and recurrence acceptance evidence.
+
 - Six bounded, read-only Operon 3.1.1 Developer API tools for native
   diagnostics, ranked finder, entity resolution, relationships, context packs,
   and timer state; no CLI passthrough or new mutation class is exposed.

--- a/README.fr.md
+++ b/README.fr.md
@@ -109,11 +109,14 @@ Les snapshots Operon obsolètes restent toujours en lecture seule.
 Le MCP expose une surface agentique gouvernée, pas toutes les fonctions de la
 CLI Operon. Les diagnostics natifs, la recherche/résolution, les relations et
 contextes bornés ainsi que l’état du timer sont disponibles en lecture seule.
-Les écritures avancées et commandes opérateur larges restent dans la CLI ; voir
-l’[audit CLI / Developer API](docs/operon-cli-audit.md). L’apply de transition
-est disponible via le Bridge. Les plans élevés ou destructifs demandent une
-confirmation fraîche dans la fenêtre Obsidian propriétaire et échouent fermés
-après 45 secondes si elle ne peut pas être présentée.
+Les relations et la récurrence disposent aussi d’écritures dédiées via des
+plans officiels scellés. Les agents passent par le MCP parce qu’il ajoute des
+schémas bornés, le moindre privilège, le dry-run, le verrouillage de révision,
+l’idempotence durable, la vérification postflight et la récupération du plan
+exact. Un relais CLI générique contournerait ces garanties. Les commandes
+destructives ou d’administration restent dans la CLI. Voir le
+[contrat MCP Operon](docs/operon-mcp-contract.fr.md) et
+l’[audit CLI / Developer API](docs/operon-cli-audit.fr.md).
 
 Note de compatibilité : l’adaptateur cible Operon officiel `3.1.1`, mais les
 preuves d’acceptation complètes de ce dépôt utilisent notre build local corrigé
@@ -124,7 +127,10 @@ reste utilisable pour les lectures et la plupart des mutations gouvernées, mais
 le settlement des frontmatters de date, le consentement entre plusieurs fenêtres
 Obsidian et les renommages implicites de File Tasks conservent les limites
 upstream décrites dans ces PR. Le MCP ne bascule jamais vers Markdown ou des
-API privées quand l’un de ces cas n’est pas supporté.
+API privées quand l’un de ces cas n’est pas supporté. Le cas particulier des
+transitions sans portée `project-serial` reste suivi dans
+[#99](https://github.com/hasanyilmaz/operon/issues/99) et
+[#101](https://github.com/hasanyilmaz/operon/pull/101).
 
 ## Racines documentaires externes
 
@@ -187,7 +193,8 @@ partagée hors du vrai coffre synchronisé.
 - Outils actuels : [Surface des outils](docs/obsidian_mcp_tools_spec.md)
 - Modes runtime : [Matrice des capacités](docs/runtime-capability-matrix.fr.md)
 - Routage agentique : [Guide de routage](docs/mcp-routing-guide.fr.md)
-- Surface Operon et routage CLI : [Audit CLI / Developer API](docs/operon-cli-audit.md)
+- Outils Operon et garanties : [Contrat MCP Operon](docs/operon-mcp-contract.fr.md)
+- Surface Operon et routage CLI : [Audit CLI / Developer API](docs/operon-cli-audit.fr.md)
 - Déploiement headless : [Profil serveur headless](docs/headless-server-profile.fr.md)
 - Pilote Linux headless multi-client : [pilote et matrice des capacités](docs/headless-multiclient-pilot.fr.md)
 - Intégration gateway OSS : [Compatibilité gateways](docs/gateway-compatibility.fr.md)

--- a/README.md
+++ b/README.md
@@ -108,7 +108,12 @@ The MCP exposes a curated agent surface rather than every Operon CLI function.
 Native diagnostics, finder/resolve, bounded relationships/context and timer
 state are available as read-only tools. Dedicated relationship and recurrence
 writes use official sealed preview/apply plans; destructive and operator
-commands stay in the CLI. See the [Operon CLI / Developer API audit](docs/operon-cli-audit.md).
+commands stay in the CLI. Agents use MCP because it adds bounded schemas,
+least-privilege capability checks, dry-run, revision locking, durable
+idempotency, postflight verification and exact-plan recovery. A generic CLI
+passthrough would bypass those guarantees. See the
+[Operon MCP contract](docs/operon-mcp-contract.md) and
+[Operon CLI / Developer API audit](docs/operon-cli-audit.md).
 Transition apply is available through the Bridge. Elevated or destructive plans
 still require fresh confirmation in the owning Obsidian vault window and fail
 closed after 45 seconds when no confirmation can be presented.
@@ -122,7 +127,9 @@ remains usable for reads and most governed mutations, but modified-time
 frontmatter settlement, consent across multiple Obsidian windows, and implicit
 File Task renames retain the upstream limitations described in those PRs. The
 MCP does not fall back to Markdown or private APIs when one of these cases is
-not supported.
+not supported. The unscoped transition edge case remains tracked in
+[#99](https://github.com/hasanyilmaz/operon/issues/99) and
+[#101](https://github.com/hasanyilmaz/operon/pull/101).
 
 ## External document roots
 
@@ -184,6 +191,7 @@ synced vault.
 - Current tools: [Tool Surface](docs/obsidian_mcp_tools_spec.md)
 - Runtime modes: [Runtime Capability Matrix](docs/runtime-capability-matrix.md)
 - Agent routing: [MCP Routing Guide](docs/mcp-routing-guide.md)
+- Operon tools and guarantees: [Operon MCP Contract](docs/operon-mcp-contract.md)
 - Operon surface and CLI routing: [Operon CLI / Developer API audit](docs/operon-cli-audit.md)
 - Headless deployment: [Headless Server Profile](docs/headless-server-profile.md)
 - Linux headless multi-client pilot: [Pilot and capability matrix](docs/headless-multiclient-pilot.md)

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -15,9 +15,9 @@ question.
 | Opérateur Codex ou agent local  | [Exploitation](../OPERATIONS.fr.md)                       | [Routage agentique](mcp-routing-guide.fr.md)                                                                                           |
 | Opérateur headless/serveur      | [Profil serveur headless](headless-server-profile.fr.md)  | [Matrice runtime](runtime-capability-matrix.fr.md), [Sécurité](../SECURITY.fr.md)                                                      |
 | Intégrateur d’une gateway       | [Compatibilité gateways OSS](gateway-compatibility.fr.md) | [Sécurité HTTP](http-multiclient-security.fr.md), [Backpressure](http-concurrency-backpressure.fr.md)                                  |
-| Intégrateur d’un client MCP     | [Surface des outils](obsidian_mcp_tools_spec.md)          | [Matrice runtime](runtime-capability-matrix.fr.md)                                                                                     |
+| Intégrateur d’un client MCP     | [Surface des outils](obsidian_mcp_tools_spec.md)          | [Contrat Operon](operon-mcp-contract.fr.md), [Matrice runtime](runtime-capability-matrix.fr.md)                                        |
 | Opérateur de documents externes | [Configuration des racines](external-roots-setup.fr.md)   | [ADR racines externes](adr/ADR-External-Document-Roots.md), [ADR intégrité des références](adr/ADR-External-Reference-Integrity.fr.md) |
-| Opérateur Tasks/Operon          | [Contrat MCP Operon](operon-mcp-contract.md)              | [Validation locale](operon-local-validation.md), [profil public ÉLYSIA](../profiles/elysia-tasks/README.fr.md)                         |
+| Opérateur Tasks/Operon          | [Contrat MCP Operon](operon-mcp-contract.fr.md)           | [Audit CLI/API](operon-cli-audit.fr.md), [Validation locale](operon-local-validation.md), [profil public ÉLYSIA](../profiles/elysia-tasks/README.fr.md) |
 | Contributeur ou relecteur       | [Décisions d’architecture](adr/README.md)                 | [Arbre du dépôt](tree.md), README des plugins                                                                                          |
 
 ## Trouver la page qui fait foi
@@ -32,7 +32,8 @@ question.
 | Comment fonctionnent lecture, handoff, move et réparation de liens externes ? | [Configuration des racines](external-roots-setup.fr.md)                                 |
 | Quelle frontière de sécurité HTTP est supportée ?                             | [Sécurité](../SECURITY.fr.md) et [ADR HTTP](adr/ADR-HTTP-External-Artifact-Delivery.md) |
 | Quel profil de gateway OSS a été prouvé de bout en bout ?                     | [Compatibilité gateways OSS](gateway-compatibility.fr.md)                               |
-| Comment les lectures et mutations Operon sont-elles gouvernées ?              | [Contrat MCP Operon](operon-mcp-contract.md)                                            |
+| Comment les lectures et mutations Operon sont-elles gouvernées ?              | [Contrat MCP Operon](operon-mcp-contract.fr.md)                                         |
+| Pourquoi le MCP expose-t-il des fonctions Operon au lieu d’appeler la CLI ?   | [Audit CLI / Developer API](operon-cli-audit.fr.md)                                     |
 | Pourquoi une décision d’architecture a-t-elle été prise ?                     | [Index des ADR](adr/README.md)                                                          |
 | Qu’est-ce qui a changé ?                                                      | [Changelog](../CHANGELOG.md)                                                            |
 
@@ -47,7 +48,8 @@ question.
 ### Tâches et exécution
 
 - lectures compatibles Tasks : [Surface des outils](obsidian_mcp_tools_spec.md#tasks) ;
-- contrat Operon gouverné : [Contrat MCP Operon](operon-mcp-contract.md) ;
+- contrat Operon gouverné : [Contrat MCP Operon](operon-mcp-contract.fr.md) ;
+- frontière MCP et CLI : [Audit CLI / Developer API](operon-cli-audit.fr.md) ;
 - bridge Operon inclus : [README Operon Bridge](../plugins/obsidian-operon-bridge/README.md) ;
 - bridge Bases inclus : [README Bases Bridge](../plugins/obsidian-bases-bridge/README.md).
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ French operator guides are linked alongside their English equivalents.
 | A gateway integrator            | [OSS Gateway Compatibility](gateway-compatibility.md) | [HTTP Security](http-multiclient-security.md), [Backpressure](http-concurrency-backpressure.md)                              |
 | An MCP client integrator        | [Tool Surface](obsidian_mcp_tools_spec.md)            | [Runtime Matrix](runtime-capability-matrix.md)                                                                               |
 | An external-document operator   | [External Roots Setup](external-roots-setup.md)       | [External Roots ADR](adr/ADR-External-Document-Roots.md), [Reference Integrity ADR](adr/ADR-External-Reference-Integrity.md) |
-| A Tasks/Operon operator         | [Operon MCP Contract](operon-mcp-contract.md)         | [Local Validation](operon-local-validation.md), [public ÉLYSIA profile](../profiles/elysia-tasks/README.fr.md)               |
+| A Tasks/Operon operator         | [Operon MCP Contract](operon-mcp-contract.md)         | [CLI/API audit](operon-cli-audit.md), [Local Validation](operon-local-validation.md), [public ÉLYSIA profile](../profiles/elysia-tasks/README.fr.md) |
 | A contributor or reviewer       | [Architecture decisions](adr/README.md)               | [Repository tree](tree.md), plugin READMEs                                                                                   |
 
 ## Find the authoritative page
@@ -33,6 +33,7 @@ French operator guides are linked alongside their English equivalents.
 | What is the supported HTTP security boundary?              | [Security](../SECURITY.md) and [HTTP ADR](adr/ADR-HTTP-External-Artifact-Delivery.md) |
 | Which OSS gateway profile has been proven end to end?      | [OSS Gateway Compatibility](gateway-compatibility.md)                                 |
 | How are Operon reads and mutations governed?               | [Operon MCP Contract](operon-mcp-contract.md)                                         |
+| Why does MCP expose Operon functions instead of calling the CLI? | [Operon CLI / Developer API audit](operon-cli-audit.md)                           |
 | Why was an architecture decision made?                     | [ADR Index](adr/README.md)                                                            |
 | What changed?                                              | [Changelog](../CHANGELOG.md)                                                          |
 
@@ -48,6 +49,7 @@ French operator guides are linked alongside their English equivalents.
 
 - Tasks-compatible reads: [Tool Surface](obsidian_mcp_tools_spec.md#tasks);
 - governed Operon contract: [Operon MCP Contract](operon-mcp-contract.md);
+- MCP versus CLI boundary: [Operon CLI / Developer API audit](operon-cli-audit.md);
 - bundled bridge implementation: [Operon Bridge README](../plugins/obsidian-operon-bridge/README.md);
 - bundled Bases implementation: [Bases Bridge README](../plugins/obsidian-bases-bridge/README.md).
 

--- a/docs/adr/ADR-Operon-Bridge.md
+++ b/docs/adr/ADR-Operon-Bridge.md
@@ -1,13 +1,14 @@
 # ADR — Operon Bridge for Optimike Obsidian MCP
 
-- Status: accepted for bounded pilot
+- Status: accepted and implemented on `main`
 - Date: 2026-07-21
+- Amended: 2026-08-08
 - MCP baseline: `optimikelabs/optimike-obsidian-mcp@8cea94610a526e50a017d334be6008b8dab79500`
 - Operon baselines: upstream `2.4.0@76d251973b149afc69192ef565d626740aa7b7cf`, `2.5.0@31099cc3d5231b320cd8520424fc29449b003778`, and official `3.1.1` Developer API V1
 
 ## Problem
 
-Operon unifies inline and file tasks around stable identity and one domain model, but official releases expose no public versioned mutation API. Agent writes must preserve workflow normalization, dependencies, recurrence, aggregates, project serials, archiving, auto-unpin, conversions, and index/view reconciliation. Direct Markdown edits or direct `TaskWriter` calls do not satisfy that contract.
+Operon unifies inline and file tasks around stable identity and one domain model. Earlier releases exposed no public versioned mutation API; official Operon `3.1.1` now exposes Developer API V1. Agent writes must still preserve workflow normalization, dependencies, recurrence, aggregates, project serials, archiving, auto-unpin, conversions, and index/view reconciliation. Direct Markdown edits or direct `TaskWriter` calls do not satisfy that contract.
 
 ## Decision
 
@@ -31,8 +32,8 @@ Official Operon `2.4.0` and `2.5.0` remain supported for reads. Official Operon 
 - `KEEP` — existing runtime modes, REST client, logger, errors, stdio/HTTP transports, write policy, and shared SQLite.
 - `KEEP` — Tasks and TaskNotes during the pilot and until a separate production cutover gate.
 - `ADD` — companion Bridge for live reads and guarded mutations.
-- `ADD` — minimal Operon GPL fork exposing only generic Public API v1 wrappers over existing domain orchestrators.
-- `ADD` — twenty-one governed Operon MCP tools, including six bounded native reads, snapshot tables, durable mutation journal, and same-plan recovery.
+- `KEEP` — the legacy Kairélys/Public API v1 path only as a bounded rollback compatibility surface.
+- `ADD` — twenty-three governed Operon MCP tools, including six bounded native reads, relationship and recurrence writes, snapshot tables, durable mutation journal, and same-plan recovery.
 - `REJECT` — MCP-side Operon parser/domain reimplementation.
 - `REJECT` — raw Markdown/YAML mutation fallback.
 - `REJECT` — reflective production calls to private Operon methods.
@@ -42,7 +43,7 @@ Official Operon `2.4.0` and `2.5.0` remain supported for reads. Official Operon 
 
 `OperonPublicApiV1` remains the legacy Kairélys boundary. Official Operon `3.1.1` exposes host-verified Developer API V1 reads plus preview/apply/recovery for typed create, update, transition, relationship replacement, recurrence update, conversion, and inline relocation. Elevated or destructive applies require fresh host-owned consent in the owning vault window and fail closed after a bounded timeout. The implementation stays inside Operon and calls its existing parser/converter, creator, workflow, writer, dependency, recurrence, aggregate, archive, and conversion paths.
 
-The fork delta must remain limited to this generic API and contract tests. No ÉLYSIA-specific workflow, UX, view, calendar, Kanban, or data-model logic belongs in the fork. An upstream PR remains preferred; the fork is the production fallback.
+No ÉLYSIA-specific workflow, UX, view, calendar, Kanban, or data-model logic belongs in Operon. Compatibility fixes remain generic upstream PRs; the MCP never depends on private methods or an ÉLYSIA-specific Operon fork.
 
 ## Read model
 
@@ -63,12 +64,12 @@ To avoid false atomicity, update accepts exactly one group per operation: descri
 - Live/hybrid with API: exact reads and mutations according to capabilities.
 - Headless: cached reads only; no mutation.
 - `readonly`: dry-run only.
-- `guarded`: adopt/create/update/transition/relocate apply with normal preconditions and fresh consent when the sealed plan is elevated.
-- `full`: conversion apply in addition.
+- `guarded`: capability-backed adopt/create/update/transition/relationship/relocate apply with normal preconditions and fresh consent when the sealed plan is elevated.
+- `full`: conversion, recurrence and exact-plan recovery apply in addition.
 
 ## Evidence gates
 
-The disposable Operon 2.5 vault passed file/inline creation, ÉLYSIA properties, hierarchy, dependency rejection/release, status transitions, identity-preserving conversions, reindex, plugin restart, live/stale cache, idempotency, revision conflicts, and duplicate-ID P0 refusal. Operon 3.1.1 has passed host grant/identity checks, live exact reads, typed preview/apply for the validated mutation families, transition consent in the owning vault window, postflight, idempotent replay, and restart/recovery without a Markdown/private-API fallback.
+The disposable Operon 2.5 vault passed file/inline creation, ÉLYSIA properties, hierarchy, dependency rejection/release, status transitions, identity-preserving conversions, reindex, plugin restart, live/stale cache, idempotency, revision conflicts, and duplicate-ID P0 refusal. The patched local Operon 3.1.1 acceptance build passed host grant/identity checks, live exact reads, typed preview/apply for the validated mutation families, relationship inverse-edge verification, scoped recurrence add/change/clear, transition consent in the owning vault window, postflight, idempotent replay, exact restoration, and restart/recovery without a Markdown/private-API fallback. Stock 3.1.1 retains the upstream limitations linked from the Operon MCP contract.
 
 Still required before production cutover:
 

--- a/docs/obsidian_mcp_tools_spec.md
+++ b/docs/obsidian_mcp_tools_spec.md
@@ -80,6 +80,10 @@ dependency of this MCP.
 
 ## Operon (contract v1)
 
+French reference: [Operon MCP contract (French)](operon-mcp-contract.fr.md).
+The authoritative English guarantees and compatibility matrix are in the
+[Operon MCP contract](operon-mcp-contract.md).
+
 - `operon_status`: inspect live Bridge compatibility and persisted snapshot state;
 - `operon_get_configuration`: read the live task-semantic Operon settings and their signed stale fallback;
   optional `forceRefresh` requests a complete live rebuild.
@@ -89,7 +93,7 @@ dependency of this MCP.
 - `operon_query_tasks`: filter by task IDs, stable pipeline/status IDs, visible workflow labels, text, source, checkbox, priority,
   tier, paths, tags, parents, dates, canonical/custom fields, or unmanaged file-task
   properties.
-- `operon_query_saved_filter`: evaluate one saved filter through Operon's native live filter engine.
+- `operon_query_saved_filter`: evaluate one saved filter only when the live engine advertises the native capability; official Operon 3.1.1 currently returns a structured unavailable result, while compatible legacy engines may implement it.
 - `operon_validate`: live duplicate/source/workflow graph validation, or a limited
   snapshot-only validation with explicit caveats.
 - `operon_get_diagnostics`: native Developer API lifecycle, persistence, grant, catalog, capability, and transport diagnostics.
@@ -98,8 +102,8 @@ dependency of this MCP.
 - `operon_get_relationships`: bounded explicit, derived, and inferred relationship graph for one stable task.
 - `operon_build_context`: bounded exact-task, neighborhood, project, planning, or creation context with a strict hydration allowlist.
 - `operon_get_timer_state`: read active and transitioning timer state without exposing timer control.
-- `operon_adopt_task`: upgrade one exact legacy checkbox in place with line-level optimistic locking.
-- `operon_create_task`: create inline/file tasks through Operon Public API v1.
+- `operon_adopt_task`: upgrade one exact legacy checkbox only when the loaded engine advertises adoption; official Operon 3.1.1 currently returns a structured unavailable result.
+- `operon_create_task`: create inline/file tasks through the loaded engine's official Developer API V1 or bounded legacy Public API v1 surface.
 - `operon_update_task`: update one mutation group with expected revision.
 - `operon_transition_task`: apply a stable status-ID or exact workflow transition through Operon's guards when the live Developer API advertises the capability; the Bridge bounds uncertain stock-runtime applies and never retries blindly.
 - `operon_set_relationships`: replace or clear parent/blocker edges with revision locking, graph validation, and inverse-edge postflight; apply is allowed in `guarded`.

--- a/docs/operon-cli-audit.fr.md
+++ b/docs/operon-cli-audit.fr.md
@@ -1,0 +1,107 @@
+# Audit CLI Operon / Developer API
+
+English version: [operon-cli-audit.md](operon-cli-audit.md)
+
+Date : 2026-08-08
+
+Référence : Operon officiel `3.1.1`, Operon CLI `1.0.9`, Developer API V1 et
+`cli-manifest-v1.json`.
+
+Les observations CLI initiales du 1er août 2026 utilisaient Operon `3.0.1` et
+restent des preuves historiques. L’adaptateur MCP cible `3.1.1`. La preuve
+d’acceptation complète utilise le build local corrigé pendant la review des PR
+upstream #135, #137 et #139. La version officielle reste utilisable pour les
+lectures et la plupart des mutations gouvernées. Le cas de transition incertain
+est suivi dans #99/#101. Le MCP échoue fermé et ne bascule jamais vers Markdown
+ou une API privée.
+
+## Décision
+
+Conserver le Bridge comme plan de contrôle destiné aux agents ÉLYSIA. Il donne
+au MCP un contrat de tâche stable et normalisé, la vérification de génération
+live, `expectedRevision`, l’idempotence, les deux opt-ins de mutation, le
+postflight et une récupération bornée au même plan.
+
+Conserver la CLI comme surface opérateur/admin pour l’acceptation native, les
+diagnostics approfondis, l’investigation de récupération, l’administration
+large et les actions ponctuelles.
+
+Ne pas exposer de passthrough CLI générique dans le MCP. Une commande disponible
+dans la CLI n’est pas automatiquement sûre, utile ou suffisamment bornée pour
+un agent.
+
+## Comparaison des surfaces
+
+Le MCP enregistre vingt-trois outils gouvernés et six lectures de raisonnement
+Developer API bornées. Deux outils de compatibilité, filtres sauvegardés et
+adoption, restent indisponibles sur Operon officiel `3.1.1` tant que le runtime
+n’annonce pas les capacités natives :
+
+- lectures : statut, configuration, liste/get/query, filtre sauvegardé borné par
+  capacité et validation ;
+- lectures de raisonnement : diagnostics, finder, résolution, relations,
+  contexte et état du timer ;
+- mutations : adoption bornée par capacité, création, update, transition,
+  relations, récurrence, conversion et relocation ;
+- récupération : liste des plans incertains et récupération d’un plan exact.
+
+La CLI et Developer API exposent une surface plus large : santé, capacités,
+catalogue, diagnostics, recherche/résolution, contexte, relations, timer, mais
+aussi rappels, état épinglé, contrôle/session du timer et suppression.
+
+La différence est volontaire. Le MCP expose seulement une opération sémantique
+avec un cas d’usage ÉLYSIA clair, une capacité officielle et des gardes prouvées.
+
+## Classement des extensions
+
+| Candidate | Utilité ÉLYSIA | Risque | Décision |
+| --- | --- | --- | --- |
+| diagnostics | Élevée | Faible | Implémenté en lecture seule |
+| finder / résolution | Élevée | Faible | Implémenté avec résultats bornés |
+| lecture des relations | Élevée | Moyen | Implémenté avec racine exacte, profondeur et plafond |
+| pack de contexte | Élevée | Moyen | Implémenté avec projections et hydratation allowlistée |
+| état du timer | Moyenne | Faible | Lecture seulement, aucun contrôle |
+| écriture de relations | Élevée | Moyen à élevé | Implémentée avec révision, plan scellé, postflight inverse et récupération |
+| écriture de récurrence | Moyenne à élevée | Élevé | Implémentée avec portée explicite, mode full, postflight et récupération |
+| rappels | Moyenne | Élevé | Différé, reste dans la CLI |
+| contrôle/session du timer | Moyenne | Élevé | Différé, change l’exécution active |
+| état épinglé | Faible à moyenne | Moyen | Différé, préférence de présentation |
+| suppression | Moyenne | Destructif | Refusée sans contrat de corbeille réversible |
+| commande CLI générique | Non bornée | Élevé | Rejetée, contournerait le contrat Bridge |
+
+## Frontière de preuve actuelle
+
+Le build local corrigé Operon `3.1.1` a passé le grant et l’identité hôte, les
+lectures live, preview/apply typés, receipt/postflight, replay idempotent,
+redémarrage et récupération du même plan. Le pilote Bridge a aussi passé
+création, update, transition, conflit de révision et replay.
+
+Les relations et la récurrence ont passé les suites adaptateur, contrat Bridge,
+service, policy, idempotence/redémarrage et documentation, puis leur pilote live
+dédié : dry-run/apply, relation inverse, replay, conflit périmé, blocage de
+transition terminale, restauration exacte, ajout/changement de portée/retrait de
+récurrence, redémarrage stable, source live, aucun résidu et
+`P0/P1/P2 = 0/0/0`.
+
+La version officielle non corrigée peut encore produire le résultat borné
+`outcome-unknown` du chemin #99/#101. Les limites frontmatter/date,
+multi-fenêtres et File Task sont suivies dans #135, #137 et #139. Le Bridge
+expose l’incertitude et ne rejoue pas la mutation.
+
+Les autres écritures avancées restent hors MCP jusqu’à disposer chacune d’un
+contrat preview/apply, révision, postflight, récupération et confirmation
+humaine adapté.
+
+## Preuves historiques du pilote CLI Windows
+
+Le 1er août 2026, la CLI officielle `1.0.0` a passé version, manifeste, schéma,
+setup, profil, doctor offline, `health`, `task.get`, `tasks.query` et
+`context.build` avec un profil temporaire isolé sur le coffre ÉLYSIA.
+
+Sur cette version, plusieurs handlers pourtant annoncés par `health` échouaient
+avant leur exécution avec `obsidian-cli-exit-failed` ou
+`persistent-write-failed`. Cette preuve reste historique et ne doit pas être
+présentée comme l’état de la CLI `1.0.9`.
+
+La conclusion d’architecture ne change pas : la CLI est la surface opérateur
+large. Le MCP/Bridge reste le contrat agentique indépendant, borné et vérifiable.

--- a/docs/operon-cli-audit.md
+++ b/docs/operon-cli-audit.md
@@ -1,5 +1,7 @@
 # Operon CLI / Developer API audit
 
+French version: [operon-cli-audit.fr.md](operon-cli-audit.fr.md)
+
 Date: 2026-08-08
 Reference: official Operon `3.1.1`, Operon CLI `1.0.9`, Developer API V1 and `cli-manifest-v1.json`.
 
@@ -28,13 +30,15 @@ Do not expose a generic CLI passthrough through MCP.
 
 ## Surface comparison
 
-The MCP currently exposes the governed task surface plus native saved-filter
-evaluation and six bounded Developer API reads:
+The MCP registers twenty-three governed tools plus six bounded Developer API
+reasoning reads. Two compatibility tools, saved-filter evaluation and adoption,
+remain unavailable on official Operon `3.1.1` until the runtime advertises the
+native capabilities:
 
-- reads: status, configuration, list/get/query, saved filters, validation;
+- reads: status, configuration, list/get/query, capability-gated saved filters, validation;
 - native reasoning reads: diagnostics, finder, resolve, relationships, context,
   and timer state;
-- mutations: adopt, create, update, transition, relationships, recurrence, convert, relocate;
+- mutations: capability-gated adoption, create, update, transition, relationships, recurrence, convert, relocate;
 - recovery: list pending official recoveries and recover one exact plan.
 
 The official CLI/Developer API additionally exposes:
@@ -77,10 +81,12 @@ production Bridge pilot also passed live read, typed create/update/transition
 preview/apply, replay, and stale revision conflict.
 
 The relationship and recurrence extensions pass the adapter, Bridge contract,
-service, policy, idempotency/restart and documentation suites. Their new live
-acceptance remains pending: the isolated 3.1.1 pilot persists the exact nine-
-capability expansion request, but the Operon settings panel currently renders
-no consumer row or approval controls. The grant is not edited or bypassed.
+service, policy, idempotency/restart and documentation suites. Their dedicated
+live Operon `3.1.1` acceptance also passed on the patched local build:
+relationship dry-run/apply, inverse-edge verification, idempotent replay,
+stale-revision conflict, blocked terminal transition, exact restoration,
+recurrence add/scope-change/clear, restart/recovery stability, live source, no
+residual relationship/recurrence state, and `P0/P1/P2 = 0/0/0`.
 
 Stock `3.1.1` may still return the bounded `outcome-unknown` transition result
 tracked by [Operon #99](https://github.com/hasanyilmaz/operon/issues/99) and
@@ -89,7 +95,8 @@ passes the terminal/recovery proof; when the stock runtime cannot prove its
 result, the Bridge reports the uncertainty and does not retry or fall back to
 Markdown/private APIs. This remains a capability gate, not a hidden bypass.
 
-The read audit and implementation of the two useful advanced writes are complete; live promotion waits for the official grant UI. Other advanced writes remain outside MCP until each has a
+The read audit, implementation and live acceptance of the two useful advanced
+writes are complete. Other advanced writes remain outside MCP until each has a
 dedicated preview/apply, revision, postflight, recovery and human-gate contract;
 CLI availability alone is not sufficient evidence to expose them to agents.
 

--- a/docs/operon-decision-report.md
+++ b/docs/operon-decision-report.md
@@ -1,127 +1,104 @@
 # Operon integration decision report
 
-## Current status — 2026-08-07
+## Current status — 2026-08-08
 
-The published MCP adapter now targets official Operon `3.1.1` and Bridge
-`0.5.1`. The complete local acceptance run is green on the patched Operon
-build, including transition, expected-revision conflicts, idempotent replay,
-restart/recovery, and postflight. The upstream compatibility fixes remain
-under review in [#135](https://github.com/hasanyilmaz/operon/pull/135),
-[#137](https://github.com/hasanyilmaz/operon/pull/137), and
-[#139](https://github.com/hasanyilmaz/operon/pull/139); the known transition
-investigation is [#99](https://github.com/hasanyilmaz/operon/issues/99) /
-[#101](https://github.com/hasanyilmaz/operon/pull/101). Stock Operon `3.1.1`
-remains supported for reads and most governed mutations, but the Bridge stays
-fail-closed when the stock runtime cannot prove a result. No Markdown/private
-API fallback is used.
+Optimike Obsidian MCP `main` targets official Operon `3.1.1` through Bridge
+`0.5.1` and Developer API V1. The canonical server registers twenty-three
+governed Operon tools. Kairélys remains disabled and retained only for bounded
+rollback compatibility.
 
-## Historical pilot record — 2026-08-01
+The complete local acceptance run is green on the patched Operon `3.1.1`
+build. Stock `3.1.1` remains supported for reads and most governed mutations,
+with fail-closed limitations tracked in:
 
-**CUTOVER COMPLETE on 2026-08-01.** The production vault was backed up,
-Operon `3.0.1` was installed and validated live, the current Bridge `0.5.0` was
-installed, and Kairélys was disabled but retained for reversible rollback.
-The cutover is read/operationally green; the official transition apply remains
-explicitly gated because its Bridge path has not produced a terminal or
-recoverable result.
+- transition settlement: [#99](https://github.com/hasanyilmaz/operon/issues/99)
+  and [#101](https://github.com/hasanyilmaz/operon/pull/101);
+- modified-time frontmatter settlement:
+  [#135](https://github.com/hasanyilmaz/operon/pull/135);
+- consent across multiple Obsidian windows:
+  [#137](https://github.com/hasanyilmaz/operon/pull/137);
+- implicit File Task description/rename behavior:
+  [#139](https://github.com/hasanyilmaz/operon/pull/139).
 
-## Implemented
+No MCP or Bridge route falls back to raw Markdown, private Operon methods or UI
+commands when a capability is missing or an outcome is uncertain.
 
-- legacy Operon Public API v1 compatibility for bounded Kairélys/2.5 fixtures;
-- Bridge read/write capability probe;
-- REST status/configuration/list/get/query/saved-filter/validate, six bounded
-  native Developer API reads, adopt/create/update/transition/convert/relocate,
-  plus official recovery;
-- twenty-one MCP tools in the canonical server;
-- dry-run by default;
-- live expected-revision conflicts;
-- Bridge and durable MCP idempotency;
-- before/requested/after evidence and post-write re-read;
-- central write policy integration;
+## Implemented surface
+
+- official Operon `3.1.1` Developer API V1 adapter;
+- Bridge status/configuration/list/get/query/validate and complete pagination;
+- six bounded native reasoning reads: diagnostics, finder, entity resolution,
+  relationships, context and timer state;
+- governed create, update, transition, relationship replacement, recurrence,
+  conversion and inline relocation;
+- registered compatibility tools for adoption and saved-filter evaluation,
+  returning unavailable on official `3.1.1` until native capabilities exist;
+- durable pending-recovery listing and exact-plan recovery;
+- dry-run by default, live `expectedRevision`, durable idempotency and postflight;
 - SQLite live/stale snapshots and mutation journal;
-- no Markdown/private-method fallback;
-- official Operon 3.0.1 Developer API V1 read/write pilot, with Bridge transition capability withheld pending a terminal REST proof;
-- exact read allowlist for Operon 2.4.0 and 2.5.0;
-- official Operon `3.0.1` Developer API V1 integration with host-owned recovery;
-- CLI/Developer API audit separating operator functions from the curated MCP
-  surface.
+- double mutation opt-in and mode-based write policy;
+- no generic CLI passthrough.
 
-## Verified in disposable Operon 2.5 vault
+## Why MCP and CLI remain separate
 
-| Evidence                                             | Result                                            |
-| ---------------------------------------------------- | ------------------------------------------------- |
-| Native file and inline fixtures                      | PASS                                              |
-| Direct MCP file and inline creation                  | PASS                                              |
-| Managed fields and tags                              | PASS                                              |
-| Unmanaged `north_star` / `rang` file properties      | PASS                                              |
-| Parent and blocker links plus inverse reconciliation | PASS                                              |
-| Completion blocked while dependency open             | PASS                                              |
-| Completion after blocker finished                    | PASS                                              |
-| Inline → file → inline with same `operonId`          | PASS                                              |
-| Dry-run default                                      | PASS                                              |
-| Durable idempotency replay                           | PASS                                              |
-| Stale revision conflict                              | PASS                                              |
-| Full V8 reindex parity                               | PASS — 13 tasks before/after, generation advanced |
-| Operon/Bridge plugin restart                         | PASS — 13 tasks, read-write restored              |
-| Live → cache fallback                                | PASS — same task/revision, `stale: true`          |
-| Duplicate identity                                   | PASS — P0 detected, last good snapshot retained   |
-| Final validation                                     | PASS — P0/P1/P2 = 0/0/0                           |
-| Actual Sync topology                                 | UNVERIFIED                                        |
-| 2.5 pilot production migration                      | NOT APPLICABLE — cutover is recorded below       |
+The MCP is the agent control plane. It exposes only bounded semantic operations
+with least-privilege capabilities, revision locking, idempotency, postflight and
+recovery evidence.
 
-## Production cutover result — 2026-08-01
+The CLI is the operator/admin surface. It remains appropriate for native
+acceptance, broad diagnostics, recovery investigation, one-off administration,
+delete, reminders, pinned state and timer control/session.
 
-| Check | Result |
-| --- | --- |
-| Backup | PASS — `E:\Mes Vibes Programmes\backups\elysia-operon-cutover-20260801-1620`, 268 files |
-| Official Operon assets | PASS — `3.0.1` release `main.js`, `manifest.json`, and `styles.css` verified before install |
-| Live plugin state | PASS — Operon `3.0.1`, Bridge `0.5.0`, 25 tasks, live generation and index ready |
-| MCP live read/configuration | PASS — `source=operon-live`, `stale=false` |
-| Native read expansion | PASS — diagnostics, finder, resolve, relationships, context and timers through Bridge/MCP service |
-| Developer API grant | PASS — exact five new read capabilities approved through Operon's official integration controller; no pending capability |
-| Live validation | PASS — P0/P1/P2 = 0/0/0, no violations |
-| Kairélys | PASS — disabled and retained; configuration hash unchanged |
-| Bridge transition | GATED — isolated transition apply exceeded 120 s and returned `outcome-unknown`; task unchanged and no pending recovery |
+CLI availability alone is not sufficient to expose a function to agents. A
+generic passthrough would bypass the Bridge contract and hide capability drift.
 
-The transition reproduction was performed only in the disposable pilot, with
-the capability gate temporarily removed from a test copy of the Bridge and then
-the normal `0.4.7` build restored. The real vault was not mutated by this
-probe.
+## Operon 3.1.1 acceptance evidence
 
-Bridge `0.5.0` was then installed with a dedicated local backup. Its official
-Developer API grant was expanded only for `tasks.finder`, `entities.resolve`,
-`relationships.read`, `context.build`, and `timers.read`. The live postflight
-returned 25 tasks, all six new capability flags, a resolved exact identity,
-bounded finder/context results, relationship and timer state, and the same
-results through the MCP service. No task mutation was performed.
+The patched local acceptance build passed:
 
-## Defects discovered and corrected
+- host-owned grant and consumer identity checks;
+- live configuration, exact reads and coherent 25-task inventory;
+- typed preview/apply, postflight and receipt evidence;
+- stale-revision conflict and idempotent replay without a second write;
+- transition and same-plan recovery after restart;
+- relationship replacement, inverse-edge verification and blocked terminal
+  transition enforcement;
+- recurrence add, scope change and explicit clear;
+- exact restoration of the two relationship tasks;
+- fixture removal through the operator CLI;
+- restart with live source, no residual relationship or recurrence state, no
+  pending recovery and `P0/P1/P2 = 0/0/0`.
 
-1. Immediate post-write reads could hit Operon's transient reindex window and report unavailable after a successful write. The Bridge now waits boundedly for a verified idle index and records `outcome_unverified` without blind retry if proof never arrives.
-2. A combined rename + managed fields + unmanaged properties request could partially apply because Obsidian metadata lagged after rename. The contract now permits exactly one mutation group per operation and one unmanaged property per call.
-3. Creating a child legitimately changes parent aggregates and therefore its revision. The rich smoke recipe now rereads the parent before transition; stale parent revisions are rejected as designed.
+The MCP repository passed `check:operon`, Bridge typecheck/build and tests,
+contract/service tests, tool-annotation checks, documentation checks and the
+Linux/Windows GitHub CI matrix.
 
-## Remaining risks
+## Historical evidence
 
-- Official transition latency/settlement behavior still needs an upstream or
-  Bridge-level fix and a fresh terminal proof.
-- Real Sync behavior remains unverified.
-- Cockpit equivalence and low-energy human workflow remain unproven.
-- Dependency audit is clean at the audited SHAs; future upstream advisories remain a maintenance risk.
-- Advanced CLI functions are intentionally not generic MCP passthroughs.
+The disposable Operon `2.5.0`/Kairélys pilot remains historical evidence for
+legacy Public API v1 only. It proved file/inline creation, managed and unmanaged
+properties, hierarchy/dependencies, blocked/released transitions, conversion,
+idempotency, stale-revision conflict, reindex/restart, stale cache and duplicate
+ID refusal. It is not presented as Developer API V1 evidence.
 
-## Recommendation
+The 2026-08-01 Operon `3.0.1` cutover and CLI `1.0.0` Windows observations also
+remain historical. Current targets are Operon `3.1.1` and CLI `1.0.9`.
 
-Keep the current cutover active for supported read/create/update/convert/
-relocate operations. Use the MCP for governed agent workflows, including
-native diagnostics, finder/resolve, bounded relationships/context and timer
-observation. Use the Operon CLI for broad administration, deep recovery
-investigation, native acceptance and one-off operator actions. Keep Kairélys disabled but retained until a separate
-non-dependency proof authorizes removal. Do not enable Bridge transition apply
-or remove its capability gate without a fresh terminal/recovery proof.
+## Deliberately excluded or unavailable
 
-## Next action
+- deletion: CLI operator action until a reversible `operon_trash_task` contract
+  exists;
+- reminders, pinned state and timer control/session: retained in the CLI;
+- adoption and saved filters: tools remain registered for compatibility but the
+  official `3.1.1` Developer API does not expose their native capabilities;
+- generic CLI execution: rejected;
+- actual multi-device Sync topology: not run by this local acceptance pilot.
 
-Prepare a focused upstream/Bridge transition report with the exact
-`outcome-unknown` evidence, then rerun a disposable terminal/recovery proof
-after a fix. Separately audit the real vault's Kairélys non-dependency before
-considering removal.
+## Decision
+
+Keep the current Operon integration active. Use MCP/Bridge for governed agent
+workflows and CLI for broad operator work. Keep Kairélys disabled but available
+for rollback until a separate non-dependency proof authorizes removal.
+
+The code and local acceptance work are complete. Remaining work is upstream
+review/release monitoring and the separate real Sync/non-dependency decision.

--- a/docs/operon-local-validation.md
+++ b/docs/operon-local-validation.md
@@ -167,6 +167,12 @@ operon_get_task
 operon_query_tasks
 operon_query_saved_filter
 operon_validate
+operon_get_diagnostics
+operon_find_tasks
+operon_resolve_task
+operon_get_relationships
+operon_build_context
+operon_get_timer_state
 operon_adopt_task
 operon_create_task
 operon_update_task
@@ -182,6 +188,8 @@ operon_recover_mutation
 PASS when:
 
 - all twenty-three tools are registered;
+- official Operon `3.1.1` returns structured unavailable results for adoption
+  and saved-filter evaluation until it advertises those native capabilities;
 - the first complete call creates a snapshot;
 - subsequent calls with unchanged generation do not rewrite the full snapshot;
 - responses say `source=operon-live`, `stale=false`.
@@ -207,6 +215,18 @@ PASS: same task identities and values; revisions change only when normalized tas
 8. Remove the fixture only through the operator CLI after backup and explicit confirmation.
 
 PASS: live source, exact inverse edges, scoped recurrence state, idempotent replay, stale-revision conflict, exact restoration, and `P0/P1/P2 = 0/0/0`.
+
+Executed result on 2026-08-08 with the patched local Operon `3.1.1`
+acceptance build:
+
+- relationship dry-run/apply passed on `oo96ct2` and `1dbefy1`;
+- the inverse edge was verified, the same key replayed without a second write,
+  a stale revision conflicted, and both tasks were restored;
+- a dedicated recurrence fixture passed add, scope change and explicit clear;
+- Obsidian and MCP restart preserved a stable recovery state;
+- final inventory returned 25 tasks outside the removed fixture, live source,
+  no residual relationship/recurrence state, no pending recovery, and
+  `P0/P1/P2 = 0/0/0`.
 
 ## 10. Stale fallback
 

--- a/docs/operon-mcp-contract.fr.md
+++ b/docs/operon-mcp-contract.fr.md
@@ -1,0 +1,218 @@
+# Outils Operon dans Optimike Obsidian MCP
+
+English version: [operon-mcp-contract.md](operon-mcp-contract.md)
+
+## Surface
+
+Le serveur MCP principal enregistre vingt-trois outils Operon :
+
+- `operon_status`
+- `operon_get_configuration`
+- `operon_list_tasks`
+- `operon_get_task`
+- `operon_query_tasks`
+- `operon_query_saved_filter`
+- `operon_validate`
+- `operon_get_diagnostics`
+- `operon_find_tasks`
+- `operon_resolve_task`
+- `operon_get_relationships`
+- `operon_build_context`
+- `operon_get_timer_state`
+- `operon_adopt_task`
+- `operon_create_task`
+- `operon_update_task`
+- `operon_transition_task`
+- `operon_set_relationships`
+- `operon_update_recurrence`
+- `operon_convert_task`
+- `operon_relocate_task`
+- `operon_list_pending_recoveries`
+- `operon_recover_mutation`
+
+Il n’existe pas de second serveur MCP. Tous ces outils partagent le même runtime,
+la même politique d’écriture, le même cache SQLite et le même journal durable.
+
+`operon_get_configuration` lit dans le runtime Operon les réglages qui changent
+le sens, la création ou le workflow des tâches. Le MCP ne duplique pas le
+parsing de `data.json`. La réponse porte une signature déterministe et indique
+explicitement lorsqu’elle provient d’un fallback headless obsolète.
+
+## Pourquoi le MCP ne relaie pas simplement la CLI
+
+La CLI est une surface large destinée à l’opérateur : diagnostics natifs,
+administration, investigation de récupération et actions ponctuelles. Le MCP
+est la surface de contrôle destinée aux agents.
+
+Une opération n’entre dans le MCP que si elle possède un contrat sémantique
+borné et les garanties correspondantes :
+
+- schéma d’entrée étroit et capacité officielle annoncée par le runtime ;
+- moindre privilège et double opt-in pour les écritures ;
+- `dryRun` par défaut et plan officiel scellé ;
+- `expectedRevision` pour empêcher l’écriture sur un état périmé ;
+- `idempotencyKey` durable pour empêcher une seconde application ;
+- vérification postflight dans l’index live ;
+- journal et récupération du plan exact après un résultat incertain ;
+- refus structuré sans fallback Markdown, API privée ou commande UI.
+
+Un passthrough CLI générique contournerait ces garanties, exposerait des
+commandes trop larges et rendrait les changements de capacités invisibles pour
+l’agent. La disponibilité d’une commande CLI ne suffit donc pas à en faire un
+outil MCP.
+
+## Lectures et fraîcheur
+
+Chaque lecture déclare `source`, `stale`, l’heure et l’âge du snapshot, les
+versions Operon/Bridge, la version du contrat, les capacités et les limites.
+
+- `operon-live` : pagination complète et validation cohérentes avec une seule
+  génération et une seule signature de réglages Operon.
+- `operon-cache` : dernier snapshot SQLite validé, toujours obsolète et jamais
+  utilisé comme preuve d’une mutation.
+
+Un payload invalide, une pagination tronquée, une génération instable, des IDs
+dupliqués, une version incompatible, un index non prêt ou une validation P0
+n’écrasent jamais le dernier snapshot sain.
+
+`operon_query_saved_filter` est live-only et dépend d’une capacité native. La
+version officielle Operon `3.1.1` ne l’annonce pas actuellement : l’outil reste
+enregistré pour compatibilité mais renvoie une indisponibilité structurée. Le
+MCP ne tente pas de reproduire le moteur de filtres depuis le cache.
+
+Les six lectures Developer API supplémentaires sont également live-only :
+diagnostics, recherche classée, résolution d’entité, graphe de relations borné,
+pack de contexte borné et état du timer. Les résultats, profondeurs et champs
+hydratés sont plafonnés. Le Markdown source brut, l’historique des trackers ou
+rappels et les packs non nécessaires restent exclus.
+
+Les agents doivent préférer les `statusId`, `pipelineId` et noms canoniques
+renvoyés par `operon_get_configuration`. Les libellés visibles en français ou en
+anglais ne sont pas des identifiants d’automatisation durables.
+
+## Mutations
+
+Les mutations passent par les routes REST du Bridge et la surface officielle du
+moteur chargé. Operon `3.1.1` utilise les plans typés preview/apply/recovery de
+Developer API V1. Le chemin legacy Kairélys utilise Public API v1. Aucun chemin
+ne modifie directement le Markdown, n’appelle `TaskWriter`, ne lance une
+commande UI et ne réfléchit vers une méthode privée.
+
+Contrôles communs :
+
+- `dryRun` vaut `true` par défaut ;
+- `idempotencyKey` est obligatoire ;
+- une tâche Operon existante exige `expectedRevision` ;
+- l’adoption legacy exige `line` et `expectedLine` exacts ;
+- Operon `3.1.1` applique uniquement le plan prévisualisé et scellé par l’hôte ;
+- `outcome-unknown` est exposé avec sa référence de récupération et n’est jamais
+  rejoué à l’aveugle ;
+- après apply, le Bridge relit l’index live vérifié et le MCP rafraîchit son
+  snapshot SQLite ;
+- aucune mutation ne s’appuie sur un snapshot headless ou obsolète.
+
+Le journal `operon_mutation_journal` réserve la clé avant l’appel au Bridge.
+Rejouer une requête terminée avec la même clé renvoie le même `operationId` sans
+second appel. Réutiliser la clé pour une autre requête renvoie `CONFLICT`. Une
+révision périmée renvoie `conflict` sans écriture. Une réservation restée
+`in_progress` après timeout ou redémarrage bloque toute nouvelle mutation à
+l’aveugle.
+
+L’apply exige aussi `OPERON_MUTATIONS_ENABLED=true` et le réglage Bridge
+**Allow task mutations**. Une mise à jour de package ne peut donc pas activer les
+écritures implicitement.
+
+### Politique d’écriture
+
+- `MCP_WRITE_MODE=readonly` : dry-run uniquement.
+- `MCP_WRITE_MODE=guarded` : apply d’adoption si la capacité existe, création,
+  update, transition, remplacement de relations et relocation inline.
+- `MCP_WRITE_MODE=full` : conversion et récurrence en plus.
+- `operon_recover_mutation` exige aussi le mode `full` et ne récupère que le
+  `recoveryRef` exact.
+
+`OPERON_MUTATION_ALLOWED_PATH_PREFIXES` peut limiter toutes les mutations à des
+dossiers relatifs au coffre. Les sources et destinations explicites doivent
+rester dans cette allowlist. Operon officiel `3.1.1` refuse encore un
+`targetFolder` arbitraire lorsqu’aucun contrat de destination exacte n’existe.
+
+La conversion reste destructive : file-to-inline déplace le fichier source
+dans la corbeille et inline-to-file remplace la ligne source par un lien durable.
+
+### Règles propres aux outils
+
+`operon_adopt_task` est un outil de compatibilité enregistré, pas une capacité
+officielle d’Operon `3.1.1`. Un moteur legacy compatible peut adopter une
+checkbox exacte avec verrouillage du chemin, de la ligne et du contenu source.
+Operon officiel renvoie une indisponibilité structurée et le MCP ne simule pas
+l’adoption en éditant le Markdown.
+
+`operon_create_task` crée une tâche inline ou fichier par les services officiels
+du moteur. Operon `3.1.1` accepte les champs typés, tags, `statusId`, relations,
+`targetPath` inline et templates configurés. Les propriétés YAML non gérées et
+les `targetFolder` arbitraires restent legacy-only.
+
+`operon_update_task` accepte un seul groupe par appel : description, champs
+gérés/tags ou propriété fichier non gérée lorsque le moteur l’autorise. Les
+statuts passent par l’outil de transition. Une description différente sur une
+File Task doit rester refusée tant qu’un contrat de renommage explicite n’existe
+pas.
+
+`operon_transition_task` préfère un `statusId` stable et accepte un libellé de
+workflow exact uniquement pour compatibilité. Les dépendances, récurrences,
+agrégats et gardes de workflow restent appliqués par Operon. Un résultat
+incertain est renvoyé tel quel sans retry.
+
+`operon_set_relationships` remplace ou supprime explicitement `parentTask`,
+`blocking` et `blockedBy`. Il refuse doublon, auto-référence et cible placée dans
+les deux directions. Operon valide le graphe/cycle et le Bridge vérifie la tâche
+source ainsi que chaque relation inverse modifiée.
+
+`operon_update_recurrence` modifie uniquement la surface officielle de
+récurrence avec une portée `this-task` ou `this-and-following`. `null` supprime
+explicitement un champ. La récurrence n’est jamais simulée par
+`operon_update_task` et son apply exige le mode `full`.
+
+`operon_convert_task` convertit inline et fichier par les chemins officiels de
+transition. File-to-inline exige un `targetPath` explicite.
+
+`operon_relocate_task` déplace une tâche inline vers un `targetPath` Markdown
+explicite en conservant `operonId`. Le Bridge vérifie source et destination
+après stabilisation de l’index.
+
+`operon_list_pending_recoveries` liste les références officielles sans appliquer
+quoi que ce soit. `operon_recover_mutation` récupère un seul plan exact et
+préserve ses preuves `planDigest` et `recoveryRef`.
+
+## Preuves du pilote
+
+Le chemin legacy Operon `2.5.0`/Kairélys a historiquement prouvé création,
+champs, relations, transitions, conversion, idempotence, conflits de révision,
+redémarrage, fallback stale et refus P0 des IDs dupliqués.
+
+Le pilote dédié Operon `3.1.1`, sur le build local corrigé, a ensuite prouvé :
+
+- grant officiel, lecture live et plans typés preview/apply ;
+- dry-run, postflight, replay idempotent et conflit de révision périmée ;
+- relation source/inverse, blocage d’une transition terminale et restauration ;
+- ajout, changement de portée et suppression exacte d’une récurrence ;
+- redémarrage/récupération stable ;
+- 25 tâches après nettoyage, aucune relation ou récurrence résiduelle ;
+- validation finale `P0/P1/P2 = 0/0/0`.
+
+La version officielle non corrigée conserve les limites upstream #99/#101,
+#135, #137 et #139. Le Bridge échoue fermé lorsque le runtime ne peut pas
+prouver le résultat.
+
+## Capacités indisponibles ou exclues
+
+Suppression, rappels, état épinglé, contrôle/session de timer, adoption et
+gestion des filtres sauvegardés restent hors de la surface officielle de
+mutation agentique. Les outils adoption et filtre sauvegardé restent enregistrés
+pour compatibilité mais renvoient une indisponibilité sur Operon officiel
+`3.1.1`.
+
+La suppression reste une action opérateur dans la CLI. Un futur
+`operon_trash_task` ne pourra être envisagé qu’avec restauration garantie sous
+le même `operonId`, relations réconciliées, journal durable et confirmation
+humaine explicite. Il n’est pas implémenté.

--- a/docs/operon-mcp-contract.md
+++ b/docs/operon-mcp-contract.md
@@ -1,5 +1,7 @@
 # Operon tools in Optimike Obsidian MCP
 
+French version: [operon-mcp-contract.fr.md](operon-mcp-contract.fr.md)
+
 ## Surface
 
 The main MCP server registers twenty-three Operon tools:
@@ -32,6 +34,16 @@ There is no second MCP server.
 
 `operon_get_configuration` is the agent-facing equivalent of the historical Tasks settings loader. It reads the live Operon runtime through the Bridge instead of duplicating `data.json` parsing in Node. The response includes the settings that change task meaning or creation behavior, a deterministic signature, and an explicitly stale cached fallback for headless use.
 
+## Why MCP does not simply call the CLI
+
+The CLI is the broad operator surface for native diagnostics, administration,
+recovery investigation and one-off actions. MCP is the agent control plane. A
+function enters MCP only with a bounded semantic schema, least-privilege
+capability check, dry-run, revision locking, durable idempotency, postflight and
+matching recovery/human gates. A generic CLI passthrough would bypass those
+guarantees, expose overly broad commands and make capability drift invisible to
+agents. CLI availability alone is therefore not an MCP admission criterion.
+
 ## Reads and freshness
 
 Every read response declares `source`, `stale`, snapshot time/age, Operon and Bridge versions, contract version, capabilities, and limitations.
@@ -41,7 +53,7 @@ Every read response declares `source`, `stale`, snapshot time/age, Operon and Br
 
 SQLite cache state lives in `operon_task_snapshot` and `operon_snapshot_meta`. Malformed payloads, incomplete pagination, generation drift, duplicate IDs, incompatible versions, unready index, or P0 validation never replace the last known-good snapshot.
 
-`operon_query_saved_filter` is intentionally live-only: it delegates to Operon's native filter evaluator and never pretends that a headless parser can reproduce plugin semantics.
+`operon_query_saved_filter` is intentionally live-only and capability-gated. It delegates to the loaded engine's native filter evaluator and never pretends that a headless parser can reproduce plugin semantics. Official Operon `3.1.1` does not currently advertise this capability, so the registered tool returns a structured unavailable result; compatible legacy engines may provide it.
 
 The six additional Developer API reads are also live-only. They expose native
 runtime diagnostics, ranked finder, entity resolution, bounded relationship
@@ -86,7 +98,7 @@ Conversion remains classified as destructive because file-to-inline moves the so
 
 ### Tool-specific rules
 
-`operon_adopt_task` upgrades one existing plain Markdown or Obsidian Tasks checkbox in place. The target file, one-based line, and exact source line must still match; otherwise the operation returns `conflict` without writing. Supported Tasks dates, priority and tags are translated by Operon before the line is indexed, and optional `statusId` uses the live language-stable workflow identity. The final task must be proven at the same path and line.
+`operon_adopt_task` is a registered compatibility tool, not an official Operon `3.1.1` capability. When a compatible legacy engine advertises adoption, it upgrades one existing plain Markdown or Obsidian Tasks checkbox in place. The target file, one-based line, and exact source line must still match; otherwise the operation returns `conflict` without writing. Official Operon `3.1.1` returns a structured unavailable result and the MCP does not simulate adoption with a Markdown edit.
 
 `operon_create_task` creates inline or file tasks through Operon's creator services. On official Operon 3.1.1, typed fields, tags, stable `statusId`, relationships, exact inline `targetPath`, and configured/default file templates are supported. Unmanaged YAML properties and arbitrary `targetFolder` placement are legacy-only; the official Developer API path rejects them instead of using a fallback.
 
@@ -122,8 +134,8 @@ On legacy Operon `2.5.0`/Kairélys in a disposable vault, direct MCP calls histo
 
 Production activation and Tasks/TaskNotes migration remain separate manual gates.
 
-The equivalent relationship and recurrence claims apply to official Operon `3.1.1` only after the dedicated 3.1.1 pilot recipe below has passed; legacy evidence is not presented as Developer API evidence.
+The dedicated Operon `3.1.1` pilot passed on the patched local acceptance build: relationship dry-run/apply, inverse-edge verification, idempotent replay, stale-revision conflict, blocked terminal-transition enforcement, exact restoration, recurrence add/scope-change/clear, restart/recovery stability, live source, no residual relationship/recurrence state, and `P0/P1/P2 = 0/0/0`. Stock `3.1.1` remains subject to the upstream limitations in #99/#101, #135, #137 and #139; the Bridge reports uncertainty or unavailability without retrying or falling back.
 
-## Deliberately excluded writes
+## Deliberately unavailable or excluded capabilities
 
-Deletion, reminders, pinned state, timer control/session, adoption, and saved-filter management remain outside the official agent mutation surface. Adoption and saved filters are unavailable until official capabilities exist. Delete remains an operator CLI action. A future `operon_trash_task` may be considered only with guaranteed restoration under the same `operonId`, reconciled relations, durable journal evidence, and an explicit human confirmation; it is not implemented.
+Deletion, reminders, pinned state, timer control/session, adoption, and saved-filter management remain outside the official agent mutation surface. The adoption and saved-filter tools stay registered for compatibility but return unavailable on official Operon `3.1.1` until native capabilities exist. Delete remains an operator CLI action. A future `operon_trash_task` may be considered only with guaranteed restoration under the same `operonId`, reconciled relations, durable journal evidence, and an explicit human confirmation; it is not implemented.

--- a/docs/runtime-capability-matrix.fr.md
+++ b/docs/runtime-capability-matrix.fr.md
@@ -73,12 +73,13 @@ Tous les modes enregistrent aussi les 23 outils du contrat Operon :
 `operon_update_recurrence`, `operon_convert_task`,
 `operon_relocate_task`, `operon_list_pending_recoveries` et
 `operon_recover_mutation`. Hors mode live, ils restent limités aux snapshots
-validés en lecture seule ; toute mutation échoue fermée. Pour Operon 3.1.1,
-la transition en apply est disponible lorsque la Developer API live annonce la
-capacité ; le Bridge borne les résultats incertains et n’effectue jamais de
-retry aveugle. Les preuves complètes utilisent le build local corrigé pendant
-l’examen des PR upstream #135, #137 et #139. Les diagnostics CLI/Developer API
-natifs restent séparés.
+validés en lecture seule ; toute mutation échoue fermée. L’enregistrement ne
+garantit pas la disponibilité runtime : Operon officiel `3.1.1` renvoie encore
+une indisponibilité pour les filtres sauvegardés et l’adoption. Les relations et
+la récurrence ont passé le pilote live dédié sur le build 3.1.1 corrigé. La
+version officielle conserve les limites bornées #99/#101, #135, #137 et #139.
+Voir le [contrat MCP Operon](operon-mcp-contract.fr.md) et
+l’[audit CLI/API](operon-cli-audit.fr.md).
 
 La livraison du handoff est un contrat de transport, pas une capacité d’écriture
 du mode runtime :

--- a/docs/runtime-capability-matrix.md
+++ b/docs/runtime-capability-matrix.md
@@ -81,10 +81,14 @@ Every mode also registers the 23 Operon contract tools:
 `operon_update_recurrence`, `operon_convert_task`,
 `operon_relocate_task`, `operon_list_pending_recoveries`, and
 `operon_recover_mutation`. In non-live modes they remain limited to validated
-read-only snapshots; mutation calls fail closed. Official Operon 3.1.1
-transition apply is available in live mode. Elevated transitions require fresh
+read-only snapshots; mutation calls fail closed. Registration does not imply
+runtime availability: official Operon `3.1.1` currently returns unavailable for
+saved-filter evaluation and adoption. Relationship and recurrence apply passed
+the dedicated patched-3.1.1 live pilot. Stock 3.1.1 retains the bounded upstream
+limits in #99/#101, #135, #137 and #139. Elevated transitions require fresh
 confirmation in the owning Obsidian vault window; unattended consent fails
-closed after 45 seconds. Native CLI/Developer API diagnostics remain separate.
+closed after 45 seconds. See the [Operon MCP contract](operon-mcp-contract.md)
+and [CLI/API audit](operon-cli-audit.md).
 
 Handoff delivery is a transport contract, not a runtime-mode write capability:
 

--- a/scripts/test-doc-contract.mjs
+++ b/scripts/test-doc-contract.mjs
@@ -71,12 +71,22 @@ const commonTools = [
   "operon_query_tasks",
   "operon_query_saved_filter",
   "operon_validate",
+  "operon_get_diagnostics",
+  "operon_find_tasks",
+  "operon_resolve_task",
+  "operon_get_relationships",
+  "operon_build_context",
+  "operon_get_timer_state",
   "operon_adopt_task",
   "operon_create_task",
   "operon_update_task",
   "operon_transition_task",
+  "operon_set_relationships",
+  "operon_update_recurrence",
   "operon_convert_task",
   "operon_relocate_task",
+  "operon_list_pending_recoveries",
+  "operon_recover_mutation",
 ];
 for (const tool of commonTools) {
   assert.ok(matrix.includes(`\`${tool}\``), `Matrix omits ${tool}`);
@@ -109,10 +119,30 @@ const bilingualPairs = [
   ["docs/runtime-capability-matrix.md", "docs/runtime-capability-matrix.fr.md"],
   ["docs/mcp-routing-guide.md", "docs/mcp-routing-guide.fr.md"],
   ["docs/headless-server-profile.md", "docs/headless-server-profile.fr.md"],
+  ["docs/operon-mcp-contract.md", "docs/operon-mcp-contract.fr.md"],
+  ["docs/operon-cli-audit.md", "docs/operon-cli-audit.fr.md"],
 ];
 for (const pair of bilingualPairs) {
   for (const file of pair) await access(path.join(root, file));
 }
+
+const operonContract = await text("docs/operon-mcp-contract.md");
+const operonContractFr = await text("docs/operon-mcp-contract.fr.md");
+const operonAudit = await text("docs/operon-cli-audit.md");
+const operonAuditFr = await text("docs/operon-cli-audit.fr.md");
+for (const content of [operonContract, operonContractFr]) {
+  for (const tool of commonTools.filter((tool) => tool.startsWith("operon_"))) {
+    assert.ok(content.includes(`\`${tool}\``), `Operon contract omits ${tool}`);
+  }
+}
+assert.doesNotMatch(operonAudit, /acceptance remains pending/i);
+assert.doesNotMatch(operonAuditFr, /acceptation (?:live )?reste en attente/i);
+assert.match(operonAudit, /no\s+residual relationship\/recurrence state/i);
+assert.match(operonAuditFr, /aucun résidu/i);
+assert.match(operonContract, /generic CLI passthrough/i);
+assert.match(operonContractFr, /passthrough CLI générique/i);
+assert.match(operonContract, /structured unavailable result/i);
+assert.match(operonContractFr, /indisponibilité structurée/i);
 
 const brokenLinks = [];
 for (const file of await markdownFiles(root)) {


### PR DESCRIPTION
## What changed

- add complete French versions of the Operon MCP contract and CLI / Developer API audit
- align the README, documentation hubs, capability matrices, ADR, decision report and validation recipe with the 23-tool surface
- explain why governed agent operations belong in MCP while broad operator and destructive actions stay in the CLI
- distinguish registered compatibility tools from capabilities unavailable in official Operon 3.1.1
- record the completed relationship and recurrence pilot evidence
- extend the documentation contract so these claims cannot silently drift again

## Why

The implementation had advanced beyond several public documents. Some pages still described 21 tools or pending relationship and recurrence acceptance, and the French documentation did not include the detailed Operon contract or CLI boundary. This change makes the published documentation match the current runtime and its verified limits.

## Impact

Users now have one coherent English/French explanation of which Operon functions agents can use, which operations remain operator-only, and why MCP is a governed control plane rather than a generic CLI passthrough.

## Checks

- `npm run test:docs`
- `npm run test:tool-annotations`
- `git diff --check`
