### PR TITLE
Add governed Operon 3.2 saved-filter support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ Thumbs.db
 # IDE and Editor Files
 .idea/
 .vscode/
+.obsidian/
 *.swp
 *.swo
 *~

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Operon `3.2.1` / CLI `1.1.0` compatibility through Bridge `0.6.0`, retaining
+  explicit `3.2.0` support and including
+  native saved-filter execution via the additive `tasks.filter-query` grant and
+  opaque pagination.
+- Regression coverage proving that a pending filter grant cannot hide already
+  approved core reads or mutations.
+- Saved-filter pagination and Bridge HTTP error mapping coverage, preserving
+  typed `404`/`422` failures instead of reporting generic internal errors.
+
+### Changed
+
+- Saved-filter documentation now distinguishes execution from catalog
+  discovery: Operon 3.2 requires an exact caller-supplied `filterSetId` because
+  its official Developer API does not list the saved-filter catalog.
+- ÉLYSIA Task Gouverneur active skill `2.2` and distributed profile skill
+  `1.3.0` align with the 3.2 capability boundary. Adoption remains unavailable
+  without a Markdown or CLI fallback.
+
 ## [2.4.0] - 2026-08-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- ÉLYSIA Task Gouverneur `1.2.0`, aligned with the complete 23-tool Operon
+  surface, capability-gated adoption/saved filters, governed relationships and
+  recurrence, exact-plan recovery, and the explicit MCP/CLI boundary.
+
 - Bilingual Operon MCP contract and CLI audit documenting the complete 23-tool
   surface, the governed MCP-versus-CLI boundary, stock 3.1.1 capability limits,
   and the completed relationship and recurrence acceptance evidence.

--- a/README.fr.md
+++ b/README.fr.md
@@ -21,7 +21,7 @@ documents autorisés hors du coffre.
 | ----------------------- | -------------------------------------------------------------------- | ----------------------------------------------------- |
 | Notes                   | Lecture, liste, recherche, mise à jour, frontmatter et tags          | Coffre ; Local REST API pour la surface live complète |
 | Bases et Canvas         | Requêtes/écritures Bases, validation et helpers Canvas bornés        | Bases Bridge pour Bases en live                       |
-| Tâches                  | Lecture/requête Tasks + 23 outils Operon gouvernés                   | Operon 3.1.1 Developer API V1 via le Bridge           |
+| Tâches                  | Lecture/requête Tasks + 23 outils Operon gouvernés                   | Operon 3.2.1 Developer API V1 via le Bridge           |
 | Recherche sémantique    | Recherche Smart Connections avec cache de métadonnées durable        | `.smart-env` + embedding Ollama ou OpenAI             |
 | Runtime                 | Cache SQLite partagé, santé, maintenance, mode dégradé et exclusions | Filesystem local                                      |
 | Documents externes      | Lectures/handoff gouvernés + move local opt-in avec réparation       | Allowlist ; stdio local pour le move                  |
@@ -93,7 +93,7 @@ Activer seulement les surfaces utilisées :
   notes, métadonnées et tags en live ;
 - **Bases Bridge (REST)** inclus : opérations `.base` en live ;
 - **Smart Connections** : index sémantique `.smart-env` ;
-- **Operon 3.1.1** et **Optimike Operon Bridge** inclus : tâches live
+- **Operon 3.2.1** et **Optimike Operon Bridge** inclus : tâches live
   gouvernées via la Developer API officielle V1 ;
 - la compatibilité Kairélys reste disponible comme chemin legacy/rollback
   borné, mais n’est plus le moteur de production ;
@@ -120,16 +120,20 @@ destructives ou d’administration restent dans la CLI. Voir le
 [contrat MCP Operon](docs/operon-mcp-contract.fr.md) et
 l’[audit CLI / Developer API](docs/operon-cli-audit.fr.md).
 
-Note de compatibilité : l’adaptateur cible Operon officiel `3.1.1`, mais les
-preuves d’acceptation complètes de ce dépôt utilisent notre build local corrigé
-pendant l’examen des correctifs upstream [#135](https://github.com/hasanyilmaz/operon/pull/135),
-[#137](https://github.com/hasanyilmaz/operon/pull/137) et
-[#139](https://github.com/hasanyilmaz/operon/pull/139). Operon officiel `3.1.1`
-reste utilisable pour les lectures et la plupart des mutations gouvernées, mais
-le settlement des frontmatters de date, le consentement entre plusieurs fenêtres
-Obsidian et les renommages implicites de File Tasks conservent les limites
-upstream décrites dans ces PR. Le MCP ne bascule jamais vers Markdown ou des
-API privées quand l’un de ces cas n’est pas supporté. Le cas particulier des
+Note de compatibilité : l’adaptateur cible Operon officiel `3.2.1` et le Bridge
+`0.6.0` ; `3.2.0` reste explicitement compatible et porte le pilote live complet.
+Le settlement des frontmatters de date et le consentement multi-fenêtres
+ont été fusionnés upstream avant ces versions. L’exécution des filtres
+sauvegardés est maintenant disponible via la Developer API task-workflow après
+un grant exact, mais l’API officielle ne publie pas leur catalogue : il faut
+fournir un `filterSetId` exact obtenu dans l’UI/configuration d’Operon ou par un
+workflow opérateur. L’adoption reste indisponible dans l’API officielle. Operon
+3.2.1 omet encore le renderer déclaratif des contrôles de grant Developer API ;
+le correctif est suivi dans [#145](https://github.com/hasanyilmaz/operon/issues/145)
+et [#146](https://github.com/hasanyilmaz/operon/pull/146).
+Le MCP ne bascule jamais vers Markdown ou des API privées. Les renommages
+implicites de File Tasks restent suivis dans
+[#139](https://github.com/hasanyilmaz/operon/pull/139), et le cas particulier des
 transitions sans portée `project-serial` reste suivi dans
 [#99](https://github.com/hasanyilmaz/operon/issues/99) et
 [#101](https://github.com/hasanyilmaz/operon/pull/101).

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ explicitly governed access to configured documents outside the vault.
 | ----------------------- | ---------------------------------------------------------------------- | -------------------------------------------------- |
 | Notes                   | Read, list, search, update, frontmatter and tags                       | Vault; Local REST API for the full live surface    |
 | Bases and Canvas        | Bases query/write tools, format validation and bounded Canvas helpers  | Bases Bridge for live Bases                        |
-| Tasks                   | Obsidian Tasks-compatible list/query plus 23 governed Operon tools     | Operon 3.1.1 Developer API V1 through the Bridge   |
+| Tasks                   | Obsidian Tasks-compatible list/query plus 23 governed Operon tools     | Operon 3.2.1 Developer API V1 through the Bridge   |
 | Semantic search         | Smart Connections index search with durable metadata cache             | `.smart-env` plus Ollama or OpenAI query embedding |
 | Runtime                 | Shared SQLite cache, health, maintenance, degraded mode and exclusions | Local filesystem                                   |
 | External documents      | Governed reads/handoff plus opt-in local move with exact link repair   | Allowlist; local stdio for move                    |
@@ -91,7 +91,7 @@ Enable only the surfaces you use:
   live note, metadata and tag operations;
 - bundled **Bases Bridge (REST)**: live `.base` operations;
 - **Smart Connections**: semantic index under `.smart-env`;
-- **Operon 3.1.1** and the bundled **Optimike Operon Bridge**: governed live
+- **Operon 3.2.1** and the bundled **Optimike Operon Bridge**: governed live
   task operations through the official Developer API V1;
 - Kairélys compatibility remains available as a bounded legacy/rollback path,
   not as the production owner;
@@ -120,16 +120,20 @@ Transition apply is available through the Bridge. Elevated or destructive plans
 still require fresh confirmation in the owning Obsidian vault window and fail
 closed after 45 seconds when no confirmation can be presented.
 
-Compatibility note: the adapter targets official Operon `3.1.1`, but the full
-acceptance evidence in this repository uses our patched local Operon build while
-upstream fixes are under review in [#135](https://github.com/hasanyilmaz/operon/pull/135),
-[#137](https://github.com/hasanyilmaz/operon/pull/137), and
-[#139](https://github.com/hasanyilmaz/operon/pull/139). Stock Operon `3.1.1`
-remains usable for reads and most governed mutations, but modified-time
-frontmatter settlement, consent across multiple Obsidian windows, and implicit
-File Task renames retain the upstream limitations described in those PRs. The
-MCP does not fall back to Markdown or private APIs when one of these cases is
-not supported. The unscoped transition edge case remains tracked in
+Compatibility note: the adapter targets official Operon `3.2.1` and Bridge
+`0.6.0`; `3.2.0` remains explicitly compatible and is the version used by the
+complete live acceptance run. Modified-time frontmatter settlement and
+multi-window consent were merged upstream before these releases. Saved-filter execution is available
+through the additive task-workflow Developer API after an exact grant, but the
+official API does not expose the saved-filter catalog: callers must supply an
+exact `filterSetId` obtained from Operon's UI/configuration or an operator
+workflow. Adoption remains unavailable on the official Developer API. Operon
+3.2.1 still omits the declarative Settings renderer for Developer API grant
+controls; the fix is tracked in [#145](https://github.com/hasanyilmaz/operon/issues/145)
+and [#146](https://github.com/hasanyilmaz/operon/pull/146).
+No MCP route falls back to Markdown or private APIs. Implicit File Task renames
+remain tracked in [#139](https://github.com/hasanyilmaz/operon/pull/139), and the
+unscoped transition edge case remains tracked in
 [#99](https://github.com/hasanyilmaz/operon/issues/99) and
 [#101](https://github.com/hasanyilmaz/operon/pull/101).
 

--- a/docs/adr/ADR-Operon-Bridge.md
+++ b/docs/adr/ADR-Operon-Bridge.md
@@ -2,20 +2,20 @@
 
 - Status: accepted and implemented on `main`
 - Date: 2026-07-21
-- Amended: 2026-08-08
+- Amended: 2026-08-09
 - MCP baseline: `optimikelabs/optimike-obsidian-mcp@8cea94610a526e50a017d334be6008b8dab79500`
-- Operon baselines: upstream `2.4.0@76d251973b149afc69192ef565d626740aa7b7cf`, `2.5.0@31099cc3d5231b320cd8520424fc29449b003778`, and official `3.1.1` Developer API V1
+- Operon baselines: upstream `2.4.0@76d251973b149afc69192ef565d626740aa7b7cf`, `2.5.0@31099cc3d5231b320cd8520424fc29449b003778`, and official `3.2.1` Developer API V1 (`3.2.0` complete live-pilot baseline)
 
 ## Problem
 
-Operon unifies inline and file tasks around stable identity and one domain model. Earlier releases exposed no public versioned mutation API; official Operon `3.1.1` now exposes Developer API V1. Agent writes must still preserve workflow normalization, dependencies, recurrence, aggregates, project serials, archiving, auto-unpin, conversions, and index/view reconciliation. Direct Markdown edits or direct `TaskWriter` calls do not satisfy that contract.
+Operon unifies inline and file tasks around stable identity and one domain model. Earlier releases exposed no public versioned mutation API; official Operon `3.2.x` exposes Developer API V1 plus an additive task-workflow filter API. Agent writes must still preserve workflow normalization, dependencies, recurrence, aggregates, project serials, archiving, auto-unpin, conversions, and index/view reconciliation. Direct Markdown edits or direct `TaskWriter` calls do not satisfy that contract.
 
 ## Decision
 
 Use one MCP server and three explicit layers:
 
 ```text
-Official Operon 3.1.1 / legacy Kairélys
+Official Operon 3.2.x / legacy Kairélys
     ↓ Developer API V1 / PublicApiV1
 Optimike Operon Bridge
     ↓ Local REST API contract v1
@@ -24,13 +24,13 @@ Optimike Obsidian MCP
 Agents
 ```
 
-Official Operon `2.4.0` and `2.5.0` remain supported for reads. Official Operon `3.1.1` uses its host-verified Developer API V1 for typed mutation plans; legacy Kairélys uses Public API v1. No fallback crosses either capability boundary.
+Official Operon `2.4.0` and `2.5.0` remain supported for reads. Official Operon `3.2.x` uses its host-verified Developer API V1 for typed mutation plans and exact-grant saved-filter execution; legacy Kairélys uses Public API v1. No fallback crosses either capability boundary.
 
 ## Component decisions
 
 - `KEEP` — Optimike Obsidian MCP as the only MCP server.
 - `KEEP` — existing runtime modes, REST client, logger, errors, stdio/HTTP transports, write policy, and shared SQLite.
-- `KEEP` — Tasks and TaskNotes during the pilot and until a separate production cutover gate.
+- `KEEP DISABLED` — Tasks and TaskNotes only as reversible rollback assets after the completed cutover.
 - `ADD` — companion Bridge for live reads and guarded mutations.
 - `KEEP` — the legacy Kairélys/Public API v1 path only as a bounded rollback compatibility surface.
 - `ADD` — twenty-three governed Operon MCP tools, including six bounded native reads, relationship and recurrence writes, snapshot tables, durable mutation journal, and same-plan recovery.
@@ -41,7 +41,7 @@ Official Operon `2.4.0` and `2.5.0` remain supported for reads. Official Operon 
 
 ## Public API boundary
 
-`OperonPublicApiV1` remains the legacy Kairélys boundary. Official Operon `3.1.1` exposes host-verified Developer API V1 reads plus preview/apply/recovery for typed create, update, transition, relationship replacement, recurrence update, conversion, and inline relocation. Elevated or destructive applies require fresh host-owned consent in the owning vault window and fail closed after a bounded timeout. The implementation stays inside Operon and calls its existing parser/converter, creator, workflow, writer, dependency, recurrence, aggregate, archive, and conversion paths.
+`OperonPublicApiV1` remains the legacy Kairélys boundary. Official Operon `3.2.0` exposes host-verified Developer API V1 reads plus preview/apply/recovery for typed create, update, transition, relationship replacement, recurrence update, conversion, and inline relocation. Its additive task-workflow API evaluates a caller-supplied saved-filter ID after an exact grant, but does not expose the catalog. Elevated or destructive applies require fresh host-owned consent in the owning vault window and fail closed after a bounded timeout. The implementation stays inside Operon and calls its existing parser/converter, creator, workflow, writer, dependency, recurrence, aggregate, archive, and conversion paths.
 
 No ÉLYSIA-specific workflow, UX, view, calendar, Kanban, or data-model logic belongs in Operon. Compatibility fixes remain generic upstream PRs; the MCP never depends on private methods or an ÉLYSIA-specific Operon fork.
 
@@ -53,7 +53,7 @@ If live access fails, the last snapshot may be returned only as `operon-cache` w
 
 ## Mutation model
 
-Every apply requires a live Bridge, the matching official mutation surface, the Bridge mutation toggle, and `OPERON_MUTATIONS_ENABLED=true`. Existing Operon-task mutations require `expectedRevision`; legacy checkbox adoption requires an exact source path, one-based line and `expectedLine`; every request requires `idempotencyKey`; `dryRun` defaults to true. Official Operon 3.1.1 applies only the exact host-sealed preview plan and surfaces `outcome-unknown` with recovery metadata. Recovery is a separate same-plan route, never a new mutation.
+Every apply requires a live Bridge, the matching official mutation surface, the Bridge mutation toggle, and `OPERON_MUTATIONS_ENABLED=true`. Existing Operon-task mutations require `expectedRevision`; legacy checkbox adoption requires an exact source path, one-based line and `expectedLine`; every request requires `idempotencyKey`; `dryRun` defaults to true. Official Operon 3.2.0 applies only the exact host-sealed preview plan and surfaces `outcome-unknown` with recovery metadata. Recovery is a separate same-plan route, never a new mutation.
 
 The Bridge returns before/requested/after and waits for a verified idle index after apply. The MCP reserves the idempotency key durably before the Bridge call, stores the result in `operon_mutation_journal`, and blocks blind retry after an uncertain timeout/restart. The same completed key and request never call the Bridge twice, while reuse with a different request is rejected as a conflict.
 
@@ -69,16 +69,13 @@ To avoid false atomicity, update accepts exactly one group per operation: descri
 
 ## Evidence gates
 
-The disposable Operon 2.5 vault passed file/inline creation, ÉLYSIA properties, hierarchy, dependency rejection/release, status transitions, identity-preserving conversions, reindex, plugin restart, live/stale cache, idempotency, revision conflicts, and duplicate-ID P0 refusal. The patched local Operon 3.1.1 acceptance build passed host grant/identity checks, live exact reads, typed preview/apply for the validated mutation families, relationship inverse-edge verification, scoped recurrence add/change/clear, transition consent in the owning vault window, postflight, idempotent replay, exact restoration, and restart/recovery without a Markdown/private-API fallback. Stock 3.1.1 retains the upstream limitations linked from the Operon MCP contract.
+The disposable Operon 2.5 vault remains historical evidence for the legacy Public API path. The local Operon 3.2.0 acceptance build passed host grant/identity checks, live exact reads, saved-filter execution with opaque pagination, typed preview/apply for the validated mutation families, relationship inverse-edge verification, scoped recurrence add/change/clear, postflight, idempotent replay, exact restoration, and restart/recovery without a Markdown/private-API fallback. The build differs from the release only by the settings-renderer fix that restores Developer API grant controls.
 
-Still required before production cutover:
+Still outside this local acceptance proof:
 
 - actual Sync topology test;
-- reconstruction of Now, Inbox, Étoile du Nord, and Audit views;
-- bounded real-project usability pilot;
-- upstream/fork maintenance decision;
-- explicit Mike approval for production plugin installation and mutation enablement;
-- separate migration/rollback approval.
+- upstream review of the settings-renderer patch and remaining #99/#101/#139 paths;
+- separate Kairélys non-dependency/removal decision.
 
 ## Security and licensing
 

--- a/docs/obsidian_mcp_tools_spec.md
+++ b/docs/obsidian_mcp_tools_spec.md
@@ -93,7 +93,7 @@ The authoritative English guarantees and compatibility matrix are in the
 - `operon_query_tasks`: filter by task IDs, stable pipeline/status IDs, visible workflow labels, text, source, checkbox, priority,
   tier, paths, tags, parents, dates, canonical/custom fields, or unmanaged file-task
   properties.
-- `operon_query_saved_filter`: evaluate one saved filter only when the live engine advertises the native capability; official Operon 3.1.1 currently returns a structured unavailable result, while compatible legacy engines may implement it.
+- `operon_query_saved_filter`: evaluate one saved filter only when the live engine advertises the native capability; official Operon 3.2.0 supports execution through `tasks.filter-query` after an exact grant, but callers must supply the exact ID because the official API does not expose the saved-filter catalog.
 - `operon_validate`: live duplicate/source/workflow graph validation, or a limited
   snapshot-only validation with explicit caveats.
 - `operon_get_diagnostics`: native Developer API lifecycle, persistence, grant, catalog, capability, and transport diagnostics.
@@ -102,7 +102,7 @@ The authoritative English guarantees and compatibility matrix are in the
 - `operon_get_relationships`: bounded explicit, derived, and inferred relationship graph for one stable task.
 - `operon_build_context`: bounded exact-task, neighborhood, project, planning, or creation context with a strict hydration allowlist.
 - `operon_get_timer_state`: read active and transitioning timer state without exposing timer control.
-- `operon_adopt_task`: upgrade one exact legacy checkbox only when the loaded engine advertises adoption; official Operon 3.1.1 currently returns a structured unavailable result.
+- `operon_adopt_task`: upgrade one exact legacy checkbox only when the loaded engine advertises adoption; official Operon 3.2.0 currently returns a structured unavailable result.
 - `operon_create_task`: create inline/file tasks through the loaded engine's official Developer API V1 or bounded legacy Public API v1 surface.
 - `operon_update_task`: update one mutation group with expected revision.
 - `operon_transition_task`: apply a stable status-ID or exact workflow transition through Operon's guards when the live Developer API advertises the capability; the Bridge bounds uncertain stock-runtime applies and never retries blindly.
@@ -117,18 +117,16 @@ Operon responses always declare `source`, `stale`, `snapshotAt`, `snapshotAgeMs`
 Operon/Bridge versions, capabilities, and limitations.
 
 Mutations require a live Bridge and the loaded engine's official contract.
-Operon 3.1.1 uses Developer API V1 typed preview/apply/recovery; legacy
+Operon 3.2.0 uses Developer API V1 typed preview/apply/recovery; legacy
 Kairélys uses Public API v1. Dry-run is the default, idempotency is mandatory,
 existing tasks require `expectedRevision`, and there is no direct Markdown
 fallback.
 
-The complete acceptance evidence uses the patched local Operon build while
-upstream PRs [#135](https://github.com/hasanyilmaz/operon/pull/135),
-[#137](https://github.com/hasanyilmaz/operon/pull/137), and
-[#139](https://github.com/hasanyilmaz/operon/pull/139) are under review. Stock
-3.1.1 remains supported for reads and most mutations, but the documented
-frontmatter-settlement, multi-window-consent, and File Task rename limitations
-remain fail-closed; no private or Markdown fallback is introduced.
+The complete 3.2.0 acceptance evidence uses a local build carrying only the
+Developer API settings-renderer fix. Frontmatter settlement and multi-window
+consent from #135/#137 are already merged; File Task rename safety remains in
+[#139](https://github.com/hasanyilmaz/operon/pull/139). Unsupported paths remain
+fail-closed; no private or Markdown fallback is introduced.
 
 ## Semantic Search
 

--- a/docs/operon-cli-audit.fr.md
+++ b/docs/operon-cli-audit.fr.md
@@ -2,18 +2,20 @@
 
 English version: [operon-cli-audit.md](operon-cli-audit.md)
 
-Date : 2026-08-08
+Date : 2026-08-09
 
-Référence : Operon officiel `3.1.1`, Operon CLI `1.0.9`, Developer API V1 et
+Référence : Operon officiel `3.2.1`, Operon CLI `1.1.0`, Developer API V1 et
 `cli-manifest-v1.json`.
 
 Les observations CLI initiales du 1er août 2026 utilisaient Operon `3.0.1` et
-restent des preuves historiques. L’adaptateur MCP cible `3.1.1`. La preuve
-d’acceptation complète utilise le build local corrigé pendant la review des PR
-upstream #135, #137 et #139. La version officielle reste utilisable pour les
-lectures et la plupart des mutations gouvernées. Le cas de transition incertain
-est suivi dans #99/#101. Le MCP échoue fermé et ne bascule jamais vers Markdown
-ou une API privée.
+restent des preuves historiques. L’adaptateur MCP cible `3.2.1`, tandis que le
+pilote live complet reste porté par le build local `3.2.0`, compatible au niveau
+du contrat. Le renderer manquant en 3.2.1 est suivi dans
+[#145](https://github.com/hasanyilmaz/operon/issues/145) et
+[#146](https://github.com/hasanyilmaz/operon/pull/146). Les correctifs #135 et #137 sont déjà fusionnés. La sécurité
+de renommage File Task reste suivie dans #139 et le cas de transition incertain
+dans #99/#101. Le MCP échoue fermé et ne bascule jamais vers Markdown ou une API
+privée.
 
 ## Décision
 
@@ -32,10 +34,11 @@ un agent.
 
 ## Comparaison des surfaces
 
-Le MCP enregistre vingt-trois outils gouvernés et six lectures de raisonnement
-Developer API bornées. Deux outils de compatibilité, filtres sauvegardés et
-adoption, restent indisponibles sur Operon officiel `3.1.1` tant que le runtime
-n’annonce pas les capacités natives :
+Le MCP enregistre vingt-trois outils gouvernés, dont six lectures de raisonnement
+Developer API bornées. L’exécution des filtres sauvegardés fonctionne sur Operon
+`3.2.x` après un grant exact `tasks.filter-query`, mais l’API officielle ne
+publie pas leur catalogue. L’adoption reste un outil de compatibilité
+indisponible :
 
 - lectures : statut, configuration, liste/get/query, filtre sauvegardé borné par
   capacité et validation ;
@@ -71,7 +74,7 @@ avec un cas d’usage ÉLYSIA clair, une capacité officielle et des gardes prou
 
 ## Frontière de preuve actuelle
 
-Le build local corrigé Operon `3.1.1` a passé le grant et l’identité hôte, les
+Le build local Operon `3.2.0` a passé le grant et l’identité hôte, les
 lectures live, preview/apply typés, receipt/postflight, replay idempotent,
 redémarrage et récupération du même plan. Le pilote Bridge a aussi passé
 création, update, transition, conflit de révision et replay.
@@ -80,13 +83,12 @@ Les relations et la récurrence ont passé les suites adaptateur, contrat Bridge
 service, policy, idempotence/redémarrage et documentation, puis leur pilote live
 dédié : dry-run/apply, relation inverse, replay, conflit périmé, blocage de
 transition terminale, restauration exacte, ajout/changement de portée/retrait de
-récurrence, redémarrage stable, source live, aucun résidu et
-`P0/P1/P2 = 0/0/0`.
+récurrence, redémarrage stable, exécution d’un filtre avec pagination opaque,
+source live, 25 tâches après nettoyage, aucun résidu et `P0/P1/P2 = 0/0/0`.
 
-La version officielle non corrigée peut encore produire le résultat borné
-`outcome-unknown` du chemin #99/#101. Les limites frontmatter/date,
-multi-fenêtres et File Task sont suivies dans #135, #137 et #139. Le Bridge
-expose l’incertitude et ne rejoue pas la mutation.
+Le chemin #99/#101 peut encore produire un résultat borné `outcome-unknown`.
+La limite File Task reste suivie dans #139. Le Bridge expose l’incertitude et ne
+rejoue pas la mutation.
 
 Les autres écritures avancées restent hors MCP jusqu’à disposer chacune d’un
 contrat preview/apply, révision, postflight, récupération et confirmation
@@ -101,7 +103,8 @@ setup, profil, doctor offline, `health`, `task.get`, `tasks.query` et
 Sur cette version, plusieurs handlers pourtant annoncés par `health` échouaient
 avant leur exécution avec `obsidian-cli-exit-failed` ou
 `persistent-write-failed`. Cette preuve reste historique et ne doit pas être
-présentée comme l’état de la CLI `1.0.9`.
+présentée comme l’état de la CLI `1.1.0`, dont la version installable a seulement
+été vérifiée dans cette mise à jour.
 
 La conclusion d’architecture ne change pas : la CLI est la surface opérateur
 large. Le MCP/Bridge reste le contrat agentique indépendant, borné et vérifiable.

--- a/docs/operon-cli-audit.md
+++ b/docs/operon-cli-audit.md
@@ -2,17 +2,17 @@
 
 French version: [operon-cli-audit.fr.md](operon-cli-audit.fr.md)
 
-Date: 2026-08-08
-Reference: official Operon `3.1.1`, Operon CLI `1.0.9`, Developer API V1 and `cli-manifest-v1.json`.
+Date: 2026-08-09
+Reference: official Operon `3.2.1`, Operon CLI `1.1.0`, Developer API V1 and `cli-manifest-v1.json`.
 
 The original 2026-08-01 CLI observations were made against Operon `3.0.1` and
-remain historical evidence. The current MCP adapter targets `3.1.1`; its full
-acceptance proof uses the patched local Operon build while upstream fixes are
-under review in [#135](https://github.com/hasanyilmaz/operon/pull/135),
-[#137](https://github.com/hasanyilmaz/operon/pull/137), and
-[#139](https://github.com/hasanyilmaz/operon/pull/139). Stock `3.1.1` remains
-the supported production target for reads and most governed mutations, with
-uncertain transition settlement tracked by [#99](https://github.com/hasanyilmaz/operon/issues/99)
+remain historical evidence. The current MCP adapter targets `3.2.1` while the
+complete live acceptance evidence remains on the contract-compatible local
+`3.2.0` build. The missing 3.2.1 settings renderer is tracked in
+[#145](https://github.com/hasanyilmaz/operon/issues/145) and
+[#146](https://github.com/hasanyilmaz/operon/pull/146). Fixes #135 and #137 are already merged. File Task rename safety
+remains tracked in [#139](https://github.com/hasanyilmaz/operon/pull/139), and
+uncertain transition settlement in [#99](https://github.com/hasanyilmaz/operon/issues/99)
 and [#101](https://github.com/hasanyilmaz/operon/pull/101). The MCP remains
 fail-closed and does not fall back to Markdown or private APIs.
 
@@ -30,10 +30,10 @@ Do not expose a generic CLI passthrough through MCP.
 
 ## Surface comparison
 
-The MCP registers twenty-three governed tools plus six bounded Developer API
-reasoning reads. Two compatibility tools, saved-filter evaluation and adoption,
-remain unavailable on official Operon `3.1.1` until the runtime advertises the
-native capabilities:
+The MCP registers twenty-three governed tools, including six bounded Developer
+API reasoning reads. Saved-filter execution is available on Operon `3.2.x`
+after an exact `tasks.filter-query` grant, but the official API does not expose
+the saved-filter catalog. Adoption remains an unavailable compatibility tool:
 
 - reads: status, configuration, list/get/query, capability-gated saved filters, validation;
 - native reasoning reads: diagnostics, finder, resolve, relationships, context,
@@ -74,7 +74,7 @@ operation with a clear ÉLYSIA use case and a matching proof/guard.
 
 ## Current proof boundary
 
-Official Operon `3.1.1` native Developer API acceptance on the patched local
+Official Operon `3.2.0` native Developer API acceptance on the local
 build passed host grant and identity checks, live reads, typed preview/apply,
 receipt/postflight, idempotent replay, restart, and same-plan recovery. The
 production Bridge pilot also passed live read, typed create/update/transition
@@ -82,18 +82,18 @@ preview/apply, replay, and stale revision conflict.
 
 The relationship and recurrence extensions pass the adapter, Bridge contract,
 service, policy, idempotency/restart and documentation suites. Their dedicated
-live Operon `3.1.1` acceptance also passed on the patched local build:
+live Operon `3.2.0` acceptance also passed on the local build:
 relationship dry-run/apply, inverse-edge verification, idempotent replay,
 stale-revision conflict, blocked terminal transition, exact restoration,
-recurrence add/scope-change/clear, restart/recovery stability, live source, no
-residual relationship/recurrence state, and `P0/P1/P2 = 0/0/0`.
+recurrence add/scope-change/clear, restart/recovery stability, saved-filter
+execution with opaque pagination, live source, 25 tasks after fixture cleanup,
+no residual relationship/recurrence state, and `P0/P1/P2 = 0/0/0`.
 
-Stock `3.1.1` may still return the bounded `outcome-unknown` transition result
+The remaining official transition edge may still return the bounded `outcome-unknown` result
 tracked by [Operon #99](https://github.com/hasanyilmaz/operon/issues/99) and
-[#101](https://github.com/hasanyilmaz/operon/pull/101). The patched local build
-passes the terminal/recovery proof; when the stock runtime cannot prove its
-result, the Bridge reports the uncertainty and does not retry or fall back to
-Markdown/private APIs. This remains a capability gate, not a hidden bypass.
+[#101](https://github.com/hasanyilmaz/operon/pull/101). When the runtime cannot
+prove its result, the Bridge reports the uncertainty and does not retry or fall
+back to Markdown/private APIs. This remains a capability gate, not a hidden bypass.
 
 The read audit, implementation and live acceptance of the two useful advanced
 writes are complete. Other advanced writes remain outside MCP until each has a
@@ -119,8 +119,9 @@ capabilities as available, while the CLI invocation itself is not reliable for
 them on this pilot. `tasks.query` also emitted strict-V1 warnings for malformed
 datetime metadata, omitting those fields rather than failing the whole query.
 
-Conclusion: the CLI is a broader operator surface, but it is not a dependable
-transport layer for MCP on this Windows installation. Keep the MCP/Bridge
-contract independent and bounded; keep the CLI for operator diagnostics,
-native acceptance and recovery investigation until Operon fixes the affected
-Windows handlers. No real mutation was applied during this audit.
+Conclusion: the CLI is a broader operator surface, but it was not a dependable
+transport layer for MCP on that historical Windows installation. The current
+package version is `1.1.0`, but this update does not claim every former handler
+failure was requalified through the CLI. Keep the MCP/Bridge contract independent
+and bounded; keep the CLI for operator diagnostics, native acceptance and
+recovery investigation. No real mutation was applied during the historical audit.

--- a/docs/operon-decision-report.md
+++ b/docs/operon-decision-report.md
@@ -1,22 +1,19 @@
 # Operon integration decision report
 
-## Current status — 2026-08-08
+## Current status — 2026-08-09
 
-Optimike Obsidian MCP `main` targets official Operon `3.1.1` through Bridge
-`0.5.1` and Developer API V1. The canonical server registers twenty-three
+Optimike Obsidian MCP targets official Operon `3.2.1` through Bridge `0.6.0`
+and Developer API V1. The canonical server registers twenty-three
 governed Operon tools. Kairélys remains disabled and retained only for bounded
 rollback compatibility.
 
-The complete local acceptance run is green on the patched Operon `3.1.1`
-build. Stock `3.1.1` remains supported for reads and most governed mutations,
-with fail-closed limitations tracked in:
+The complete local acceptance run is green on a contract-compatible Operon `3.2.0` build carrying
+only the settings-renderer fix that restores Developer API grant controls. The
+equivalent 3.2.1 fix is tracked in upstream #145/#146. Remaining fail-closed
+limitations are tracked in:
 
 - transition settlement: [#99](https://github.com/hasanyilmaz/operon/issues/99)
   and [#101](https://github.com/hasanyilmaz/operon/pull/101);
-- modified-time frontmatter settlement:
-  [#135](https://github.com/hasanyilmaz/operon/pull/135);
-- consent across multiple Obsidian windows:
-  [#137](https://github.com/hasanyilmaz/operon/pull/137);
 - implicit File Task description/rename behavior:
   [#139](https://github.com/hasanyilmaz/operon/pull/139).
 
@@ -25,14 +22,14 @@ commands when a capability is missing or an outcome is uncertain.
 
 ## Implemented surface
 
-- official Operon `3.1.1` Developer API V1 adapter;
+- official Operon `3.2.0` Developer API V1 adapter;
 - Bridge status/configuration/list/get/query/validate and complete pagination;
 - six bounded native reasoning reads: diagnostics, finder, entity resolution,
   relationships, context and timer state;
 - governed create, update, transition, relationship replacement, recurrence,
   conversion and inline relocation;
-- registered compatibility tools for adoption and saved-filter evaluation,
-  returning unavailable on official `3.1.1` until native capabilities exist;
+- saved-filter execution through `tasks.filter-query` after an exact grant and
+  caller-supplied filter ID; adoption remains an unavailable compatibility tool;
 - durable pending-recovery listing and exact-plan recovery;
 - dry-run by default, live `expectedRevision`, durable idempotency and postflight;
 - SQLite live/stale snapshots and mutation journal;
@@ -52,12 +49,13 @@ delete, reminders, pinned state and timer control/session.
 CLI availability alone is not sufficient to expose a function to agents. A
 generic passthrough would bypass the Bridge contract and hide capability drift.
 
-## Operon 3.1.1 acceptance evidence
+## Operon 3.2.0 acceptance evidence
 
 The patched local acceptance build passed:
 
 - host-owned grant and consumer identity checks;
 - live configuration, exact reads and coherent 25-task inventory;
+- native saved-filter execution with opaque pagination;
 - typed preview/apply, postflight and receipt evidence;
 - stale-revision conflict and idempotent replay without a second write;
 - transition and same-plan recovery after restart;
@@ -69,9 +67,8 @@ The patched local acceptance build passed:
 - restart with live source, no residual relationship or recurrence state, no
   pending recovery and `P0/P1/P2 = 0/0/0`.
 
-The MCP repository passed `check:operon`, Bridge typecheck/build and tests,
-contract/service tests, tool-annotation checks, documentation checks and the
-Linux/Windows GitHub CI matrix.
+The MCP repository passed its full local Operon, runtime, profile, annotation,
+documentation and package checks. Remote CI is a separate publication gate.
 
 ## Historical evidence
 
@@ -82,15 +79,16 @@ idempotency, stale-revision conflict, reindex/restart, stale cache and duplicate
 ID refusal. It is not presented as Developer API V1 evidence.
 
 The 2026-08-01 Operon `3.0.1` cutover and CLI `1.0.0` Windows observations also
-remain historical. Current targets are Operon `3.1.1` and CLI `1.0.9`.
+remain historical. Current targets are Operon `3.2.0` and CLI `1.1.0`.
 
 ## Deliberately excluded or unavailable
 
 - deletion: CLI operator action until a reversible `operon_trash_task` contract
   exists;
 - reminders, pinned state and timer control/session: retained in the CLI;
-- adoption and saved filters: tools remain registered for compatibility but the
-  official `3.1.1` Developer API does not expose their native capabilities;
+- adoption remains unavailable in the official Developer API;
+- saved-filter execution is available with an exact ID and grant, while catalog
+  discovery and filter creation/editing remain unavailable;
 - generic CLI execution: rejected;
 - actual multi-device Sync topology: not run by this local acceptance pilot.
 
@@ -100,5 +98,6 @@ Keep the current Operon integration active. Use MCP/Bridge for governed agent
 workflows and CLI for broad operator work. Keep Kairélys disabled but available
 for rollback until a separate non-dependency proof authorizes removal.
 
-The code and local acceptance work are complete. Remaining work is upstream
-review/release monitoring and the separate real Sync/non-dependency decision.
+The code and local acceptance work are complete. Remaining work is reviewing
+and publishing the prepared MCP and Operon settings patches under separate
+authorization, plus the separate real Sync/non-dependency decision.

--- a/docs/operon-local-validation.md
+++ b/docs/operon-local-validation.md
@@ -7,19 +7,17 @@ This recipe is the Desktop proof. Run destructive fixtures only in a disposable 
 - Node.js `>=22.7.5`
 - Obsidian Desktop
 - Local REST API enabled
-- Operon `3.1.1` enabled for the official Developer API V1 pilot; `2.4.0` / `2.5.0` remain legacy-read fixtures
+- Operon `3.2.1` enabled for current compatibility checks; `3.2.0` remains the complete live-pilot baseline and `2.4.0` / `2.5.0` remain legacy-read fixtures
 - Optimike Operon Bridge built from this branch
 - Optimike Obsidian MCP built from this branch
 - a backup or disposable vault
 
-The adapter targets official Operon `3.1.1`. The complete acceptance evidence
-listed below uses the patched local Operon build while upstream fixes are under
-review in [#135](https://github.com/hasanyilmaz/operon/pull/135),
-[#137](https://github.com/hasanyilmaz/operon/pull/137), and
-[#139](https://github.com/hasanyilmaz/operon/pull/139). Stock `3.1.1` remains
-usable for reads and most governed mutations, but unsupported or uncertain
-settlement is fail-closed; this recipe never authorizes a Markdown/private-API
-fallback or a blind retry.
+The adapter targets official Operon `3.2.1`; the complete live acceptance run
+used the contract-compatible local `3.2.0` build. The missing 3.2.1 grant-control
+renderer is tracked in upstream #145/#146. Fixes #135 and #137 are already merged. File Task rename safety remains
+tracked by [#139](https://github.com/hasanyilmaz/operon/pull/139), and transition
+settlement by #99/#101. Unsupported or uncertain paths stay fail-closed; this
+recipe never authorizes a Markdown/private-API fallback or a blind retry.
 
 ## 1. Automated checks
 
@@ -78,7 +76,7 @@ PASS when:
 - index generation is greater than zero;
 - diagnostics report `health=healthy`, `runtimePhase=idle`,
   `verifiedThisSession=true`, and `dirtySourceCount=0`;
-- official Operon `3.1.1` reports the exact grant and typed Developer API
+- official Operon `3.2.0` reports the exact grants and typed Developer APIs
   surface; the Bridge advertises only the mutation capabilities that the live
   runtime proves, and bounds uncertain applies without a blind retry;
 - `adopt` remains false on official Operon; legacy Kairélys/Public API probes
@@ -188,8 +186,9 @@ operon_recover_mutation
 PASS when:
 
 - all twenty-three tools are registered;
-- official Operon `3.1.1` returns structured unavailable results for adoption
-  and saved-filter evaluation until it advertises those native capabilities;
+- official Operon `3.2.0` returns a structured unavailable result for adoption;
+- saved-filter execution succeeds only after an exact `tasks.filter-query`
+  grant and caller-supplied filter ID; the official catalog remains unavailable;
 - the first complete call creates a snapshot;
 - subsequent calls with unchanged generation do not rewrite the full snapshot;
 - responses say `source=operon-live`, `stale=false`.
@@ -216,7 +215,7 @@ PASS: same task identities and values; revisions change only when normalized tas
 
 PASS: live source, exact inverse edges, scoped recurrence state, idempotent replay, stale-revision conflict, exact restoration, and `P0/P1/P2 = 0/0/0`.
 
-Executed result on 2026-08-08 with the patched local Operon `3.1.1`
+Executed result refreshed on 2026-08-09 with the local Operon `3.2.0`
 acceptance build:
 
 - relationship dry-run/apply passed on `oo96ct2` and `1dbefy1`;
@@ -247,7 +246,7 @@ FAIL if cached data is presented as live.
 ## 11. Incompatibility test
 
 Disable Operon or use any test manifest version outside the explicit allowlist
-(`2.4.0`, `2.5.0`, and official `3.1.1`).
+(`2.4.0`, `2.5.0`, `3.0.1`, `3.1.0`, `3.1.1`, and official `3.2.0`).
 
 PASS:
 
@@ -288,10 +287,11 @@ Review Local REST routes, MCP tools, and the loaded Operon capability probe.
 PASS:
 
 - official Operon without an active Developer API V1 grant remains read-only;
-- official Operon 3.1.1 exposes typed create/update/transition/convert/relocate
+- official Operon 3.2.0 exposes typed create/update/transition/relationship/recurrence/convert/relocate
   only after the grant; an uncertain transition apply is bounded by the Bridge,
   while `adopt`, unmanaged properties, and arbitrary
-  `targetFolder` remain explicitly unsupported;
+  `targetFolder` remain explicitly unsupported; saved-filter execution is
+  available after an exact grant and caller-supplied ID, without catalog listing;
 - the minimal Operon fork exposes native saved-filter queries plus adopt/create/update/transition/convert/relocate through its versioned Public API;
 - dry-run is the default;
 - apply requires live capabilities and an idempotency key;
@@ -305,7 +305,7 @@ PASS:
 Run `scripts/smoke-operon-mutations.mjs` in guarded mode, then
 `scripts/smoke-operon-rich-mutations.mjs` in full mode against a disposable
 vault when validating the legacy Kairélys/Public API path. For official
-Operon 3.1.1 use section 16; do not expect unmanaged properties or arbitrary
+Operon 3.2.0 use section 18; do not expect unmanaged properties or arbitrary
 `targetFolder` values to map to Developer API V1.
 
 PASS:
@@ -367,6 +367,40 @@ LIMITATION:
   in upstream [#135](https://github.com/hasanyilmaz/operon/pull/135),
   [#137](https://github.com/hasanyilmaz/operon/pull/137), and
   [#139](https://github.com/hasanyilmaz/operon/pull/139).
+
+## 18. Official Operon 3.2.0 Bridge/MCP acceptance — 2026-08-09
+
+The production-shaped ÉLYSIA pilot used Operon `3.2.0`, CLI `1.1.0`, Bridge
+`0.6.0`, both mutation opt-ins, and the official Developer APIs. The local
+Operon build included only the settings-renderer fix required to display grant
+controls.
+
+PASS:
+
+- live `operon-live` source, 25 tasks, compatible 3.2.0/0.6.0 runtime;
+- all intended capabilities true except adoption;
+- exact `tasks.filter-query` grant and saved-filter execution with opaque
+  pagination; catalog discovery correctly remains unavailable;
+- live `fs_elysia_now` replay returned 11 results, two three-item pages without
+  overlap, and remained available during concurrent status/query refreshes;
+- service regression coverage preserves Bridge `404` and `422` filter failures
+  as `NOT_FOUND` and `VALIDATION_ERROR` instead of `INTERNAL_ERROR`;
+- relationship preview/apply, inverse edge, idempotent replay, blocked terminal
+  transition and exact restoration;
+- recurrence create/change/clear with explicit scopes and normalized postflight;
+- temporary recurrence fixture backed up, removed through the operator CLI, and
+  verified absent from disk and index;
+- Obsidian and MCP backend restart, no pending recovery, no residual relation or
+  recurrence, and final `P0/P1/P2 = 0/0/0`.
+
+OPEN BOUNDARIES:
+
+- adoption is not exposed by the official Developer API;
+- saved-filter IDs must come from Operon's UI/configuration or an operator
+  workflow because the official API does not list the catalog;
+- #99/#101 and #139 remain fail-closed paths;
+- no deletion tool, generic CLI passthrough, raw Markdown or private API exists
+  in the MCP.
 
 ## Executed pilot result — 2026-07-21
 

--- a/docs/operon-mcp-contract.fr.md
+++ b/docs/operon-mcp-contract.fr.md
@@ -75,10 +75,11 @@ Un payload invalide, une pagination tronquée, une génération instable, des ID
 dupliqués, une version incompatible, un index non prêt ou une validation P0
 n’écrasent jamais le dernier snapshot sain.
 
-`operon_query_saved_filter` est live-only et dépend d’une capacité native. La
-version officielle Operon `3.1.1` ne l’annonce pas actuellement : l’outil reste
-enregistré pour compatibilité mais renvoie une indisponibilité structurée. Le
-MCP ne tente pas de reproduire le moteur de filtres depuis le cache.
+`operon_query_saved_filter` est live-only et dépend d’une capacité native. Sur
+Operon officiel `3.2.0`, il utilise la Developer API task-workflow après un grant
+exact `tasks.filter-query`. L’appelant doit fournir un `filterSetId` exact :
+l’API officielle exécute les filtres mais n’en publie pas le catalogue. Le MCP
+ne tente jamais de reproduire leur sémantique depuis le cache.
 
 Les six lectures Developer API supplémentaires sont également live-only :
 diagnostics, recherche classée, résolution d’entité, graphe de relations borné,
@@ -93,7 +94,7 @@ anglais ne sont pas des identifiants d’automatisation durables.
 ## Mutations
 
 Les mutations passent par les routes REST du Bridge et la surface officielle du
-moteur chargé. Operon `3.1.1` utilise les plans typés preview/apply/recovery de
+moteur chargé. Operon `3.2.0` utilise les plans typés preview/apply/recovery de
 Developer API V1. Le chemin legacy Kairélys utilise Public API v1. Aucun chemin
 ne modifie directement le Markdown, n’appelle `TaskWriter`, ne lance une
 commande UI et ne réfléchit vers une méthode privée.
@@ -104,7 +105,7 @@ Contrôles communs :
 - `idempotencyKey` est obligatoire ;
 - une tâche Operon existante exige `expectedRevision` ;
 - l’adoption legacy exige `line` et `expectedLine` exacts ;
-- Operon `3.1.1` applique uniquement le plan prévisualisé et scellé par l’hôte ;
+- Operon `3.2.0` applique uniquement le plan prévisualisé et scellé par l’hôte ;
 - `outcome-unknown` est exposé avec sa référence de récupération et n’est jamais
   rejoué à l’aveugle ;
 - après apply, le Bridge relit l’index live vérifié et le MCP rafraîchit son
@@ -133,7 +134,7 @@ L’apply exige aussi `OPERON_MUTATIONS_ENABLED=true` et le réglage Bridge
 
 `OPERON_MUTATION_ALLOWED_PATH_PREFIXES` peut limiter toutes les mutations à des
 dossiers relatifs au coffre. Les sources et destinations explicites doivent
-rester dans cette allowlist. Operon officiel `3.1.1` refuse encore un
+rester dans cette allowlist. Operon officiel `3.2.0` refuse encore un
 `targetFolder` arbitraire lorsqu’aucun contrat de destination exacte n’existe.
 
 La conversion reste destructive : file-to-inline déplace le fichier source
@@ -142,13 +143,13 @@ dans la corbeille et inline-to-file remplace la ligne source par un lien durable
 ### Règles propres aux outils
 
 `operon_adopt_task` est un outil de compatibilité enregistré, pas une capacité
-officielle d’Operon `3.1.1`. Un moteur legacy compatible peut adopter une
+officielle d’Operon `3.2.0`. Un moteur legacy compatible peut adopter une
 checkbox exacte avec verrouillage du chemin, de la ligne et du contenu source.
 Operon officiel renvoie une indisponibilité structurée et le MCP ne simule pas
 l’adoption en éditant le Markdown.
 
 `operon_create_task` crée une tâche inline ou fichier par les services officiels
-du moteur. Operon `3.1.1` accepte les champs typés, tags, `statusId`, relations,
+du moteur. Operon `3.2.0` accepte les champs typés, tags, `statusId`, relations,
 `targetPath` inline et templates configurés. Les propriétés YAML non gérées et
 les `targetFolder` arbitraires restent legacy-only.
 
@@ -190,9 +191,10 @@ Le chemin legacy Operon `2.5.0`/Kairélys a historiquement prouvé création,
 champs, relations, transitions, conversion, idempotence, conflits de révision,
 redémarrage, fallback stale et refus P0 des IDs dupliqués.
 
-Le pilote dédié Operon `3.1.1`, sur le build local corrigé, a ensuite prouvé :
+Le pilote dédié Operon `3.2.0`, sur le build local corrigé, a prouvé :
 
 - grant officiel, lecture live et plans typés preview/apply ;
+- exécution d’un filtre sauvegardé avec pagination opaque ;
 - dry-run, postflight, replay idempotent et conflit de révision périmée ;
 - relation source/inverse, blocage d’une transition terminale et restauration ;
 - ajout, changement de portée et suppression exacte d’une récurrence ;
@@ -200,17 +202,19 @@ Le pilote dédié Operon `3.1.1`, sur le build local corrigé, a ensuite prouvé
 - 25 tâches après nettoyage, aucune relation ou récurrence résiduelle ;
 - validation finale `P0/P1/P2 = 0/0/0`.
 
-La version officielle non corrigée conserve les limites upstream #99/#101,
-#135, #137 et #139. Le Bridge échoue fermé lorsque le runtime ne peut pas
-prouver le résultat.
+Le build local ne diffère de la release que par le correctif du renderer de
+réglages nécessaire pour afficher les contrôles de grant Developer API. Les
+limites upstream restantes sont #99/#101 et #139. Le Bridge échoue fermé lorsque
+le runtime ne peut pas prouver le résultat.
 
 ## Capacités indisponibles ou exclues
 
 Suppression, rappels, état épinglé, contrôle/session de timer, adoption et
 gestion des filtres sauvegardés restent hors de la surface officielle de
-mutation agentique. Les outils adoption et filtre sauvegardé restent enregistrés
-pour compatibilité mais renvoient une indisponibilité sur Operon officiel
-`3.1.1`.
+mutation agentique. L’**exécution** d’un filtre sauvegardé fonctionne sur
+Operon `3.2.0` avec un ID exact et le grant requis ; la découverte du catalogue,
+la création et l’édition des filtres ne sont pas exposées. L’adoption reste
+indisponible dans la Developer API officielle.
 
 La suppression reste une action opérateur dans la CLI. Un futur
 `operon_trash_task` ne pourra être envisagé qu’avec restauration garantie sous

--- a/docs/operon-mcp-contract.md
+++ b/docs/operon-mcp-contract.md
@@ -53,7 +53,11 @@ Every read response declares `source`, `stale`, snapshot time/age, Operon and Br
 
 SQLite cache state lives in `operon_task_snapshot` and `operon_snapshot_meta`. Malformed payloads, incomplete pagination, generation drift, duplicate IDs, incompatible versions, unready index, or P0 validation never replace the last known-good snapshot.
 
-`operon_query_saved_filter` is intentionally live-only and capability-gated. It delegates to the loaded engine's native filter evaluator and never pretends that a headless parser can reproduce plugin semantics. Official Operon `3.1.1` does not currently advertise this capability, so the registered tool returns a structured unavailable result; compatible legacy engines may provide it.
+`operon_query_saved_filter` is intentionally live-only and capability-gated. On
+official Operon `3.2.0`, it delegates to the additive task-workflow Developer
+API after an exact `tasks.filter-query` grant. The caller must supply an exact
+`filterSetId`: the official API executes saved filters but does not expose their
+catalog. Headless snapshots never attempt to reproduce plugin filter semantics.
 
 The six additional Developer API reads are also live-only. They expose native
 runtime diagnostics, ranked finder, entity resolution, bounded relationship
@@ -67,7 +71,7 @@ The cached metadata also stores the configuration used for that snapshot. Tasks 
 
 ## Mutations
 
-Mutation tools call Bridge REST routes backed by the loaded engine's official mutation surface. Operon `3.1.1` uses Developer API V1 typed preview → apply plans with host-owned recovery; legacy Kairélys versions continue to use their Public API v1 contract. No route edits Markdown, calls `TaskWriter` directly, invokes UI commands, or reflects into private methods.
+Mutation tools call Bridge REST routes backed by the loaded engine's official mutation surface. Operon `3.2.0` uses Developer API V1 typed preview → apply plans with host-owned recovery; legacy Kairélys versions continue to use their Public API v1 contract. No route edits Markdown, calls `TaskWriter` directly, invokes UI commands, or reflects into private methods.
 
 Common controls:
 
@@ -75,7 +79,7 @@ Common controls:
 - `idempotencyKey` is mandatory;
 - existing Operon tasks require `expectedRevision`;
 - legacy checkbox adoption requires an exact one-based `line` and `expectedLine` precondition;
-- Operon 3.1.1 previews and applies one exact host-sealed plan;
+- Operon 3.2.0 previews and applies one exact host-sealed plan;
 - `outcome-unknown` is surfaced with its recovery reference and never blind-retried;
 - after apply, the Bridge rereads the verified live index;
 - the MCP refreshes its SQLite snapshot;
@@ -92,27 +96,27 @@ Apply additionally requires `OPERON_MUTATIONS_ENABLED=true` and the Bridge setti
 - `MCP_WRITE_MODE=full`: conversion and recurrence apply are additionally allowed.
 - `operon_recover_mutation` also requires `MCP_WRITE_MODE=full` because it may complete an uncertain prior write; it only recovers the exact `recoveryRef` plan.
 
-`OPERON_MUTATION_ALLOWED_PATH_PREFIXES` optionally limits every Operon mutation to a comma-separated set of vault-relative folders. When configured, existing tasks must already live under one of those prefixes, and creation requires an explicit allowed destination: `targetFolder` for legacy file-task creation or `targetPath` for inline tasks. Official Operon 3.1.1 still rejects arbitrary `targetFolder` because its Developer API has no exact folder-only target contract. Scoped conversion apply is allowed in guarded mode only when the current source and explicit destination are both inside the allowlist.
+`OPERON_MUTATION_ALLOWED_PATH_PREFIXES` optionally limits every Operon mutation to a comma-separated set of vault-relative folders. When configured, existing tasks must already live under one of those prefixes, and creation requires an explicit allowed destination: `targetFolder` for legacy file-task creation or `targetPath` for inline tasks. Official Operon 3.2.0 still rejects arbitrary `targetFolder` because its Developer API has no exact folder-only target contract. Scoped conversion apply is allowed in guarded mode only when the current source and explicit destination are both inside the allowlist.
 
 Conversion remains classified as destructive because file-to-inline moves the source file to trash and inline-to-file replaces the source line with a durable link.
 
 ### Tool-specific rules
 
-`operon_adopt_task` is a registered compatibility tool, not an official Operon `3.1.1` capability. When a compatible legacy engine advertises adoption, it upgrades one existing plain Markdown or Obsidian Tasks checkbox in place. The target file, one-based line, and exact source line must still match; otherwise the operation returns `conflict` without writing. Official Operon `3.1.1` returns a structured unavailable result and the MCP does not simulate adoption with a Markdown edit.
+`operon_adopt_task` is a registered compatibility tool, not an official Operon `3.2.0` capability. When a compatible legacy engine advertises adoption, it upgrades one existing plain Markdown or Obsidian Tasks checkbox in place. The target file, one-based line, and exact source line must still match; otherwise the operation returns `conflict` without writing. Official Operon `3.2.0` returns a structured unavailable result and the MCP does not simulate adoption with a Markdown edit.
 
-`operon_create_task` creates inline or file tasks through Operon's creator services. On official Operon 3.1.1, typed fields, tags, stable `statusId`, relationships, exact inline `targetPath`, and configured/default file templates are supported. Unmanaged YAML properties and arbitrary `targetFolder` placement are legacy-only; the official Developer API path rejects them instead of using a fallback.
+`operon_create_task` creates inline or file tasks through Operon's creator services. On official Operon 3.2.0, typed fields, tags, stable `statusId`, relationships, exact inline `targetPath`, and configured/default file templates are supported. Unmanaged YAML properties and arbitrary `targetFolder` placement are legacy-only; the official Developer API path rejects them instead of using a fallback.
 
-`operon_update_task` accepts exactly one group per call: description, managed fields/tags, or one unmanaged file property. Status transitions use the dedicated tool. Unmanaged file properties are supported only by the legacy Public API path; official Operon 3.1.1 rejects them explicitly.
+`operon_update_task` accepts exactly one group per call: description, managed fields/tags, or one unmanaged file property. Status transitions use the dedicated tool. Unmanaged file properties are supported only by the legacy Public API path; official Operon 3.2.0 rejects them explicitly.
 
 `operon_set_relationships` replaces or explicitly clears `parentTask`, `blocking`, and `blockedBy`. It rejects duplicate targets, self-reference, and a target present in both dependency directions before preview. Operon seals the complete affected-resource set and performs graph/cycle validation; after apply the Bridge verifies the source and every changed inverse dependency edge.
 
 `operon_update_recurrence` changes only the official recurrence surface with an explicit `this-task` or `this-and-following` scope. `null` clears a field. Recurrence is not simulated through `operon_update_task`; apply requires full mode, and the Bridge rereads every requested normalized field after the sealed plan completes.
 
-`operon_transition_task` prefers a stable status ID from `operon_get_configuration`, while still accepting exactly one current configured workflow value for compatibility. Operon 3.1.1 transition preview/apply is available through the Bridge. Elevated transitions require fresh host-owned consent: the confirmation modal is constructed in the owning vault window and an unattended request fails closed after 45 seconds. The CLI/native official path remains an operator diagnostic surface, not a bypass; no Markdown/private fallback is introduced.
+`operon_transition_task` prefers a stable status ID from `operon_get_configuration`, while still accepting exactly one current configured workflow value for compatibility. Operon 3.2.0 transition preview/apply is available through the Bridge. Elevated transitions require fresh host-owned consent: the confirmation modal is constructed in the owning vault window and an unattended request fails closed after 45 seconds. The CLI/native official path remains an operator diagnostic surface, not a bypass; no Markdown/private fallback is introduced.
 
-`operon_convert_task` converts inline ↔ file through Operon's transition-safe paths. File-to-inline requires an explicit `targetPath`. Official Operon 3.1.1 uses its configured target/template contract and does not accept arbitrary `targetFolder`; the legacy Public API path retains scoped folder support.
+`operon_convert_task` converts inline ↔ file through Operon's transition-safe paths. File-to-inline requires an explicit `targetPath`. Official Operon 3.2.0 uses its configured target/template contract and does not accept arbitrary `targetFolder`; the legacy Public API path retains scoped folder support.
 
-`operon_relocate_task` moves an inline task to an explicit Markdown `targetPath` through Operon while preserving `operonId`. Official Operon 3.1.1 resolves a live blank destination line through `context.build`; it never guesses a line or writes the file directly. Source and target are verified after the index settles.
+`operon_relocate_task` moves an inline task to an explicit Markdown `targetPath` through Operon while preserving `operonId`. Official Operon 3.2.0 resolves a live blank destination line through `context.build`; it never guesses a line or writes the file directly. Source and target are verified after the index settles.
 
 `operon_list_pending_recoveries` lists durable official recovery references without applying anything. `operon_recover_mutation` invokes the official same-plan recovery, requires both opt-ins plus full MCP write mode, and preserves the original `planDigest`/`recoveryRef` evidence.
 
@@ -134,8 +138,23 @@ On legacy Operon `2.5.0`/Kairélys in a disposable vault, direct MCP calls histo
 
 Production activation and Tasks/TaskNotes migration remain separate manual gates.
 
-The dedicated Operon `3.1.1` pilot passed on the patched local acceptance build: relationship dry-run/apply, inverse-edge verification, idempotent replay, stale-revision conflict, blocked terminal-transition enforcement, exact restoration, recurrence add/scope-change/clear, restart/recovery stability, live source, no residual relationship/recurrence state, and `P0/P1/P2 = 0/0/0`. Stock `3.1.1` remains subject to the upstream limitations in #99/#101, #135, #137 and #139; the Bridge reports uncertainty or unavailability without retrying or falling back.
+The dedicated Operon `3.2.0` pilot passed on the local acceptance build:
+saved-filter execution with opaque pagination, relationship dry-run/apply,
+inverse-edge verification, idempotent replay, blocked terminal-transition
+enforcement, exact restoration, recurrence add/scope-change/clear,
+restart/recovery stability, live source, 25 tasks after fixture cleanup, no
+residual relationship/recurrence state, and `P0/P1/P2 = 0/0/0`. The build
+contains only the settings-renderer fix needed to expose Developer API grant
+controls. The remaining upstream limits are #99/#101 and #139; the Bridge
+reports uncertainty or unavailability without retrying or falling back.
 
 ## Deliberately unavailable or excluded capabilities
 
-Deletion, reminders, pinned state, timer control/session, adoption, and saved-filter management remain outside the official agent mutation surface. The adoption and saved-filter tools stay registered for compatibility but return unavailable on official Operon `3.1.1` until native capabilities exist. Delete remains an operator CLI action. A future `operon_trash_task` may be considered only with guaranteed restoration under the same `operonId`, reconciled relations, durable journal evidence, and an explicit human confirmation; it is not implemented.
+Deletion, reminders, pinned state, timer control/session, adoption, and
+saved-filter management remain outside the official agent mutation surface.
+Saved-filter **execution** is available on Operon `3.2.0` when the exact ID and
+grant are present; catalog discovery and filter creation/editing are not.
+Adoption remains unavailable on the official Developer API. Delete remains an
+operator CLI action. A future `operon_trash_task` may be considered only with
+guaranteed restoration under the same `operonId`, reconciled relations, durable
+journal evidence, and an explicit human confirmation; it is not implemented.

--- a/docs/operon-rest-contract.md
+++ b/docs/operon-rest-contract.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-The Bridge projects the active Operon-compatible engine's live index through Obsidian Local REST API. Reads work with official Operon `2.4.0` and `2.5.0`, with official Operon `3.1.1` through the Developer API V1, with Kairélys `2.5.1` through `2.5.3` (based on Operon `2.5.0`), and with Kairélys `2.6.1` through `2.6.3` (based on Operon `2.6.0`). Compatibility is decided by plugin ID and version together. Operon 3.1.1 mutations use the official Developer API V1 preview/apply/recovery surface; legacy Kairélys mutations use Public API v1. There is no raw Markdown or private-reflection fallback.
+The Bridge projects the active Operon-compatible engine's live index through Obsidian Local REST API. Reads work with official Operon `2.4.0` and `2.5.0`, with official Operon `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, and `3.2.1` through Developer API V1, with Kairélys `2.5.1` through `2.5.3` (based on Operon `2.5.0`), and with Kairélys `2.6.1` through `2.6.3` (based on Operon `2.6.0`). Compatibility is decided by plugin ID and version together. Operon 3.2.x mutations use the official Developer API V1 preview/apply/recovery surface; legacy Kairélys mutations use Public API v1. There is no raw Markdown or private-reflection fallback.
 
 Prefix:
 
@@ -15,18 +15,18 @@ All routes inherit Local REST API authentication and TLS behavior.
 ## Compatibility and capabilities
 
 - Bridge contract: `1`
-- Latest tested compatibility target: official Operon `3.1.1` Developer API V1 read/write pilot
+- Latest contract compatibility target: official Operon `3.2.1`; complete live read/write pilot: `3.2.0`
 - Official Operon legacy read allowlist: `2.4.0`, `2.5.0`
-- Official Operon Developer API V1 read/write pilot: `3.1.1`
+- Official Operon Developer API V1 allowlist: `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, `3.2.1`
 - Kairélys read allowlist: `2.5.1`, `2.5.2`, `2.5.3`, `2.6.1`, `2.6.2`, `2.6.3`
 - Legacy mutation contract: Operon Public API `1`
 - Official Operon `2.5.0`: read-only
-- Official Operon `3.1.1`: typed create/update/transition/relationship/recurrence/convert/relocate through Developer API V1 when the grant is active. The grant state and capability advertisement are both reported in `/status`; an uncertain apply is returned as such and is never retried blindly.
+- Official Operon `3.2.x`: typed create/update/transition/relationship/recurrence/convert/relocate through Developer API V1, plus saved-filter execution through the additive task-workflow API, when the exact grants are active. The grant state and capability advertisement are both reported in `/status`; an uncertain apply is returned as such and is never retried blindly.
 - Kairélys `2.5.1` through `2.5.3` and `2.6.1` through `2.6.3` with Public API v1: read-write
 
 `GET /status` reports `bridge.mode` as `read-only` or `read-write` and exposes each capability independently. A future Operon version is not assumed compatible merely because its Markdown looks similar.
 
-The adapter targets the official `3.1.1` contract. The complete acceptance evidence in this repository uses a patched local Operon build while upstream fixes are under review in [#135](https://github.com/hasanyilmaz/operon/pull/135), [#137](https://github.com/hasanyilmaz/operon/pull/137), and [#139](https://github.com/hasanyilmaz/operon/pull/139); the known transition investigation remains tracked by [#99](https://github.com/hasanyilmaz/operon/issues/99) and [#101](https://github.com/hasanyilmaz/operon/pull/101). Stock `3.1.1` remains usable for reads and most governed mutations, but those limitations stay fail-closed. No Markdown or private-API fallback is introduced.
+The adapter targets the official `3.2.1` contract while the complete live acceptance evidence remains on the compatible local `3.2.0` build. The missing 3.2.1 settings renderer is tracked by [#145](https://github.com/hasanyilmaz/operon/issues/145) and [#146](https://github.com/hasanyilmaz/operon/pull/146). Modified-time settlement and multi-window consent fixes from #135 and #137 are already merged. File Task rename safety remains tracked by [#139](https://github.com/hasanyilmaz/operon/pull/139), and the transition investigation by [#99](https://github.com/hasanyilmaz/operon/issues/99) and [#101](https://github.com/hasanyilmaz/operon/pull/101). Those paths stay fail-closed. No Markdown or private-API fallback is introduced.
 
 Readiness requires a compatible plugin, positive generation, healthy idle V8 index, zero dirty sources, and a task count matching diagnostics. A duplicate-ID conflict is reported separately and causes MCP snapshot refresh refusal.
 
@@ -56,9 +56,9 @@ The `revision` covers the normalized projection and source mtime. Every existing
 
 Query supports task IDs, language-stable `statusIds` / `pipelineIds`, visible status/pipeline values, text, source, checkbox, priority, tier, paths, tags, parent, ISO dates, managed-field equality, unmanaged-property equality, sorting, cursor, and limit. Agents should prefer stable workflow IDs whenever the intent is semantic rather than presentational.
 
-`GET /configuration` is the live source of task semantics. It exposes only an explicit safe subset of Operon settings: UI language; pipeline/status IDs, labels and semantic flags; priorities; canonical-to-visible key mappings; creation targets and available file-task templates; task automation rules; excluded folders; Operon Docs location; and saved filter definitions. Its deterministic `settingsSignature` is also attached to task pages. A semantic setting change therefore invalidates an in-flight read instead of being silently interpreted with stale assumptions.
+`GET /configuration` is the live source of task semantics. It exposes only an explicit safe subset of Operon settings: UI language; pipeline/status IDs, labels and semantic flags; priorities; canonical-to-visible key mappings; creation targets and available file-task templates; task automation rules; excluded folders; and Operon Docs location. Saved-filter definitions are included only when the loaded official API exposes them; Operon 3.2.0 does not. Its deterministic `settingsSignature` is also attached to task pages. A semantic setting change therefore invalidates an in-flight read instead of being silently interpreted with stale assumptions.
 
-`POST /tasks/filter` accepts a saved `filterSetId` plus optional scope and pagination. It evaluates through Operon's native filter engine and is never synthesized from the stale MCP snapshot.
+`POST /tasks/filter` accepts an exact saved `filterSetId` supplied by the caller plus optional scope and opaque pagination. It evaluates through Operon's native task-workflow filter engine after the exact `tasks.filter-query` grant and is never synthesized from the stale MCP snapshot. Operon 3.2.0 does not expose the filter catalog through the official API, so the ID must come from its UI/configuration or an operator workflow.
 
 The six native Developer API read routes return the official result inside a
 versioned `{ operation, result }` Bridge envelope. Finder is capped at 50 rows;
@@ -75,7 +75,7 @@ All mutation routes require `idempotencyKey`. The key is bound to the canonical 
 
 Every mutation destination is validated without normalization at both the MCP and Bridge boundaries. `targetPath` must be an exact vault-relative Markdown path; `targetFolder` must be an exact vault-relative folder path. Leading or trailing whitespace, backslashes, absolute paths, empty segments, trailing separators, `.` and `..` are rejected before any call to the task engine.
 
-Mutation capabilities remain false until **Allow task mutations** is explicitly enabled in Bridge settings. The MCP has a separate `OPERON_MUTATIONS_ENABLED` apply opt-in. On official Operon 3.1.1, the Bridge requests the typed mutation grant only while that setting is enabled; a pending or revoked grant remains a live `503`/read-only condition.
+Mutation capabilities remain false until **Allow task mutations** is explicitly enabled in Bridge settings. The MCP has a separate `OPERON_MUTATIONS_ENABLED` apply opt-in. On official Operon 3.2.0, the Bridge requests the typed mutation grant only while that setting is enabled; a pending or revoked grant remains a live `503`/read-only condition. The additive filter grant is requested separately so a pending filter authorization cannot hide already-approved core reads or mutations.
 
 Responses use:
 
@@ -95,7 +95,7 @@ Responses use:
 }
 ```
 
-For Operon 3.1.1, the Bridge sends the exact preview plan to `apply`; it never reconstructs or retries a plan after the host reports `outcome-unknown`. The response carries `recoveryRef`, `planDigest`, and `mutationMayHaveApplied` when recovery is required. The Bridge waits for Operon's index to return to a verified idle state before proving `after`. If the final state cannot be proven, it records `failed/outcome_unverified` and does not invite a blind retry. A Bridge apply is bounded at 120 seconds; a timeout is uncertain, not a permission to retry.
+For Operon 3.2.0, the Bridge sends the exact preview plan to `apply`; it never reconstructs or retries a plan after the host reports `outcome-unknown`. The response carries `recoveryRef`, `planDigest`, and `mutationMayHaveApplied` when recovery is required. The Bridge waits for Operon's index to return to a verified idle state before proving `after`. If the final state cannot be proven, it records `failed/outcome_unverified` and does not invite a blind retry. A Bridge apply is bounded at 120 seconds; a timeout is uncertain, not a permission to retry.
 
 ### `GET /mutations/pending-recoveries`
 
@@ -146,7 +146,7 @@ Adoption upgrades one existing checkbox in place through Operon. `line` is one-b
 }
 ```
 
-Creation uses Operon's Task Creator paths, template resolution, identity generation, indexing, dependency reconciliation, aggregates, and workflow transition logic. Official Operon 3.1.1 maps the MCP payload to its typed create plan; unmanaged properties and arbitrary `targetFolder` placement are rejected because they are not part of the official Developer API contract.
+Creation uses Operon's Task Creator paths, template resolution, identity generation, indexing, dependency reconciliation, aggregates, and workflow transition logic. Official Operon 3.2.0 maps the MCP payload to its typed create plan; unmanaged properties and arbitrary `targetFolder` placement are rejected because they are not part of the official Developer API contract.
 
 `statusId` is preferred over `fields.status`: it remains stable when a vault translates the displayed pipeline and status labels. Supplying both is rejected. `targetDateKey` is projected to the official `dateDue` field; destination selection remains governed by the configured Operon target policy. An explicit inline `targetPath` remains available for vault-specific layouts.
 
@@ -188,7 +188,7 @@ Relationship and recurrence fields are also rejected here; use their dedicated r
 
 Exactly one of stable `statusId` or the current configured `Pipeline.Status` string is required. Checkbox, terminal dates, dependencies, recurrence, aggregates, project serials, archiving, auto-unpin, and view refreshes remain Operon's responsibility.
 
-The route remains documented for the legacy Kairélys/Public API path and is also available for official Operon `3.1.1` when the live Developer API advertises it. A stock runtime that cannot produce a terminal or recoverable result is reported as unavailable/uncertain; the Bridge never retries blindly or falls back to Markdown/private APIs.
+The route remains documented for the legacy Kairélys/Public API path and is also available for official Operon `3.2.0` when the live Developer API advertises it. A stock runtime that cannot produce a terminal or recoverable result is reported as unavailable/uncertain; the Bridge never retries blindly or falls back to Markdown/private APIs.
 
 ### `POST /tasks/:operonId/relationships`
 
@@ -236,7 +236,7 @@ Scope is mandatory and must be `this-task` or `this-and-following`. Supported fi
 }
 ```
 
-Inline-to-file accepts an optional `fileTemplateId`. File-to-inline requires an explicit different Markdown `targetPath`. Conversion uses Operon's transition-safe paths; no copy/delete logic lives in the MCP. Official Operon 3.1.1 accepts configured/default template targets for inline-to-file and a configured-target/exact path for file-to-inline; arbitrary `targetFolder` is legacy-only.
+Inline-to-file accepts an optional `fileTemplateId`. File-to-inline requires an explicit different Markdown `targetPath`. Conversion uses Operon's transition-safe paths; no copy/delete logic lives in the MCP. Official Operon 3.2.0 accepts configured/default template targets for inline-to-file and a configured-target/exact path for file-to-inline; arbitrary `targetFolder` is legacy-only.
 
 ### `POST /tasks/:operonId/relocate`
 
@@ -249,7 +249,7 @@ Inline-to-file accepts an optional `fileTemplateId`. File-to-inline requires an 
 }
 ```
 
-Relocation is limited to inline tasks. The Bridge asks official Operon 3.1.1 for a live blank placement candidate, then sends the exact destination in the preview plan. Operon writes the target and removes the source through its domain operation, preserving `operonId`; the Bridge then proves the final indexed source/path before returning `applied`.
+Relocation is limited to inline tasks. The Bridge asks official Operon 3.2.0 for a live blank placement candidate, then sends the exact destination in the preview plan. Operon writes the target and removes the source through its domain operation, preserving `operonId`; the Bridge then proves the final indexed source/path before returning `applied`.
 
 ## Errors
 

--- a/docs/runtime-capability-matrix.fr.md
+++ b/docs/runtime-capability-matrix.fr.md
@@ -74,10 +74,11 @@ Tous les modes enregistrent aussi les 23 outils du contrat Operon :
 `operon_relocate_task`, `operon_list_pending_recoveries` et
 `operon_recover_mutation`. Hors mode live, ils restent limités aux snapshots
 validés en lecture seule ; toute mutation échoue fermée. L’enregistrement ne
-garantit pas la disponibilité runtime : Operon officiel `3.1.1` renvoie encore
-une indisponibilité pour les filtres sauvegardés et l’adoption. Les relations et
-la récurrence ont passé le pilote live dédié sur le build 3.1.1 corrigé. La
-version officielle conserve les limites bornées #99/#101, #135, #137 et #139.
+garantit pas la disponibilité runtime : Operon officiel `3.2.x` exécute les
+filtres sauvegardés après un grant exact `tasks.filter-query`, mais ne publie pas
+leur catalogue ; l’adoption reste indisponible. Les relations et la récurrence
+ont passé le pilote live dédié 3.2.0. Les limites bornées #99/#101 et #139
+restent ouvertes. Le renderer Settings manquant en 3.2.1 est suivi dans #145/#146.
 Voir le [contrat MCP Operon](operon-mcp-contract.fr.md) et
 l’[audit CLI/API](operon-cli-audit.fr.md).
 

--- a/docs/runtime-capability-matrix.md
+++ b/docs/runtime-capability-matrix.md
@@ -82,10 +82,11 @@ Every mode also registers the 23 Operon contract tools:
 `operon_relocate_task`, `operon_list_pending_recoveries`, and
 `operon_recover_mutation`. In non-live modes they remain limited to validated
 read-only snapshots; mutation calls fail closed. Registration does not imply
-runtime availability: official Operon `3.1.1` currently returns unavailable for
-saved-filter evaluation and adoption. Relationship and recurrence apply passed
-the dedicated patched-3.1.1 live pilot. Stock 3.1.1 retains the bounded upstream
-limits in #99/#101, #135, #137 and #139. Elevated transitions require fresh
+runtime availability: official Operon `3.2.x` exposes saved-filter evaluation
+after an exact `tasks.filter-query` grant, but not catalog discovery; adoption
+remains unavailable. Relationship and recurrence apply passed the dedicated
+3.2.0 live pilot. The bounded upstream limits in #99/#101 and #139 remain.
+The missing 3.2.1 Settings renderer is tracked in #145/#146. Elevated transitions require fresh
 confirmation in the owning Obsidian vault window; unattended consent fails
 closed after 45 seconds. See the [Operon MCP contract](operon-mcp-contract.md)
 and [CLI/API audit](operon-cli-audit.md).

--- a/plugins/obsidian-operon-bridge/README.md
+++ b/plugins/obsidian-operon-bridge/README.md
@@ -15,22 +15,24 @@ If both plugins are enabled, the Bridge refuses to choose an owner. Disable one 
 
 - Obsidian Desktop
 - Operon `2.4.0` or `2.5.0` for legacy reads
-- Operon `3.1.1` for Developer API V1 reads and governed mutations (`3.0.1` and `3.1.0` remain explicitly allowlisted)
+- Operon `3.2.1` for Developer API V1 reads and governed mutations (`3.0.1`, `3.1.0`, `3.1.1`, and `3.2.0` remain explicitly allowlisted)
 - Kairélys `2.5.1` through `2.5.3` (based on Operon `2.5.0`) and Kairélys `2.6.1` through `2.6.3`
   (based on Operon `2.6.0`) with Public API v1 for mutations
 - Obsidian Local REST API
 
-Operon `3.1.1` uses the official Developer API V1 for live reads, previews, applies, and durable recovery. Its inline task-update settlement path has been revalidated with modified-time frontmatter writes that occur during apply on the patched local acceptance build. No Markdown/private-API fallback is used. `adopt`, unmanaged properties, and arbitrary `targetFolder` destinations remain unsupported on this path and are rejected explicitly.
-
-Stock `3.1.1` remains the supported target for reads and most governed
-mutations, but the full acceptance evidence is currently carried by that local
-build while upstream fixes are reviewed in [#135](https://github.com/hasanyilmaz/operon/pull/135),
-[#137](https://github.com/hasanyilmaz/operon/pull/137), and
-[#139](https://github.com/hasanyilmaz/operon/pull/139). The known transition
-settlement issue is tracked in [#99](https://github.com/hasanyilmaz/operon/issues/99)
-and [#101](https://github.com/hasanyilmaz/operon/pull/101). Uncertain outcomes
-remain fail-closed; the Bridge never retries blindly or falls back to Markdown
-or private APIs.
+Operon `3.2.0` and `3.2.1` use the official Developer API V1 for live reads, previews,
+applies, durable recovery, and the additive `tasks.filter-query` capability.
+Saved-filter execution requires an exact grant and exact `filterSetId`; the
+official API does not expose the saved-filter catalog. Adoption, unmanaged
+properties, and arbitrary `targetFolder` destinations remain unsupported and
+are rejected explicitly. The complete live pilot used the local 3.2.0 build.
+The equivalent Settings UI fix for 3.2.1 is tracked in upstream
+[#145](https://github.com/hasanyilmaz/operon/issues/145) and
+[#146](https://github.com/hasanyilmaz/operon/pull/146). Uncertain outcomes remain fail-closed;
+the Bridge never retries blindly or falls back to Markdown/private APIs. File
+Task rename safety remains tracked in [#139](https://github.com/hasanyilmaz/operon/pull/139),
+and the transition edge in [#99](https://github.com/hasanyilmaz/operon/issues/99)
+and [#101](https://github.com/hasanyilmaz/operon/pull/101).
 
 ## Routes
 
@@ -53,11 +55,11 @@ Prefix: `/extensions/optimike-operon-bridge/v1`
 - `GET /mutations/pending-recoveries`
 - `POST /mutations/recover`
 
-All routes inherit Local REST API authentication and local TLS settings. Saved filters run through Operon's native filter evaluator. Mutations require idempotency; an idempotency key is bound to one canonical request and conflicting reuse is rejected before later payload validation. Existing-task mutations require the live revision; in-place adoption instead requires an exact one-based line plus `expectedLine`. Dry-run is the default.
+All routes inherit Local REST API authentication and local TLS settings. Saved filters run through Operon's native filter evaluator with an exact caller-supplied `filterSetId`; the official 3.2 API does not list saved filters. Mutations require idempotency; an idempotency key is bound to one canonical request and conflicting reuse is rejected before later payload validation. Existing-task mutations require the live revision; in-place adoption instead requires an exact one-based line plus `expectedLine` on engines that advertise it. Dry-run is the default.
 
 Mutation paths are strict, exact vault-relative paths. The MCP and Bridge reject leading or trailing whitespace, backslashes, absolute paths, empty segments, traversal, and non-Markdown `targetPath` values; they never trim or rewrite an invalid destination into a valid one.
 
-Mutation apply is disabled by default. Operon 3.1.1 mutation routes are advertised only when the Bridge setting is enabled, the official grant exposes the matching preview/apply capabilities, and the MCP runtime has the separate `OPERON_MUTATIONS_ENABLED` opt-in. Relationship apply rereads the source and inverse dependency edges; recurrence uses the official scoped recurrence plan and never passes through the generic update route.
+Mutation apply is disabled by default. Operon 3.2.x mutation routes are advertised only when the Bridge setting is enabled, the official grant exposes the matching preview/apply capabilities, and the MCP runtime has the separate `OPERON_MUTATIONS_ENABLED` opt-in. Relationship apply rereads the source and inverse dependency edges; recurrence uses the official scoped recurrence plan and never passes through the generic update route.
 
 ## Build
 

--- a/plugins/obsidian-operon-bridge/manifest.json
+++ b/plugins/obsidian-operon-bridge/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "optimike-operon-bridge",
   "name": "Optimike Kairélys / Operon Bridge",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "minAppVersion": "1.7.2",
   "description": "Versioned Local REST API bridge from Kairélys or Operon's live task engine to Optimike Obsidian MCP.",
   "author": "Optimike",

--- a/plugins/obsidian-operon-bridge/package-lock.json
+++ b/plugins/obsidian-operon-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optimike-operon-bridge",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optimike-operon-bridge",
-      "version": "0.5.1",
+      "version": "0.6.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "esbuild": "^0.25.0",

--- a/plugins/obsidian-operon-bridge/package.json
+++ b/plugins/obsidian-operon-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optimike-operon-bridge",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/obsidian-operon-bridge/src/contract.test.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.test.ts
@@ -206,13 +206,23 @@ test("version compatibility is an explicit tested-version allowlist", () => {
 });
 
 test("official Developer API versions remain explicit and only unverified mutations stay fail-closed", () => {
-	assert.deepEqual(OPERON_BRIDGE_DEVELOPER_API_VERSIONS, ["3.0.1", "3.1.0", "3.1.1"]);
+	assert.deepEqual(OPERON_BRIDGE_DEVELOPER_API_VERSIONS, [
+		"3.0.1",
+		"3.1.0",
+		"3.1.1",
+		"3.2.0",
+		"3.2.1",
+	]);
 	assert.equal(isDeveloperApiVersion("3.0.1"), true);
 	assert.equal(isDeveloperApiVersion("3.1.0"), true);
 	assert.equal(isDeveloperApiVersion("3.1.1"), true);
+	assert.equal(isDeveloperApiVersion("3.2.0"), true);
+	assert.equal(isDeveloperApiVersion("3.2.1"), true);
 	assert.deepEqual(OPERON_BRIDGE_BLOCKED_MUTATIONS["3.0.1"], ["transition"]);
 	assert.deepEqual(OPERON_BRIDGE_BLOCKED_MUTATIONS["3.1.0"], []);
 	assert.deepEqual(OPERON_BRIDGE_BLOCKED_MUTATIONS["3.1.1"], []);
+	assert.deepEqual(OPERON_BRIDGE_BLOCKED_MUTATIONS["3.2.0"], []);
+	assert.deepEqual(OPERON_BRIDGE_BLOCKED_MUTATIONS["3.2.1"], []);
 });
 
 test("mutation paths are rejected instead of normalized at the Bridge boundary", () => {

--- a/plugins/obsidian-operon-bridge/src/contract.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.ts
@@ -1,8 +1,10 @@
 export const OPERON_BRIDGE_CONTRACT_VERSION = "1" as const;
-export const OPERON_BRIDGE_TESTED_VERSION = "3.1.1" as const;
+export const OPERON_BRIDGE_TESTED_VERSION = "3.2.1" as const;
 export const OPERON_BRIDGE_DEVELOPER_API_VERSIONS = [
 	"3.0.1",
 	"3.1.0",
+	"3.1.1",
+	"3.2.0",
 	OPERON_BRIDGE_TESTED_VERSION,
 ] as const;
 export const OPERON_BRIDGE_SUPPORTED_VERSIONS = {
@@ -18,6 +20,8 @@ export const OPERON_BRIDGE_BLOCKED_MUTATIONS = {
 	"3.0.1": ["transition"],
 	"3.1.0": [],
 	"3.1.1": [],
+	"3.2.0": [],
+	"3.2.1": [],
 } as const;
 
 export function isDeveloperApiVersion(version: string): boolean {

--- a/plugins/obsidian-operon-bridge/src/developer-api-adapter.test.ts
+++ b/plugins/obsidian-operon-bridge/src/developer-api-adapter.test.ts
@@ -6,7 +6,7 @@ const consumer = {
   manifest: {
     id: "optimike-operon-bridge",
     name: "Optimike Operon Bridge",
-    version: "0.5.0",
+    version: "0.6.0",
   },
 };
 
@@ -138,6 +138,191 @@ test("Operon 3 Developer API adapter reads a live task snapshot through the offi
     (await adapter.indexer.getIndexV8Diagnostics()).health,
     "healthy",
   );
+});
+
+test("Operon 3.2 adapter evaluates saved filters through the additive task-workflow Developer API", async () => {
+  let filterRequest: Record<string, unknown> = {};
+  const api = {
+    hasCapability: (name: string) =>
+      [
+        "system.health",
+        "system.capabilities",
+        "catalog.read",
+        "tasks.read",
+        "tasks.query",
+      ].includes(name),
+    channel: { status: readyStatus },
+    system: {
+      health: async () => ({
+        ok: true,
+        contextRevision: { index: { ramGeneration: 32 } },
+      }),
+      capabilities: () => [],
+      diagnostics: async () => ({ ok: true }),
+    },
+    catalog: {
+      snapshot: async () => ({
+        ok: true,
+        settingsFingerprint: "settings-32",
+        taxonomy: { pipelines: [], priorities: [] },
+        fields: [],
+        filters: [
+          {
+            id: "filter-now",
+            name: "Maintenant",
+            icon: "zap",
+            root: { type: "group", children: [] },
+          },
+        ],
+        policies: { creation: {} },
+      }),
+    },
+    tasks: {
+      query: async () => ({
+        ok: true,
+        tasks: [],
+        page: { truncated: false },
+        contextRevision: { index: { ramGeneration: 32 } },
+      }),
+    },
+  };
+  const operon = {
+    getDeveloperApiV1: () => ({ ok: true, status: readyStatus(), api }),
+    getTaskWorkflowDeveloperApiV1: (
+      _candidate: unknown,
+      request: { requestedCapabilities: readonly string[] },
+    ) => ({
+      ok: request.requestedCapabilities[0] === "tasks.filter-query",
+      api: {
+        tasks: {
+          filterQuery: async (input: Record<string, unknown>) => {
+            filterRequest = input;
+            return {
+              ok: true,
+              tasks: [],
+              page: {
+                actualCount: 0,
+                returnedCount: 0,
+                truncated: false,
+                asOf: "2026-08-09T16:50:02Z",
+              },
+              contextRevision: { index: { ramGeneration: 32 } },
+            };
+          },
+        },
+      },
+    }),
+  };
+
+  const adapter = new OperonDeveloperApiRuntimeAdapter(consumer, operon);
+  assert.equal(await adapter.refresh(), true);
+  assert.equal(adapter.hasFilterQueryCapability(), true);
+  assert.deepEqual(adapter.semanticConfiguration.views.filters[0], {
+    id: "filter-now",
+    name: "Maintenant",
+    icon: "zap",
+    definition: {
+      id: "filter-now",
+      name: "Maintenant",
+      icon: "zap",
+      root: { type: "group", children: [] },
+    },
+  });
+  const result = await adapter.querySavedFilter({
+    filterSetId: "filter-now",
+    scopePath: "Efforts/Projets",
+    includeProperties: true,
+    limit: 25,
+    cursor: "opaque-filter-cursor",
+  });
+  assert.equal(result.ok, true);
+  assert.deepEqual(filterRequest, {
+    contractVersion: 1,
+    requestId: filterRequest.requestId,
+    kind: "task-filter-query",
+    consistency: "live-verified",
+    filterSetId: "filter-now",
+    scope: { kind: "folder-tree", path: "Efforts/Projets" },
+    include: ["custom-fields"],
+    limit: 25,
+    cursor: "opaque-filter-cursor",
+  });
+});
+
+test("a pending Operon 3.2 filter grant does not hide approved core reads or mutations", async () => {
+  const granted = new Set([
+    "system.health",
+    "system.capabilities",
+    "catalog.read",
+    "tasks.read",
+    "tasks.query",
+    "tasks.update.preview",
+    "tasks.update.apply",
+  ]);
+  const api = {
+    hasCapability: (name: string) => granted.has(name),
+    channel: { status: readyStatus },
+    system: {
+      health: async () => ({
+        ok: true,
+        contextRevision: { index: { ramGeneration: 33 } },
+      }),
+      capabilities: () => [],
+      diagnostics: async () => ({ ok: true }),
+    },
+    catalog: {
+      snapshot: async () => ({
+        ok: true,
+        settingsFingerprint: "settings-33",
+        taxonomy: { pipelines: [], priorities: [] },
+        fields: [],
+        policies: { creation: {} },
+      }),
+    },
+    tasks: {
+      query: async () => ({
+        ok: true,
+        tasks: [],
+        page: { truncated: false },
+        contextRevision: { index: { ramGeneration: 33 } },
+      }),
+    },
+    mutations: {
+      preview: async () => ({ ok: true, plan: { planDigest: "filter-pending" } }),
+      apply: async () => ({ status: "applied" as const }),
+    },
+  };
+  const operon = {
+    getDeveloperApiV1: (
+      _candidate: unknown,
+      request: { requestedCapabilities: readonly string[] },
+    ) => ({
+      ok: request.requestedCapabilities.every((capability) => granted.has(capability)),
+      status: {
+        ...readyStatus(),
+        admission: { reads: true, writes: true },
+        grant: {
+          state: "active",
+          grantedCapabilities: [...granted],
+          effectiveCapabilities: request.requestedCapabilities,
+        },
+      },
+      api,
+    }),
+    getTaskWorkflowDeveloperApiV1: () => ({
+      ok: false,
+      error: {
+        code: "authority-insufficient",
+        reason: "tasks.filter-query grant pending",
+      },
+    }),
+  };
+
+  const adapter = new OperonDeveloperApiRuntimeAdapter(consumer, operon);
+  assert.equal(await adapter.refresh(true), true);
+  assert.equal(adapter.indexer.getGeneration(), 33);
+  assert.equal(adapter.hasMutationCapability("update"), true);
+  assert.equal(adapter.hasFilterQueryCapability(), false);
 });
 
 test("Operon 3 Developer API adapter stays unavailable when the host grant is pending", async () => {

--- a/plugins/obsidian-operon-bridge/src/developer-api-adapter.test.ts
+++ b/plugins/obsidian-operon-bridge/src/developer-api-adapter.test.ts
@@ -249,7 +249,7 @@ test("Operon 3.2 adapter evaluates saved filters through the additive task-workf
   });
 });
 
-test("a pending Operon 3.2 filter grant does not hide approved core reads or mutations", async () => {
+test("an unavailable Operon 3.2 filter accessor does not hide approved core reads or mutations", async () => {
   const granted = new Set([
     "system.health",
     "system.capabilities",
@@ -323,6 +323,17 @@ test("a pending Operon 3.2 filter grant does not hide approved core reads or mut
   assert.equal(adapter.indexer.getGeneration(), 33);
   assert.equal(adapter.hasMutationCapability("update"), true);
   assert.equal(adapter.hasFilterQueryCapability(), false);
+
+  const throwingAdapter = new OperonDeveloperApiRuntimeAdapter(consumer, {
+    ...operon,
+    getTaskWorkflowDeveloperApiV1: () => {
+      throw new Error("optional task-workflow accessor unavailable");
+    },
+  });
+  assert.equal(await throwingAdapter.refresh(true), true);
+  assert.equal(throwingAdapter.indexer.getGeneration(), 33);
+  assert.equal(throwingAdapter.hasMutationCapability("update"), true);
+  assert.equal(throwingAdapter.hasFilterQueryCapability(), false);
 });
 
 test("Operon 3 Developer API adapter stays unavailable when the host grant is pending", async () => {

--- a/plugins/obsidian-operon-bridge/src/developer-api-adapter.ts
+++ b/plugins/obsidian-operon-bridge/src/developer-api-adapter.ts
@@ -1087,7 +1087,14 @@ export class OperonDeveloperApiRuntimeAdapter {
       // consent request. Probe it only after preserving every already-granted
       // core read and mutation session, so a pending filter grant cannot make
       // the established V1 surface appear unavailable during the same refresh.
-      this.filterQueryApi = this.connectFilterQuery();
+      try {
+        this.filterQueryApi = this.connectFilterQuery();
+      } catch {
+        // Saved-filter execution is an additive Operon 3.2 capability. A
+        // broken or temporarily incompatible optional accessor must not tear
+        // down the already-verified core Developer API session.
+        this.filterQueryApi = null;
+      }
       return true;
     } catch (error) {
       this.readApi = null;

--- a/plugins/obsidian-operon-bridge/src/developer-api-adapter.ts
+++ b/plugins/obsidian-operon-bridge/src/developer-api-adapter.ts
@@ -5,6 +5,7 @@ import {
   type RuntimeKeyMapping,
   type RuntimePipeline,
   type RuntimePriorityDefinition,
+  isCanonicalVaultRelativePath,
   resolvePriorityStableId,
 } from "./contract";
 
@@ -271,6 +272,12 @@ interface DeveloperApiCatalog {
     }[];
   };
   readonly fields?: readonly DeveloperApiField[];
+  readonly filters?: readonly {
+    readonly id: string;
+    readonly name: string;
+    readonly icon?: string;
+    readonly [key: string]: unknown;
+  }[];
   readonly policies?: {
     readonly creation?: {
       readonly defaultEstimateMinutes?: number;
@@ -315,6 +322,43 @@ interface DeveloperApiAccessor {
       readonly requestedCapabilities: readonly string[];
     },
   ) => DeveloperApiAccessResult;
+}
+
+interface TaskWorkflowFilterResult {
+  readonly ok: boolean;
+  readonly tasks?: readonly DeveloperApiTask[];
+  readonly page?: {
+    readonly actualCount?: number;
+    readonly returnedCount?: number;
+    readonly truncated?: boolean;
+    readonly nextCursor?: string;
+    readonly asOf?: string;
+  };
+  readonly contextRevision?: DeveloperApiContextRevision;
+  readonly error?: DeveloperApiError;
+}
+
+interface TaskWorkflowDeveloperApiV1 {
+  readonly tasks: {
+    readonly filterQuery: (
+      request: Record<string, unknown>,
+    ) => Promise<TaskWorkflowFilterResult>;
+  };
+}
+
+interface TaskWorkflowDeveloperApiAccessor {
+  readonly getTaskWorkflowDeveloperApiV1: (
+    consumerPlugin: DeveloperApiConsumerPlugin,
+    request: {
+      readonly contractVersion: 1;
+      readonly runtimeApi: { readonly min: 1; readonly max: 1 };
+      readonly requestedCapabilities: readonly ["tasks.filter-query"];
+    },
+  ) => {
+    readonly ok: boolean;
+    readonly api?: TaskWorkflowDeveloperApiV1;
+    readonly error?: DeveloperApiError;
+  };
 }
 
 interface DeveloperApiAccessResult {
@@ -819,6 +863,17 @@ function catalogConfiguration(catalog: DeveloperApiCatalog): {
     ...configuration.indexing,
     excludedFolders: [...(catalog.policies?.exclusions?.folders ?? [])],
   };
+  configuration.views = {
+    filters: (catalog.filters ?? []).map((filter) => ({
+      id: filter.id,
+      name: filter.name,
+      icon: filter.icon ?? null,
+      definition: JSON.parse(JSON.stringify(filter)) as Record<
+        string,
+        unknown
+      >,
+    })),
+  };
   return { pipelines, keyMappings, priorities, configuration };
 }
 
@@ -826,6 +881,16 @@ function isDeveloperApiAccessor(value: unknown): value is DeveloperApiAccessor {
   if (!value || typeof value !== "object") return false;
   const candidate = value as { readonly getDeveloperApiV1?: unknown };
   return typeof candidate.getDeveloperApiV1 === "function";
+}
+
+function isTaskWorkflowDeveloperApiAccessor(
+  value: unknown,
+): value is TaskWorkflowDeveloperApiAccessor {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as {
+    readonly getTaskWorkflowDeveloperApiV1?: unknown;
+  };
+  return typeof candidate.getTaskWorkflowDeveloperApiV1 === "function";
 }
 
 function grantedCapabilitiesFromStatus(
@@ -854,6 +919,7 @@ export class OperonDeveloperApiRuntimeAdapter {
   defaultPipelineName: string | null = null;
 
   private readonly accessor: DeveloperApiAccessor | null;
+  private readonly taskWorkflowAccessor: TaskWorkflowDeveloperApiAccessor | null;
   private tasks: RuntimeIndexedTask[] = [];
   private rawTasks: DeveloperApiTask[] = [];
   private generation = 0;
@@ -876,6 +942,7 @@ export class OperonDeveloperApiRuntimeAdapter {
     DeveloperApiV1
   >();
   private recoveryApi: DeveloperApiV1 | null = null;
+  private filterQueryApi: TaskWorkflowDeveloperApiV1 | null = null;
   private grantedCapabilities: ReadonlySet<string> | null = null;
   private refreshInFlight: Promise<boolean> | null = null;
 
@@ -884,6 +951,9 @@ export class OperonDeveloperApiRuntimeAdapter {
     operonPlugin: unknown,
   ) {
     this.accessor = isDeveloperApiAccessor(operonPlugin) ? operonPlugin : null;
+    this.taskWorkflowAccessor = isTaskWorkflowDeveloperApiAccessor(operonPlugin)
+      ? operonPlugin
+      : null;
   }
 
   get semanticConfiguration(): OperonSemanticConfiguration {
@@ -911,6 +981,7 @@ export class OperonDeveloperApiRuntimeAdapter {
     this.optionalReadApis.clear();
     this.mutationApis.clear();
     this.recoveryApi = null;
+    this.filterQueryApi = null;
     this.grantedCapabilities = null;
 
     // Establish a baseline session first. Operon evaluates a requested set as
@@ -1012,6 +1083,11 @@ export class OperonDeveloperApiRuntimeAdapter {
       }
       if (includeMutationCapabilities) this.connectMutationApis();
       this.requestMissingCapabilities(includeMutationCapabilities);
+      // The additive task-workflow accessor may create a new exact-capability
+      // consent request. Probe it only after preserving every already-granted
+      // core read and mutation session, so a pending filter grant cannot make
+      // the established V1 surface appear unavailable during the same refresh.
+      this.filterQueryApi = this.connectFilterQuery();
       return true;
     } catch (error) {
       this.readApi = null;
@@ -1044,6 +1120,65 @@ export class OperonDeveloperApiRuntimeAdapter {
       this.readApi?.hasCapability(capability) ||
         this.optionalReadApis.get(capability)?.hasCapability(capability),
     );
+  }
+
+  hasFilterQueryCapability(): boolean {
+    return Boolean(this.filterQueryApi?.tasks.filterQuery);
+  }
+
+  async querySavedFilter(
+    request: Record<string, unknown>,
+  ): Promise<TaskWorkflowFilterResult> {
+    const api = this.filterQueryApi;
+    if (!api?.tasks.filterQuery) {
+      throw new Error(
+        "Operon task-workflow Developer API grant is unavailable: tasks.filter-query.",
+      );
+    }
+    const filterSetId = String(request.filterSetId ?? "").trim();
+    if (!filterSetId) throw new Error("filterSetId is required.");
+    const rawScopePath = request.scopePath;
+    if (
+      rawScopePath !== undefined &&
+      !isCanonicalVaultRelativePath(rawScopePath)
+    ) {
+      throw new Error(
+        "scopePath must be an exact canonical vault-relative note or folder path.",
+      );
+    }
+    const scopePath = typeof rawScopePath === "string" ? rawScopePath : "";
+    const requestedLimit = Number(request.limit ?? 100);
+    const limit = Math.min(
+      250,
+      Math.max(
+        1,
+        Number.isFinite(requestedLimit) ? Math.trunc(requestedLimit) : 100,
+      ),
+    );
+    return api.tasks.filterQuery({
+      contractVersion: 1,
+      requestId: requestId(),
+      kind: "task-filter-query",
+      consistency: "live-verified",
+      filterSetId,
+      ...(scopePath
+        ? {
+            scope: {
+              kind: scopePath.toLocaleLowerCase().endsWith(".md")
+                ? "exact-file"
+                : "folder-tree",
+              path: scopePath,
+            },
+          }
+        : {}),
+      ...(request.includeProperties === true
+        ? { include: ["custom-fields"] }
+        : {}),
+      limit,
+      ...(typeof request.cursor === "string" && request.cursor
+        ? { cursor: request.cursor }
+        : {}),
+    });
   }
 
   private requireReadApi(
@@ -1189,6 +1324,19 @@ export class OperonDeveloperApiRuntimeAdapter {
         if (!this.recoveryApi) this.recoveryApi = api;
       }
     }
+  }
+
+  private connectFilterQuery(): TaskWorkflowDeveloperApiV1 | null {
+    if (!this.taskWorkflowAccessor) return null;
+    const access = this.taskWorkflowAccessor.getTaskWorkflowDeveloperApiV1(
+      this.consumerPlugin,
+      {
+        contractVersion: 1,
+        runtimeApi: { min: 1, max: 1 },
+        requestedCapabilities: ["tasks.filter-query"],
+      },
+    );
+    return access.ok && access.api?.tasks.filterQuery ? access.api : null;
   }
 
   private requestMissingCapabilities(includeMutations: boolean): void {

--- a/plugins/obsidian-operon-bridge/src/main.ts
+++ b/plugins/obsidian-operon-bridge/src/main.ts
@@ -6,6 +6,7 @@ import {
   OPERON_BRIDGE_TESTED_VERSION,
   isIndexReady,
   isDeveloperApiVersion,
+  isCanonicalVaultRelativePath,
   isCanonicalVaultMarkdownPath,
   mutationPathValidationError,
   resolveMutationPreflight,
@@ -711,7 +712,8 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
         transition: supports("transition"),
         relationshipMutation: supports("relationships"),
         recurrenceMutation: supports("recurrence"),
-        filterQuery: false,
+        filterQuery:
+          readable && runtime.developerApi!.hasFilterQueryCapability(),
         relocate: supports("relocate"),
         convert: supports("convert"),
         recovery: mutationEnabled && runtime.developerApi!.hasRecoverySupport(),
@@ -2647,6 +2649,112 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
             return;
           }
           const runtime = this.requireRuntime();
+          if (runtime.developerApi) {
+            // A force-refresh temporarily rebuilds the additive capability
+            // sessions. Wait for the shared live snapshot first so a parallel
+            // status/configuration refresh cannot surface a false 503 here.
+            const snapshot = await this.allTasksSnapshot(
+              boolValue(body.includeProperties),
+            );
+            if (!runtime.developerApi.hasFilterQueryCapability()) {
+              sendJson(
+                res,
+                503,
+                errorPayload(
+                  new Error(
+                    "Operon saved-filter Developer API grant is unavailable.",
+                  ),
+                  "capability_unavailable",
+                ),
+              );
+              return;
+            }
+            const nativeResult = await runtime.developerApi.querySavedFilter({
+              filterSetId,
+              ...(typeof body.scopePath === "string" && body.scopePath.trim()
+                ? { scopePath: body.scopePath.trim() }
+                : {}),
+              includeProperties: boolValue(body.includeProperties),
+              limit: Math.min(
+                250,
+                Math.max(1, Math.trunc(numberValue(body.limit) ?? 100)),
+              ),
+              ...(typeof body.cursor === "string" && body.cursor
+                ? { cursor: body.cursor }
+                : {}),
+            });
+            if (!nativeResult.ok) {
+              sendJson(
+                res,
+                nativeResult.error?.code === "not-found" ? 404 : 422,
+                errorPayload(
+                  new Error(
+                    nativeResult.error?.reason ??
+                      nativeResult.error?.message ??
+                      nativeResult.error?.code ??
+                      "Operon saved-filter query failed.",
+                  ),
+                  nativeResult.error?.code ?? "filter_query_error",
+                ),
+              );
+              return;
+            }
+            const nativeGeneration =
+              nativeResult.contextRevision?.index?.ramGeneration;
+            if (
+              Number.isInteger(nativeGeneration) &&
+              nativeGeneration !== snapshot.generation
+            ) {
+              throw new Error(
+                "Operon generation changed while evaluating the saved filter; retry.",
+              );
+            }
+            const taskById = new Map(
+              snapshot.tasks.map((task) => [task.operonId, task]),
+            );
+            const tasks = (nativeResult.tasks ?? [])
+              .map((task) => taskById.get(task.identity.operonId))
+              .filter((task): task is OperonBridgeTask => Boolean(task));
+            if (tasks.length !== (nativeResult.tasks ?? []).length) {
+              throw new Error(
+                "Operon saved-filter results changed before hydration; retry.",
+              );
+            }
+            sendJson(res, 200, {
+              ok: true,
+              contractVersion: OPERON_BRIDGE_CONTRACT_VERSION,
+              source: "operon-live",
+              stale: false,
+              generation: snapshot.generation,
+              settingsSignature: snapshot.settingsSignature,
+              total: nativeResult.page?.actualCount ?? tasks.length,
+              count: tasks.length,
+              cursor: typeof body.cursor === "string" ? body.cursor : "",
+              ...(nativeResult.page?.nextCursor
+                ? { nextCursor: nativeResult.page.nextCursor }
+                : {}),
+              hasMore: nativeResult.page?.truncated === true,
+              tasks,
+              limitations: this.limitations(runtime, true),
+            });
+            return;
+          }
+          if (
+            body.scopePath !== undefined &&
+            !isCanonicalVaultRelativePath(body.scopePath)
+          ) {
+            sendJson(
+              res,
+              400,
+              errorPayload(
+                new Error(
+                  "scopePath must be an exact canonical vault-relative note or folder path.",
+                ),
+                "validation_error",
+              ),
+            );
+            return;
+          }
           const publicCapabilities = runtime.api?.capabilities();
           if (
             !runtime.api ||

--- a/profiles/elysia-tasks/README.fr.md
+++ b/profiles/elysia-tasks/README.fr.md
@@ -76,20 +76,22 @@ Le fichier de référence est [`v1/profile.json`](v1/profile.json).
 
 ## Skill agentique publique
 
-La skill portable [`elysia-task-gouverneur`](skills/elysia-task-gouverneur/SKILL.md) permet à un agent de piloter ce profil via les 13 outils `operon_*` du MCP Optimike.
+La skill portable [`elysia-task-gouverneur`](skills/elysia-task-gouverneur/SKILL.md) permet à un agent de piloter ce profil via les 23 outils `operon_*` gouvernés du MCP Optimike.
 
 Elle couvre :
 
-- création, adoption, mise à jour, transition, conversion et relocalisation ;
-- audit et triage par saved filters ;
+- création, mise à jour, transition, relations, récurrence, conversion et relocalisation ; adoption seulement lorsque le moteur annonce la capacité ;
+- audit et triage par saved filters lorsqu’ils existent, sinon par requêtes bornées dérivées du profil ;
 - cycle de vie des backlogs de projet ;
-- diagnostic du runtime et du cache ;
+- diagnostic du runtime, du cache, des grants et récupération du même plan incertain ;
 - dry-run, révisions optimistes, idempotence et preuve après application.
 - admission P90-J avant création/adoption et clés d’idempotence distinctes pour le plan et l’application.
 
 La skill ne contient aucun chemin absolu, aucune tâche réelle, aucun identifiant privé et aucune copie de configuration `data.json`. Les règles propres à un coffre doivent être fournies comme politique locale au moment de l’exécution.
 
 La version publique suit son propre versionnement et n’est pas un miroir automatique d’une configuration privée. Toute évolution doit être promue après contrôle de portabilité et de non-régression.
+
+La CLI reste la surface opérateur pour la suppression, les rappels, le pin et le contrôle du timer. La skill n’expose aucun passthrough CLI générique.
 
 Pour l’installer dans un runtime Agent Skills, copier le dossier complet :
 

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/SKILL.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: elysia-task-gouverneur
-description: 'Orchestre les tâches d’un coffre compatible avec le profil public ÉLYSIA Tasks : opérations ponctuelles, audits, triage, cycle de vie et santé du runtime Kairélys/Operon via les outils operon_*, avec IDs stables, dry-run et validation humaine.'
+description: 'Orchestre les tâches d’un coffre compatible avec le profil public ÉLYSIA Tasks via les 23 outils operon_* gouvernés : opérations ponctuelles, relations, récurrence, récupération, audits, triage, cycle de vie et santé du runtime, avec capacités live, IDs stables, dry-run et validation humaine.'
 metadata:
-  version: '1.1.0'
+  version: '1.2.0'
   skill_structure: graph
   portability_class: profile-bound-portable
   profile_id: elysia.tasks
@@ -17,7 +17,8 @@ Utilise le profil public `elysia.tasks` et la configuration live du moteur pour 
 
 ## Quand l’utiliser
 
-- Créer, adopter, modifier, terminer, convertir ou déplacer une tâche.
+- Créer, modifier, terminer, convertir ou déplacer une tâche ; adopter seulement si le runtime annonce la capacité.
+- Lire ou modifier des relations et récurrences, ou récupérer exactement une mutation incertaine.
 - Auditer ou trier un backlog compatible avec le profil ÉLYSIA Tasks.
 - Contrôler les filtres canoniques et le respect du propriétaire unique.
 - Diagnostiquer un runtime Kairélys/Operon stale, incompatible ou incohérent.
@@ -30,6 +31,8 @@ Utilise le profil public `elysia.tasks` et la configuration live du moteur pour 
 - Ne jamais muter une tâche par regex, patch Markdown, édition YAML brute ou déplacement de fichier.
 - Toute mutation d’une tâche existante passe par `expectedRevision`, `idempotencyKey`, dry-run, validation humaine, apply, relecture et `operon_validate`.
 - Runtime stale/non-live, capacité absente ou référence critique inaccessible : lecture seulement.
+- L’enregistrement d’un outil ne prouve ni sa capacité, ni son grant, ni un mode d’écriture suffisant.
+- Suppression, rappels, pin, contrôle de timer et passthrough CLI générique restent opérateur-only.
 - Une tâche appartient à un seul moteur. Ne jamais écrire en miroir dans Operon, Tasks et TaskNotes.
 - Toute création ou adoption passe par [admission-p90-j.md](references/admission-p90-j.md). Un plan ou une liste n’autorise pas automatiquement la création de tâches.
 
@@ -38,18 +41,15 @@ Utilise le profil public `elysia.tasks` et la configuration live du moteur pour 
 | Intention | `module_route` | Modules obligatoires |
 |---|---|---|
 | Créer ou adopter | `operation-ponctuelle` | [admission-p90-j.md](references/admission-p90-j.md) + [operations-ponctuelles.md](references/operations-ponctuelles.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
-| Modifier, terminer, convertir, déplacer | `operation-ponctuelle` | [operations-ponctuelles.md](references/operations-ponctuelles.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
+| Modifier, terminer, lier, gérer une récurrence, convertir ou déplacer | `operation-ponctuelle` | [operations-ponctuelles.md](references/operations-ponctuelles.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
+| Résultat incertain ou récupération | `sante-performance` | [sante-et-performance.md](references/sante-et-performance.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
 | Audit, triage, conformité ou saved filters | `audit-triage` | [audits-et-triage.md](references/audits-et-triage.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
 | Changement de phase d’un projet ou nettoyage de backlog | `cycle-vie-projet` | [cycle-de-vie-projet.md](references/cycle-de-vie-projet.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
 | Cache stale, incident, incompatibilité ou lenteur | `sante-performance` | [sante-et-performance.md](references/sante-et-performance.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
 
 ## Routage rapide
 
-- Création ou adoption -> ouvrir `admission-p90-j`, `operations-ponctuelles`, puis `runtime-et-mutations`.
-- Autre opération sur une tâche -> ouvrir `operations-ponctuelles` puis `runtime-et-mutations`.
-- Audit ou cockpit -> ouvrir `audits-et-triage` puis `runtime-et-mutations`.
-- Projet qui change de phase -> ouvrir `cycle-de-vie-projet` puis `runtime-et-mutations`.
-- Runtime stale ou incident -> ouvrir `sante-et-performance` puis `runtime-et-mutations`.
+Choisir une seule ligne de la `Reference Gate Map`, ouvrir tous ses modules, puis élargir seulement si la situation change de route.
 
 ## Profile Gate
 
@@ -95,10 +95,3 @@ Appliquer [contrat-de-sortie.md](references/contrat-de-sortie.md) et renseigner 
 - Cycle de vie projet : [cycle-de-vie-projet.md](references/cycle-de-vie-projet.md)
 - Santé et performance : [sante-et-performance.md](references/sante-et-performance.md)
 - Contrat de sortie : [contrat-de-sortie.md](references/contrat-de-sortie.md)
-
-## Exemples de déclencheurs
-
-- « Crée cette tâche dans le projet et mets-la dans le statut planifié. »
-- « Termine cette tâche via Operon sans modifier le Markdown. »
-- « Audite les tâches hors des racines autorisées par le profil ÉLYSIA. »
-- « Why is the Operon runtime stale? »

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/SKILL.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/SKILL.md
@@ -2,7 +2,7 @@
 name: elysia-task-gouverneur
 description: 'Orchestre les tâches d’un coffre compatible avec le profil public ÉLYSIA Tasks via les 23 outils operon_* gouvernés : opérations ponctuelles, relations, récurrence, récupération, audits, triage, cycle de vie et santé du runtime, avec capacités live, IDs stables, dry-run et validation humaine.'
 metadata:
-  version: '1.2.0'
+  version: 1.3.0
   skill_structure: graph
   portability_class: profile-bound-portable
   profile_id: elysia.tasks

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/admission-p90-j.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/admission-p90-j.md
@@ -21,6 +21,8 @@ Décider si un item mérite un cycle de vie de tâche avant toute création ou a
 - `REJECT_DUPLICATE`
 - `DEFER_CAPACITY`
 
+`ADOPT` est un verdict d’admission, pas une garantie technique. Si la capacité `adopt` manque, conserver la checkbox ou demander une action opérateur ; ne jamais contourner l’absence par une édition Markdown.
+
 ## Sortie minimale
 
 ```yaml

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/audits-et-triage.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/audits-et-triage.md
@@ -22,13 +22,13 @@ Pour un audit de conformité ÉLYSIA, ouvrir `profiles/elysia-tasks/v1/profile.j
 - `fs_elysia_periodic_leakage`
 - `fs_elysia_folder_open` avec un `scopePath` explicite
 
-Appeler `operon_query_saved_filter` ; ne pas reconstruire la logique du filtre côté agent.
+Si `filterQuery: true`, appeler `operon_query_saved_filter`. Sinon, lire les critères dans `profile.json` et les traduire dans `operon_query_tasks` ou `operon_find_tasks` pour cette exécution seulement. Ne pas figer une seconde copie de la logique dans la skill.
 
 ## Méthode
 
 1. Exécuter le préflight live.
 2. Déclarer le périmètre et la politique de référence.
-3. Interroger le saved filter ou les tâches concernées.
+3. Interroger le saved filter lorsqu’il est disponible, sinon les tâches concernées avec les critères du profil.
 4. Séparer faits, écarts au profil, politique locale et interprétation.
 5. Proposer uniquement les mutations nécessaires.
 6. Pour un audit complet, comparer toutes les tâches ouvertes à l’union des surfaces et exiger `open_without_surface = 0`, `now_not_in_week = 0` et `periodic_non_inbox = 0`.

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/audits-et-triage.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/audits-et-triage.md
@@ -22,7 +22,7 @@ Pour un audit de conformité ÉLYSIA, ouvrir `profiles/elysia-tasks/v1/profile.j
 - `fs_elysia_periodic_leakage`
 - `fs_elysia_folder_open` avec un `scopePath` explicite
 
-Si `filterQuery: true`, appeler `operon_query_saved_filter`. Sinon, lire les critères dans `profile.json` et les traduire dans `operon_query_tasks` ou `operon_find_tasks` pour cette exécution seulement. Ne pas figer une seconde copie de la logique dans la skill.
+Si `filterQuery: true` et qu’un `filterSetId` exact vient de l’UI/configuration d’Operon ou d’un workflow opérateur, appeler `operon_query_saved_filter`. Un catalogue vide dans `operon_get_configuration` ne prouve pas l’indisponibilité. Si l’ID manque, lire les critères dans `profile.json` et les traduire dans `operon_query_tasks` ou `operon_find_tasks` pour cette exécution seulement. Ne jamais inventer l’ID depuis le nom ni figer une seconde copie de la logique dans la skill.
 
 ## Méthode
 

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/contrat-de-sortie.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/contrat-de-sortie.md
@@ -9,6 +9,8 @@ runtime_preflight:
   configuration_lue: true | false
   capacite_requise: nom | aucune
   capacite_disponible: true | false | non_applicable
+  outil_charge: true | false | inconnu
+  mode_ecriture: readonly | guarded | full | inconnu
 references_ouvertes:
   - path: ressource exacte
     type: skill_reference | public_profile | local_policy | runtime
@@ -38,6 +40,9 @@ preuve_application:
   filtre_attendu_verifie: true | false | non_applicable
   invisible: false | true | non_applicable
   operon_validate: résultat réel
+  recovery_ref: identifiant | non_applicable
+  relations_inverses_verifiees: true | false | non_applicable
+  recurrence_portee_verifiee: true | false | non_applicable
   divergence: aucune | description
 ```
 

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/operations-ponctuelles.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/operations-ponctuelles.md
@@ -14,7 +14,7 @@ Utiliser `operon_create_task` pour une action qui n’existe pas encore. Résoud
 
 ### Adopter
 
-Utiliser `operon_adopt_task` pour promouvoir une checkbox existante qui constitue une vraie action. Verrouiller le chemin, le numéro de ligne et le contenu attendu.
+Le verdict `ADOPT` ne garantit pas l’apply. Utiliser `operon_adopt_task` seulement si le runtime annonce `adopt: true`, puis verrouiller le chemin, le numéro de ligne et le contenu attendu. Sinon retourner une indisponibilité structurée sans modifier le Markdown.
 
 ### Modifier
 
@@ -24,6 +24,14 @@ Utiliser `operon_update_task` et envoyer seulement les champs intentionnellement
 
 Utiliser `operon_transition_task` pour terminer, annuler, rouvrir ou changer de statut. Utiliser un `statusId` live et vérifier les effets métier après application.
 
+### Lier ou délier
+
+Lire d’abord le graphe avec `operon_get_relationships`, puis utiliser `operon_set_relationships` pour remplacer explicitement parent, blocages ou bloqueurs. Refuser doublons, auto-références, sens contradictoires et cycles évidents. Relire la source et les relations inverses après apply.
+
+### Gérer une récurrence
+
+Utiliser `operon_update_recurrence` en mode `full`, avec une portée explicite `this-task` ou `this-and-following`. Employer `null` pour une suppression volontaire et vérifier la règle normalisée ainsi que la portée.
+
 ### Convertir
 
 Utiliser `operon_convert_task` pour inline ↔ fichier lorsque la forme cible apporte un gain réel. Vérifier le mode d’écriture requis et résoudre la destination avant le dry-run.
@@ -31,6 +39,14 @@ Utiliser `operon_convert_task` pour inline ↔ fichier lorsque la forme cible ap
 ### Déplacer
 
 Utiliser exclusivement `operon_relocate_task`. Vérifier la politique locale du dossier cible et la conservation de l’identité `operonId`.
+
+### Récupérer
+
+Lister les plans incertains avec `operon_list_pending_recoveries`, puis appeler `operon_recover_mutation` uniquement avec le `recoveryRef` du même plan, une nouvelle clé d’idempotence et le mode `full`. Ne jamais reconstruire ou rejouer la mutation originale.
+
+### Rester côté opérateur
+
+Suppression, rappels, pin et contrôle/session de timer restent dans la CLI. Une modification de description d’une File Task reste refusée sans contrat explicite de renommage.
 
 ## Heuristiques portables
 

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/runtime-et-mutations.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/runtime-et-mutations.md
@@ -55,7 +55,7 @@ Récupération :
 - `operon_list_pending_recoveries`
 - `operon_recover_mutation`
 
-Le serveur enregistre vingt-trois outils. Leur présence ne remplace jamais le contrôle de capacité live. Operon officiel `3.1.1` n’annonce actuellement ni `adopt` ni `filterQuery` : les outils restent enregistrés pour compatibilité mais doivent renvoyer une indisponibilité structurée. `operon_query_tasks` est la requête structurée Operon ; l’ancien outil non préfixé `query_tasks` relève du legacy Markdown.
+Le serveur enregistre vingt-trois outils. Leur présence ne remplace jamais le contrôle de capacité live. Operon officiel `3.2.0` exécute les filtres sauvegardés après un grant exact `tasks.filter-query` et avec un `filterSetId` exact, mais ne publie pas le catalogue de ces IDs. `adopt` reste indisponible et doit échouer de façon structurée. `operon_query_tasks` est la requête structurée Operon ; l’ancien outil non préfixé `query_tasks` relève du legacy Markdown.
 
 Les relations sont admises en mode `guarded`. La récurrence et la récupération exigent le mode `full`. La CLI reste la surface opérateur/admin et n’est pas relayée génériquement par le MCP.
 
@@ -71,7 +71,7 @@ Pour une tâche existante :
 6. Relire la tâche et sa révision ; arrêter ou recalculer si elle a changé.
 7. Construire une clé d’application distincte : `<intention>-apply-<nonce>`.
 8. Appliquer avec `dryRun: false` et la révision actuelle.
-9. Relire la tâche, vérifier la surface attendue et appeler `operon_validate`. Utiliser un saved filter seulement si `filterQuery` est disponible ; sinon traduire les critères du profil dans une requête bornée pour cette exécution.
+9. Relire la tâche, vérifier la surface attendue et appeler `operon_validate`. Utiliser un saved filter seulement si `filterQuery` est disponible et si son ID exact vient de l’UI/configuration d’Operon ou d’un workflow opérateur ; sinon traduire les critères du profil dans une requête bornée pour cette exécution.
 10. Si la tâche apparaît dans `fs_elysia_now`, prouver sa présence dans `fs_elysia_week` et rapporter `invisible: false`.
 
 Ne jamais réutiliser la clé du dry-run pour l’apply : `dryRun` fait partie de la requête canonique.

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/runtime-et-mutations.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/runtime-et-mutations.md
@@ -32,6 +32,12 @@ Lecture :
 - `operon_query_tasks`
 - `operon_query_saved_filter`
 - `operon_validate`
+- `operon_get_diagnostics`
+- `operon_find_tasks`
+- `operon_resolve_task`
+- `operon_get_relationships`
+- `operon_build_context`
+- `operon_get_timer_state`
 
 Mutation :
 
@@ -39,8 +45,19 @@ Mutation :
 - `operon_create_task`
 - `operon_update_task`
 - `operon_transition_task`
+- `operon_set_relationships`
+- `operon_update_recurrence`
 - `operon_convert_task`
 - `operon_relocate_task`
+
+Récupération :
+
+- `operon_list_pending_recoveries`
+- `operon_recover_mutation`
+
+Le serveur enregistre vingt-trois outils. Leur présence ne remplace jamais le contrôle de capacité live. Operon officiel `3.1.1` n’annonce actuellement ni `adopt` ni `filterQuery` : les outils restent enregistrés pour compatibilité mais doivent renvoyer une indisponibilité structurée. `operon_query_tasks` est la requête structurée Operon ; l’ancien outil non préfixé `query_tasks` relève du legacy Markdown.
+
+Les relations sont admises en mode `guarded`. La récurrence et la récupération exigent le mode `full`. La CLI reste la surface opérateur/admin et n’est pas relayée génériquement par le MCP.
 
 ## Protocole
 
@@ -54,12 +71,12 @@ Pour une tâche existante :
 6. Relire la tâche et sa révision ; arrêter ou recalculer si elle a changé.
 7. Construire une clé d’application distincte : `<intention>-apply-<nonce>`.
 8. Appliquer avec `dryRun: false` et la révision actuelle.
-9. Relire la tâche, vérifier le filtre attendu et appeler `operon_validate`.
+9. Relire la tâche, vérifier la surface attendue et appeler `operon_validate`. Utiliser un saved filter seulement si `filterQuery` est disponible ; sinon traduire les critères du profil dans une requête bornée pour cette exécution.
 10. Si la tâche apparaît dans `fs_elysia_now`, prouver sa présence dans `fs_elysia_week` et rapporter `invisible: false`.
 
 Ne jamais réutiliser la clé du dry-run pour l’apply : `dryRun` fait partie de la requête canonique.
 
-Pour une création, aucune révision antérieure n’existe : destination, pipeline, statut initial et clé d’idempotence doivent être explicites. Pour une adoption, verrouiller le chemin, la ligne et le contenu attendu de la checkbox.
+Pour une création, aucune révision antérieure n’existe : destination, pipeline, statut initial et clé d’idempotence doivent être explicites. Pour une adoption, exiger d’abord `adopt: true`, puis verrouiller le chemin, la ligne et le contenu attendu. Après une mutation de relations, relire la source et les relations inverses. Après une mutation de récurrence, vérifier règle et portée. Après `outcome-unknown`, récupérer uniquement le même `recoveryRef` ; ne jamais rejouer la mutation initiale.
 
 ## Interdits
 
@@ -68,3 +85,5 @@ Pour une création, aucune révision antérieure n’existe : destination, pipel
 - Aucune écriture miroir vers un autre moteur de tâches.
 - Aucune opération bulk avant un dry-run borné.
 - Aucun succès annoncé si l’état final n’a pas été relu.
+- Aucun retry aveugle après un résultat incertain.
+- Aucune suppression, gestion de rappel, pin ou commande de timer via le MCP.

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/sante-et-performance.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/sante-et-performance.md
@@ -3,10 +3,11 @@
 ## Diagnostic
 
 1. Relever `source`, `stale`, âge du snapshot, versions moteur/Bridge, compatibilité et capacités.
-2. Appeler `operon_validate` et distinguer erreurs, avertissements et doublons.
-3. Vérifier si l’incident concerne le Bridge, le moteur, l’index, le cache, une capacité, une version ou une donnée malformée.
+2. Appeler `operon_get_diagnostics`, puis `operon_validate`, et distinguer lifecycle, grant, transport, erreurs, avertissements et doublons.
+3. Distinguer outil non chargé, capacité absente, grant absent, mode d’écriture insuffisant, Bridge, moteur, index, cache, version ou donnée malformée.
 4. Reproduire sur une lecture bornée avant d’accuser le volume global.
 5. Mesurer toute affirmation de performance sur la même requête, le même périmètre et le même état de cache.
+6. Pour une mutation incertaine, appeler `operon_list_pending_recoveries` avant toute nouvelle écriture et ne récupérer que le même plan en mode `full` après validation humaine.
 
 ## Documentation publique utile
 
@@ -23,3 +24,5 @@ Les versions réellement chargées viennent du runtime, pas d’une documentatio
 - Une validation sans violation ne prouve pas la performance.
 - Ne pas réindexer, réinstaller ou effectuer un rollback sans sauvegarde et validation explicite.
 - Après correction, rejouer le même test et rapporter le delta mesuré.
+- L’état du timer est lisible ; son contrôle reste opérateur-only.
+- Ne jamais retenter une mutation incertaine avec un nouveau plan.

--- a/scripts/test-elysia-task-profile.mjs
+++ b/scripts/test-elysia-task-profile.mjs
@@ -37,7 +37,7 @@ assert.ok(frontmatterMatch, "public task skill must have YAML frontmatter");
 const frontmatter = parseYaml(frontmatterMatch[1]);
 
 assert.equal(frontmatter.name, "elysia-task-gouverneur");
-assert.equal(frontmatter.metadata.version, "1.2.0");
+assert.equal(frontmatter.metadata.version, "1.3.0");
 assert.equal(frontmatter.metadata.skill_structure, "graph");
 assert.equal(frontmatter.metadata.portability_class, "profile-bound-portable");
 assert.equal(frontmatter.metadata.profile_id, profile.profileId);

--- a/scripts/test-elysia-task-profile.mjs
+++ b/scripts/test-elysia-task-profile.mjs
@@ -37,7 +37,7 @@ assert.ok(frontmatterMatch, "public task skill must have YAML frontmatter");
 const frontmatter = parseYaml(frontmatterMatch[1]);
 
 assert.equal(frontmatter.name, "elysia-task-gouverneur");
-assert.equal(frontmatter.metadata.version, "1.1.0");
+assert.equal(frontmatter.metadata.version, "1.2.0");
 assert.equal(frontmatter.metadata.skill_structure, "graph");
 assert.equal(frontmatter.metadata.portability_class, "profile-bound-portable");
 assert.equal(frontmatter.metadata.profile_id, profile.profileId);
@@ -74,6 +74,34 @@ const publicSkillFiles = [
   ),
 ];
 const publicSkillCorpus = publicSkillFiles.join("\n");
+const operonTools = [
+  "operon_status",
+  "operon_get_configuration",
+  "operon_list_tasks",
+  "operon_get_task",
+  "operon_query_tasks",
+  "operon_query_saved_filter",
+  "operon_validate",
+  "operon_get_diagnostics",
+  "operon_find_tasks",
+  "operon_resolve_task",
+  "operon_get_relationships",
+  "operon_build_context",
+  "operon_get_timer_state",
+  "operon_adopt_task",
+  "operon_create_task",
+  "operon_update_task",
+  "operon_transition_task",
+  "operon_set_relationships",
+  "operon_update_recurrence",
+  "operon_convert_task",
+  "operon_relocate_task",
+  "operon_list_pending_recoveries",
+  "operon_recover_mutation",
+];
+for (const tool of operonTools) {
+  assert.ok(publicSkillCorpus.includes(tool), `public task skill corpus is missing ${tool}`);
+}
 const forbiddenPrivateMarkers = [
   /\b[A-Z]:\\/,
   /\/Users\//,

--- a/scripts/test-operon-service.mjs
+++ b/scripts/test-operon-service.mjs
@@ -29,6 +29,7 @@ const capabilities = {
   transition: false,
   convert: false,
   recovery: false,
+  filterQuery: true,
 };
 
 const semanticConfiguration = {
@@ -364,6 +365,48 @@ const server = http.createServer((request, response) => {
     });
     return;
   }
+  if (request.method === "POST" && url.pathname.endsWith("/tasks/filter")) {
+    let body = "";
+    request.on("data", (chunk) => {
+      body += chunk;
+    });
+    request.on("end", () => {
+      const params = body ? JSON.parse(body) : {};
+      if (params.filterSetId === "missing-filter") {
+        sendJson(response, 404, {
+          ok: false,
+          error: { code: "not-found", message: "Saved filter was not found." },
+        });
+        return;
+      }
+      if (params.filterSetId === "invalid-filter") {
+        sendJson(response, 422, {
+          ok: false,
+          error: {
+            code: "invalid-request",
+            message: "Saved filter request is invalid.",
+          },
+        });
+        return;
+      }
+      sendJson(response, 200, {
+        ok: true,
+        contractVersion: "1",
+        source: "operon-live",
+        stale: false,
+        generation: state.generation,
+        settingsSignature: "fnv1a32:settings",
+        total: tasks.length,
+        count: 1,
+        cursor: String(params.cursor ?? ""),
+        nextCursor: params.cursor ? undefined : "filter-page-2",
+        hasMore: !params.cursor,
+        tasks: [params.cursor ? tasks[1] : tasks[0]],
+        limitations: ["read-only"],
+      });
+    });
+    return;
+  }
   if (
     request.method === "POST" &&
     url.pathname.endsWith("/mutations/recover")
@@ -658,6 +701,36 @@ try {
     "exact-task context must preserve Operon's projection-specific defaults",
   );
   assert.equal((await service.timers()).operation, "timers");
+
+  const firstFilterPage = await service.querySavedFilter({
+    filterSetId: "elysia-now",
+    limit: 1,
+  });
+  assert.equal(firstFilterPage.count, 1);
+  assert.equal(firstFilterPage.hasMore, true);
+  assert.equal(firstFilterPage.tasks[0].operonId, "abc1234");
+  const secondFilterPage = await service.querySavedFilter({
+    filterSetId: "elysia-now",
+    limit: 1,
+    cursor: firstFilterPage.nextCursor,
+  });
+  assert.equal(secondFilterPage.count, 1);
+  assert.equal(secondFilterPage.hasMore, false);
+  assert.equal(secondFilterPage.tasks[0].operonId, "bcd2345");
+  await assert.rejects(
+    () =>
+      service.querySavedFilter({ filterSetId: "missing-filter", limit: 1 }),
+    (error) =>
+      error?.code === "NOT_FOUND" &&
+      error?.message === "Saved filter was not found.",
+  );
+  await assert.rejects(
+    () =>
+      service.querySavedFilter({ filterSetId: "invalid-filter", limit: 1 }),
+    (error) =>
+      error?.code === "VALIDATION_ERROR" &&
+      error?.message === "Saved filter request is invalid.",
+  );
 
   state.mode = "offline";
   const offline = await service.ensureSnapshot(false);

--- a/src/mcp-server/tools/operonTools/registration.ts
+++ b/src/mcp-server/tools/operonTools/registration.ts
@@ -100,7 +100,7 @@ export async function registerOperonTools(server: McpServer): Promise<void> {
 
   server.tool(
     "operon_get_configuration",
-    "Read the task-semantic Operon configuration from the live plugin runtime: language, stable workflow/status IDs, priority definitions, canonical-to-visible key mappings, creation targets/templates, task automations, excluded folders, documentation location, and saved filter catalog. Falls back only to an explicitly stale persisted snapshot.",
+    "Read the task-semantic Operon configuration from the live plugin runtime: language, stable workflow/status IDs, priority definitions, canonical-to-visible key mappings, creation targets/templates, task automations, excluded folders, and documentation location. A saved-filter catalog is included only when the official runtime exposes one. Falls back only to an explicitly stale persisted snapshot.",
     ForceRefreshSchema.shape,
     READ_ONLY_ANNOTATIONS,
     async (params: z.infer<typeof ForceRefreshSchema>) =>
@@ -127,7 +127,7 @@ export async function registerOperonTools(server: McpServer): Promise<void> {
 
   server.tool(
     "operon_query_saved_filter",
-    "Evaluate one saved Operon filter through Operon's native filter engine. Use filterSetId from operon_get_configuration; optional scopePath limits results to one note or folder. This capability is live-only because headless snapshots cannot reproduce plugin filter semantics.",
+    "Evaluate one saved Operon filter through Operon's native filter engine. filterSetId must be an exact ID obtained from Operon's UI/configuration or an operator workflow; Operon 3.2 can execute a filter but does not expose the saved-filter catalog through its official Developer API. optional scopePath limits results to one note or folder. This capability is live-only because headless snapshots cannot reproduce plugin filter semantics.",
     OperonFilterQuerySchema.shape,
     READ_ONLY_ANNOTATIONS,
     async (params: z.infer<typeof OperonFilterQuerySchema>) =>
@@ -154,7 +154,7 @@ export async function registerOperonTools(server: McpServer): Promise<void> {
 
   server.tool(
     "operon_get_diagnostics",
-    "Read Operon 3.1.1 native runtime diagnostics through Developer API V1. Use this for lifecycle, persistence, capability/grant, catalog, and transport diagnosis; it never modifies the vault.",
+    "Read Operon 3.2 native runtime diagnostics through Developer API V1. Use this for lifecycle, persistence, capability/grant, catalog, and transport diagnosis; it never modifies the vault.",
     {},
     READ_ONLY_ANNOTATIONS,
     async () => runTool(() => service.diagnostics()),
@@ -206,7 +206,7 @@ export async function registerOperonTools(server: McpServer): Promise<void> {
 
   server.tool(
     "operon_adopt_task",
-    "Adopt one existing plain Markdown or Obsidian Tasks checkbox in place as an Operon inline task. Requires an exact one-based line and expectedLine precondition, plus idempotencyKey; dryRun defaults to true. The live Operon domain path preserves supported Tasks metadata and no raw Markdown fallback exists.",
+    "Adopt one existing plain Markdown or Obsidian Tasks checkbox in place only when the live engine advertises adoption. Requires an exact one-based line and expectedLine precondition, plus idempotencyKey; dryRun defaults to true. Official Operon 3.2 does not currently expose this capability, and no raw Markdown fallback exists.",
     OperonAdoptTaskSchema.shape,
     MUTATION_ANNOTATIONS,
     async (params: z.infer<typeof OperonAdoptTaskSchema>) =>
@@ -215,7 +215,7 @@ export async function registerOperonTools(server: McpServer): Promise<void> {
 
   server.tool(
     "operon_create_task",
-    "Create an Operon inline or file task through Operon Public API v1. dryRun defaults to true. Apply requires the live Bridge and an idempotencyKey; no raw Markdown fallback exists.",
+    "Create an Operon inline or file task through the loaded engine's supported official API. dryRun defaults to true. Apply requires the live Bridge and an idempotencyKey; no raw Markdown fallback exists.",
     OperonCreateTaskSchema.shape,
     MUTATION_ANNOTATIONS,
     async (params: z.infer<typeof OperonCreateTaskSchema>) =>

--- a/src/services/operon/service.ts
+++ b/src/services/operon/service.ts
@@ -255,6 +255,50 @@ export class OperonService {
     return this.client;
   }
 
+  private bridgeHttpError(error: unknown, operation: string): never {
+    if (!axios.isAxiosError(error) || !error.response) throw error;
+    const status = error.response.status;
+    const payload =
+      error.response.data && typeof error.response.data === "object"
+        ? (error.response.data as Record<string, unknown>)
+        : null;
+    const nativeError =
+      payload?.error && typeof payload.error === "object"
+        ? (payload.error as Record<string, unknown>)
+        : null;
+    const code =
+      status === 400 || status === 422
+        ? BaseErrorCode.VALIDATION_ERROR
+        : status === 401
+          ? BaseErrorCode.UNAUTHORIZED
+          : status === 403
+            ? BaseErrorCode.FORBIDDEN
+            : status === 404
+              ? BaseErrorCode.NOT_FOUND
+              : status === 409
+                ? BaseErrorCode.CONFLICT
+                : status === 429
+                  ? BaseErrorCode.RATE_LIMITED
+                  : status >= 500
+                    ? BaseErrorCode.SERVICE_UNAVAILABLE
+                    : BaseErrorCode.INTERNAL_ERROR;
+    const message =
+      typeof nativeError?.message === "string"
+        ? nativeError.message
+        : typeof payload?.message === "string"
+          ? payload.message
+          : `Operon Bridge request failed with HTTP ${status}.`;
+    throw new McpError(
+      code,
+      message,
+      this.requestContext(operation, {
+        httpStatus: status,
+        bridgeCode:
+          typeof nativeError?.code === "string" ? nativeError.code : undefined,
+      }),
+    );
+  }
+
   private openDb(): DatabaseSync {
     mkdirSync(path.dirname(this.dbPath), { recursive: true });
     const db = new DatabaseSync(this.dbPath);
@@ -1693,10 +1737,14 @@ export class OperonService {
         this.requestContext("operonQuerySavedFilter"),
       );
     }
-    const response = await this.getClient().post(
-      `${BRIDGE_PREFIX}/tasks/filter`,
-      params,
-    );
+    const response = await this.getClient()
+      .post(
+        `${BRIDGE_PREFIX}/tasks/filter`,
+        params,
+      )
+      .catch((error: unknown) =>
+        this.bridgeHttpError(error, "operonQuerySavedFilter"),
+      );
     const parsed = OperonBridgePageSchema.safeParse(response.data);
     if (!parsed.success) {
       throw new McpError(


### PR DESCRIPTION
## Summary

- add official Operon 3.2.x task-workflow saved-filter support to Bridge 0.6.0 with an exact `tasks.filter-query` grant, opaque pagination, and no catalog/private-API fallback;
- keep core reads and approved mutations available when the independent filter grant is pending;
- allowlist Operon 3.2.1 while retaining the complete 3.2.0 live-pilot evidence;
- preserve typed Bridge `404`/`422` filter failures instead of collapsing them to `INTERNAL_ERROR`;
- align the bilingual 23-tool contract, runtime matrix, CLI boundary, validation recipe, README, and public ÉLYSIA Task Governor profile.

## Why MCP instead of a CLI passthrough

The MCP exposes bounded schemas, exact capabilities, dry-run, revision locks, durable idempotency, postflight proof, and same-plan recovery. The CLI remains the broader operator/admin surface. No raw Markdown or private Operon API is introduced.

## Live evidence

On the ÉLYSIA vault with Operon 3.2.0 and Bridge 0.6.0:

- source remained `operon-live`, 25 tasks, validation `P0/P1/P2 = 0/0/0`;
- `fs_elysia_now` returned 11 tasks;
- two opaque three-item pages had no overlap;
- filter execution remained available during concurrent status and task-query refreshes;
- all intended capabilities were true except adoption, which remains unavailable in the official Developer API.

The code now accepts 3.2.1 by the unchanged official contract. A separate upstream Operon fix for its missing 3.2.1 Developer API Settings controls is tracked by hasanyilmaz/operon#145 and #146.

## Validation

- `npm run check:operon`
- `npm run test:runtime`
- `npm run test:profiles`
- `npm run test:tool-annotations`
- `npm run test:docs`
- `npm run test:package`
- `npm run audit:production` — 0 vulnerabilities
- `npm pack --dry-run`
- `git diff --check`

All passed on Windows.