### PR TITLE
Release v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-08-09
+
 ### Added
 
 - Bilingual Operon MCP contract and CLI audit documenting the complete 23-tool

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,5 +1,7 @@
 # Optimike Obsidian MCP
 
+[![Dernière version](https://img.shields.io/github/v/release/optimikelabs/optimike-obsidian-mcp?display_name=tag&sort=semver)](https://github.com/optimikelabs/optimike-obsidian-mcp/releases/latest)
+
 English version: [README.md](README.md)
 Hub documentaire : [docs/README.fr.md](docs/README.fr.md)
 Exploitation : [OPERATIONS.fr.md](OPERATIONS.fr.md)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Optimike Obsidian MCP
 
+[![Latest release](https://img.shields.io/github/v/release/optimikelabs/optimike-obsidian-mcp?display_name=tag&sort=semver)](https://github.com/optimikelabs/optimike-obsidian-mcp/releases/latest)
+
 French version: [README.fr.md](README.fr.md)
 Documentation hub: [docs/README.md](docs/README.md)
 Operations: [OPERATIONS.md](OPERATIONS.md)


### PR DESCRIPTION
## What changed

- promoted the accumulated changelog entries from `Unreleased` to `2.4.0` dated 2026-08-09
- added a live GitHub release badge to the English and French README entrypoints

## Why

The package manifests already declare `2.4.0`, while GitHub's latest tag is `v2.2.0` and no GitHub Release exists. This change makes the repository's public version surface explicit before publishing the matching tag and release.

## Impact

Visitors can see and reach the latest published version directly from either README. No runtime behavior changes.

## Validation

- `npm run test:docs`
- `npm run build`
- `git diff --check`
