### PR TITLE
Make Operon Bridge vacation-safe across compatible releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ explicitly governed access to configured documents outside the vault.
 | ----------------------- | ---------------------------------------------------------------------- | -------------------------------------------------- |
 | Notes                   | Read, list, search, update, frontmatter and tags                       | Vault; Local REST API for the full live surface    |
 | Bases and Canvas        | Bases query/write tools, format validation and bounded Canvas helpers  | Bases Bridge for live Bases                        |
-| Tasks                   | Obsidian Tasks-compatible list/query plus 23 governed Operon tools     | Operon 3.2.1 Developer API V1 through the Bridge   |
+| Tasks                   | Obsidian Tasks-compatible list/query plus 23 governed Operon tools     | Operon Developer API V1 through the Bridge         |
 | Semantic search         | Smart Connections index search with durable metadata cache             | `.smart-env` plus Ollama or OpenAI query embedding |
 | Runtime                 | Shared SQLite cache, health, maintenance, degraded mode and exclusions | Local filesystem                                   |
 | External documents      | Governed reads/handoff plus opt-in local move with exact link repair   | Allowlist; local stdio for move                    |
@@ -91,7 +91,7 @@ Enable only the surfaces you use:
   live note, metadata and tag operations;
 - bundled **Bases Bridge (REST)**: live `.base` operations;
 - **Smart Connections**: semantic index under `.smart-env`;
-- **Operon 3.2.1** and the bundled **Optimike Operon Bridge**: governed live
+- **Operon Developer API V1** and the bundled **Optimike Operon Bridge**: governed live
   task operations through the official Developer API V1;
 - Kairélys compatibility remains available as a bounded legacy/rollback path,
   not as the production owner;
@@ -120,9 +120,13 @@ Transition apply is available through the Bridge. Elevated or destructive plans
 still require fresh confirmation in the owning Obsidian vault window and fail
 closed after 45 seconds when no confirmation can be presented.
 
-Compatibility note: the adapter targets official Operon `3.2.1` and Bridge
-`0.6.0`; `3.2.0` remains explicitly compatible and is the version used by the
-complete live acceptance run. Modified-time frontmatter settlement and
+Compatibility note: the adapter negotiates Operon Developer API V1 with
+`contractVersion: 1` and `runtimeApi: 1`. Versions proven by a complete live
+acceptance run are `certified`; an otherwise unknown Operon release exposing
+the same validated contract is `compatible-provisional` instead of being
+blocked by its product version alone. Missing capabilities fail closed only for
+the affected tools, while known regressions remain explicitly denied.
+Operon `3.2.0` is the version used by the complete live acceptance run. Modified-time frontmatter settlement and
 multi-window consent were merged upstream before these releases. Saved-filter execution is available
 through the additive task-workflow Developer API after an exact grant, but the
 official API does not expose the saved-filter catalog: callers must supply an

--- a/docs/operon-mcp-contract.fr.md
+++ b/docs/operon-mcp-contract.fr.md
@@ -75,6 +75,25 @@ Un payload invalide, une pagination tronquée, une génération instable, des ID
 dupliqués, une version incompatible, un index non prêt ou une validation P0
 n’écrasent jamais le dernier snapshot sain.
 
+### Compatibilité « vacation-safe »
+
+L’admission d’Operon 3.x dépend du contrat runtime, pas d’une allowlist exacte
+de versions produit. Le Bridge exige l’accesseur officiel
+`getDeveloperApiV1`, négocie `contractVersion: 1` avec `runtimeApi: 1`, puis
+valide les capacités accordées, les schémas de réponse, la santé live, le
+catalogue, la pagination complète des tâches et les diagnostics d’index.
+
+Le statut distingue :
+
+- `certified` : release ayant passé l’acceptation live ;
+- `compatible-provisional` : release inconnue dont la frontière Developer API
+  V1 passe les mêmes contrôles runtime ;
+- `incompatible` : frontière absente, explicitement refusée ou invalide.
+
+Une régression comportementale connue peut rester bloquée par version et par
+opération. Une capacité optionnelle absente désactive seulement les outils qui
+en dépendent. Un futur contrat n’est jamais accepté silencieusement.
+
 `operon_query_saved_filter` est live-only et dépend d’une capacité native. Sur
 Operon officiel `3.2.0`, il utilise la Developer API task-workflow après un grant
 exact `tasks.filter-query`. L’appelant doit fournir un `filterSetId` exact :

--- a/docs/operon-mcp-contract.md
+++ b/docs/operon-mcp-contract.md
@@ -53,6 +53,23 @@ Every read response declares `source`, `stale`, snapshot time/age, Operon and Br
 
 SQLite cache state lives in `operon_task_snapshot` and `operon_snapshot_meta`. Malformed payloads, incomplete pagination, generation drift, duplicate IDs, incompatible versions, unready index, or P0 validation never replace the last known-good snapshot.
 
+### Vacation-safe compatibility
+
+Operon 3.x admission follows the runtime contract, not an exact product-version
+allowlist. The Bridge requires the official `getDeveloperApiV1` accessor,
+negotiates `contractVersion: 1` with `runtimeApi: 1`, and validates the granted
+capabilities, response shapes, live health, catalog, complete task pagination,
+and index diagnostics. Status distinguishes:
+
+- `certified`: a release that completed live acceptance;
+- `compatible-provisional`: an unknown release whose Developer API V1 boundary
+  passes the same runtime checks;
+- `incompatible`: an absent, denied, or invalid contract boundary.
+
+Known behavioral regressions may remain denied by exact version and operation.
+Missing optional capabilities disable only dependent tools. A future contract
+version is never accepted silently.
+
 `operon_query_saved_filter` is intentionally live-only and capability-gated. On
 official Operon `3.2.0`, it delegates to the additive task-workflow Developer
 API after an exact `tasks.filter-query` grant. The caller must supply an exact
@@ -71,7 +88,7 @@ The cached metadata also stores the configuration used for that snapshot. Tasks 
 
 ## Mutations
 
-Mutation tools call Bridge REST routes backed by the loaded engine's official mutation surface. Operon `3.2.0` uses Developer API V1 typed preview → apply plans with host-owned recovery; legacy Kairélys versions continue to use their Public API v1 contract. No route edits Markdown, calls `TaskWriter` directly, invokes UI commands, or reflects into private methods.
+Mutation tools call Bridge REST routes backed by the loaded engine's official mutation surface. Operon 3.x uses Developer API V1 typed preview → apply plans with host-owned recovery; legacy Kairélys versions continue to use their Public API v1 contract. No route edits Markdown, calls `TaskWriter` directly, invokes UI commands, or reflects into private methods.
 
 Common controls:
 

--- a/plugins/obsidian-operon-bridge/README.md
+++ b/plugins/obsidian-operon-bridge/README.md
@@ -15,7 +15,8 @@ If both plugins are enabled, the Bridge refuses to choose an owner. Disable one 
 
 - Obsidian Desktop
 - Operon `2.4.0` or `2.5.0` for legacy reads
-- Operon `3.2.1` for Developer API V1 reads and governed mutations (`3.0.1`, `3.1.0`, `3.1.1`, and `3.2.0` remain explicitly allowlisted)
+- Operon exposing the negotiated Developer API V1 contract (`contractVersion: 1`, `runtimeApi: 1`)
+- certified Developer API releases: `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, and `3.2.1`; later compatible releases are admitted provisionally by contract rather than product-version allowlist
 - Kairélys `2.5.1` through `2.5.3` (based on Operon `2.5.0`) and Kairélys `2.6.1` through `2.6.3`
   (based on Operon `2.6.0`) with Public API v1 for mutations
 - Obsidian Local REST API
@@ -33,6 +34,18 @@ the Bridge never retries blindly or falls back to Markdown/private APIs. File
 Task rename safety remains tracked in [#139](https://github.com/hasanyilmaz/operon/pull/139),
 and the transition edge in [#99](https://github.com/hasanyilmaz/operon/issues/99)
 and [#101](https://github.com/hasanyilmaz/operon/pull/101).
+
+Compatibility is reported explicitly:
+
+- `certified`: the release completed the Bridge acceptance path;
+- `compatible-provisional`: the product version is new, but the Developer API
+  V1 negotiation, capabilities, schemas, and live index checks pass;
+- `incompatible`: the contract boundary is absent, denied, or fails validation.
+
+The product version remains diagnostic metadata and may select a narrowly
+documented denylist entry. It is not the primary admission key for Operon 3.x.
+An unavailable optional capability removes only the dependent route; it does
+not tear down already verified core reads or mutations.
 
 ## Routes
 

--- a/plugins/obsidian-operon-bridge/manifest.json
+++ b/plugins/obsidian-operon-bridge/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "optimike-operon-bridge",
   "name": "Optimike Kairélys / Operon Bridge",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "minAppVersion": "1.7.2",
   "description": "Versioned Local REST API bridge from Kairélys or Operon's live task engine to Optimike Obsidian MCP.",
   "author": "Optimike",

--- a/plugins/obsidian-operon-bridge/package-lock.json
+++ b/plugins/obsidian-operon-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optimike-operon-bridge",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optimike-operon-bridge",
-      "version": "0.6.0",
+      "version": "0.7.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "esbuild": "^0.25.0",

--- a/plugins/obsidian-operon-bridge/package.json
+++ b/plugins/obsidian-operon-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optimike-operon-bridge",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/obsidian-operon-bridge/src/contract.test.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.test.ts
@@ -2,15 +2,17 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
 	OPERON_BRIDGE_BLOCKED_MUTATIONS,
+	OPERON_BRIDGE_DENIED_DEVELOPER_API_VERSIONS,
 	OPERON_BRIDGE_DEVELOPER_API_VERSIONS,
 	filterTasks,
 	isCanonicalVaultMarkdownPath,
 	isCanonicalVaultRelativePath,
-	isDeveloperApiVersion,
+	isCertifiedDeveloperApiVersion,
 	isIndexReady,
   isVersionCompatible,
   normalizeTask,
   resolvePriorityStableId,
+  resolveOperonCompatibility,
   paginateTasks,
   queryTasks,
   resolveWorkflow,
@@ -184,7 +186,7 @@ test("task revision is invariant across the unmanaged-properties projection", ()
   assert.equal(redacted.revision, projected.revision);
 });
 
-test("version compatibility is an explicit tested-version allowlist", () => {
+test("legacy version compatibility remains an explicit tested-version allowlist", () => {
   assert.equal(isVersionCompatible("operon", "2.4.0"), true);
   assert.equal(isVersionCompatible("operon", "2.5.0"), true);
   assert.equal(isVersionCompatible("operon", "3.0.0"), false);
@@ -205,7 +207,7 @@ test("version compatibility is an explicit tested-version allowlist", () => {
   assert.equal(isVersionCompatible("kairelys", "2.6.4"), false);
 });
 
-test("official Developer API versions remain explicit and only unverified mutations stay fail-closed", () => {
+test("certified Developer API versions remain explicit and only unverified mutations stay fail-closed", () => {
 	assert.deepEqual(OPERON_BRIDGE_DEVELOPER_API_VERSIONS, [
 		"3.0.1",
 		"3.1.0",
@@ -213,16 +215,60 @@ test("official Developer API versions remain explicit and only unverified mutati
 		"3.2.0",
 		"3.2.1",
 	]);
-	assert.equal(isDeveloperApiVersion("3.0.1"), true);
-	assert.equal(isDeveloperApiVersion("3.1.0"), true);
-	assert.equal(isDeveloperApiVersion("3.1.1"), true);
-	assert.equal(isDeveloperApiVersion("3.2.0"), true);
-	assert.equal(isDeveloperApiVersion("3.2.1"), true);
+	assert.equal(isCertifiedDeveloperApiVersion("3.0.1"), true);
+	assert.equal(isCertifiedDeveloperApiVersion("3.1.0"), true);
+	assert.equal(isCertifiedDeveloperApiVersion("3.1.1"), true);
+	assert.equal(isCertifiedDeveloperApiVersion("3.2.0"), true);
+	assert.equal(isCertifiedDeveloperApiVersion("3.2.1"), true);
 	assert.deepEqual(OPERON_BRIDGE_BLOCKED_MUTATIONS["3.0.1"], ["transition"]);
 	assert.deepEqual(OPERON_BRIDGE_BLOCKED_MUTATIONS["3.1.0"], []);
 	assert.deepEqual(OPERON_BRIDGE_BLOCKED_MUTATIONS["3.1.1"], []);
 	assert.deepEqual(OPERON_BRIDGE_BLOCKED_MUTATIONS["3.2.0"], []);
 	assert.deepEqual(OPERON_BRIDGE_BLOCKED_MUTATIONS["3.2.1"], []);
+});
+
+test("unknown Operon versions are admitted provisionally by the Developer API V1 contract", () => {
+	assert.deepEqual(
+		resolveOperonCompatibility({
+			pluginId: "operon",
+			version: "3.3.0",
+			hasDeveloperApiV1: true,
+		}),
+		{
+			state: "compatible-provisional",
+			admission: "developer-api-v1",
+			reason:
+				"The loaded Operon version is not yet certified, but it exposes the negotiated Developer API V1 boundary; runtime capability and schema checks remain mandatory.",
+		},
+	);
+	assert.equal(
+		resolveOperonCompatibility({
+			pluginId: "operon",
+			version: "3.3.0",
+			hasDeveloperApiV1: false,
+		}).state,
+		"incompatible",
+	);
+});
+
+test("certified and denied Developer API versions keep deterministic admission", () => {
+	assert.equal(
+		resolveOperonCompatibility({
+			pluginId: "operon",
+			version: "3.2.1",
+			hasDeveloperApiV1: true,
+		}).state,
+		"certified",
+	);
+	assert.match(OPERON_BRIDGE_DENIED_DEVELOPER_API_VERSIONS["3.0.0"] ?? "", /predates/u);
+	assert.equal(
+		resolveOperonCompatibility({
+			pluginId: "operon",
+			version: "3.0.0",
+			hasDeveloperApiV1: true,
+		}).state,
+		"incompatible",
+	);
 });
 
 test("mutation paths are rejected instead of normalized at the Bridge boundary", () => {

--- a/plugins/obsidian-operon-bridge/src/contract.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.ts
@@ -7,10 +7,46 @@ export const OPERON_BRIDGE_DEVELOPER_API_VERSIONS = [
 	"3.2.0",
 	OPERON_BRIDGE_TESTED_VERSION,
 ] as const;
-export const OPERON_BRIDGE_SUPPORTED_VERSIONS = {
-	operon: ["2.4.0", "2.5.0", ...OPERON_BRIDGE_DEVELOPER_API_VERSIONS],
+export const OPERON_BRIDGE_LEGACY_VERSIONS = {
+	operon: ["2.4.0", "2.5.0"],
 	kairelys: ["2.5.1", "2.5.2", "2.5.3", "2.6.1", "2.6.2", "2.6.3"],
 } as const;
+
+export const OPERON_BRIDGE_SUPPORTED_VERSIONS = {
+	operon: [
+		...OPERON_BRIDGE_LEGACY_VERSIONS.operon,
+		...OPERON_BRIDGE_DEVELOPER_API_VERSIONS,
+	],
+	kairelys: OPERON_BRIDGE_LEGACY_VERSIONS.kairelys,
+} as const;
+
+export const OPERON_BRIDGE_DEVELOPER_API_CONTRACT = {
+	contractVersion: 1,
+	runtimeApi: { min: 1, max: 1 },
+} as const;
+
+export const OPERON_BRIDGE_DENIED_DEVELOPER_API_VERSIONS: Readonly<
+	Record<string, string>
+> = {
+	"3.0.0":
+		"Operon 3.0.0 predates the accepted Developer API V1 integration baseline.",
+};
+
+export type OperonCompatibilityState =
+	| "certified"
+	| "compatible-provisional"
+	| "incompatible";
+
+export type OperonCompatibilityAdmission =
+	| "developer-api-v1"
+	| "legacy-version"
+	| "none";
+
+export interface OperonCompatibilityDecision {
+	state: OperonCompatibilityState;
+	admission: OperonCompatibilityAdmission;
+	reason: string;
+}
 
 // Fail closed only for upstream mutation paths that have not produced a
 // trustworthy terminal or durable recovery result in live acceptance.
@@ -24,8 +60,58 @@ export const OPERON_BRIDGE_BLOCKED_MUTATIONS = {
 	"3.2.1": [],
 } as const;
 
-export function isDeveloperApiVersion(version: string): boolean {
+export function isCertifiedDeveloperApiVersion(version: string): boolean {
 	return (OPERON_BRIDGE_DEVELOPER_API_VERSIONS as readonly string[]).includes(version.trim());
+}
+
+export function resolveOperonCompatibility(options: {
+	pluginId: "kairelys" | "operon";
+	version: string;
+	hasDeveloperApiV1: boolean;
+}): OperonCompatibilityDecision {
+	const version = options.version.trim();
+	if (options.pluginId === "operon" && options.hasDeveloperApiV1) {
+		const deniedReason = OPERON_BRIDGE_DENIED_DEVELOPER_API_VERSIONS[version];
+		if (deniedReason) {
+			return {
+				state: "incompatible",
+				admission: "none",
+				reason: deniedReason,
+			};
+		}
+		if (isCertifiedDeveloperApiVersion(version)) {
+			return {
+				state: "certified",
+				admission: "developer-api-v1",
+				reason: `Operon ${version} is certified against Developer API V1.`,
+			};
+		}
+		return {
+			state: "compatible-provisional",
+			admission: "developer-api-v1",
+			reason:
+				"The loaded Operon version is not yet certified, but it exposes the negotiated Developer API V1 boundary; runtime capability and schema checks remain mandatory.",
+		};
+	}
+
+	if (
+		(OPERON_BRIDGE_LEGACY_VERSIONS[options.pluginId] as readonly string[]).includes(version)
+	) {
+		return {
+			state: "certified",
+			admission: "legacy-version",
+			reason: `${options.pluginId} ${version} is certified on the bounded legacy adapter.`,
+		};
+	}
+
+	return {
+		state: "incompatible",
+		admission: "none",
+		reason:
+			options.pluginId === "operon"
+				? "Operon does not expose the accepted Developer API V1 boundary and is not a certified legacy version."
+				: "The loaded Kairélys version is outside the certified legacy compatibility set.",
+	};
 }
 
 export function isCanonicalVaultRelativePath(value: unknown): value is string {

--- a/plugins/obsidian-operon-bridge/src/developer-api-adapter.test.ts
+++ b/plugins/obsidian-operon-bridge/src/developer-api-adapter.test.ts
@@ -6,7 +6,7 @@ const consumer = {
   manifest: {
     id: "optimike-operon-bridge",
     name: "Optimike Operon Bridge",
-    version: "0.6.0",
+    version: "0.7.0",
   },
 };
 
@@ -359,6 +359,31 @@ test("Operon 3 Developer API adapter stays unavailable when the host grant is pe
   );
   assert.equal(adapter.indexer.taskCount, 0);
   assert.equal(adapter.status.reason, "grant-pending");
+});
+
+test("Operon 3 Developer API adapter turns malformed or throwing negotiation into diagnostics", async () => {
+  const throwing = new OperonDeveloperApiRuntimeAdapter(consumer, {
+    getDeveloperApiV1: () => {
+      throw new Error("contract handshake failed");
+    },
+  });
+  assert.equal(await throwing.refresh(), false);
+  assert.equal(throwing.status.error?.reason, "contract handshake failed");
+  assert.equal(throwing.negotiatedContractState, "invalid");
+
+  const incomplete = new OperonDeveloperApiRuntimeAdapter(consumer, {
+    getDeveloperApiV1: () => ({
+      ok: true,
+      status: readyStatus(),
+      api: { hasCapability: () => true },
+    }),
+  });
+  assert.equal(await incomplete.refresh(), false);
+  assert.equal(
+    incomplete.status.error?.reason,
+    "Operon Developer API V1 negotiation returned an incomplete runtime contract.",
+  );
+  assert.equal(incomplete.negotiatedContractState, "invalid");
 });
 
 test("Operon 3 Developer API adapter keeps approved capabilities usable with a partial grant", async () => {

--- a/plugins/obsidian-operon-bridge/src/developer-api-adapter.test.ts
+++ b/plugins/obsidian-operon-bridge/src/developer-api-adapter.test.ts
@@ -361,6 +361,70 @@ test("Operon 3 Developer API adapter stays unavailable when the host grant is pe
   assert.equal(adapter.status.reason, "grant-pending");
 });
 
+test("Operon 3 Developer API adapter retries the bounded cache-ready startup window", async () => {
+  let healthCalls = 0;
+  const api = {
+    hasCapability: (name: string) =>
+      [
+        "system.health",
+        "system.capabilities",
+        "catalog.read",
+        "tasks.read",
+        "tasks.query",
+      ].includes(name),
+    channel: {
+      status: () =>
+        healthCalls === 0
+          ? {
+              ...readyStatus(),
+              availability: "degraded",
+              reason: "cache-ready",
+              retryAfterMs: 0,
+            }
+          : readyStatus(),
+    },
+    system: {
+      health: async () => {
+        healthCalls += 1;
+        return healthCalls === 1
+          ? { ok: false }
+          : {
+              ok: true,
+              contextRevision: { index: { ramGeneration: 34 } },
+            };
+      },
+      capabilities: () => [],
+      diagnostics: async () => ({ ok: true }),
+    },
+    catalog: {
+      snapshot: async () => ({
+        ok: true,
+        settingsFingerprint: "settings-34",
+        taxonomy: { pipelines: [], priorities: [] },
+        fields: [],
+        policies: { creation: {} },
+      }),
+    },
+    tasks: {
+      query: async () => ({
+        ok: true,
+        tasks: [],
+        page: { truncated: false },
+        contextRevision: { index: { ramGeneration: 34 } },
+      }),
+    },
+  };
+  const operon = {
+    getDeveloperApiV1: () => ({ ok: true, status: api.channel.status(), api }),
+  };
+  const adapter = new OperonDeveloperApiRuntimeAdapter(consumer, operon);
+
+  assert.equal(await adapter.refresh(), true);
+  assert.equal(healthCalls, 2);
+  assert.equal(adapter.indexer.getGeneration(), 34);
+  assert.equal(adapter.status.reason, "ready");
+});
+
 test("Operon 3 Developer API adapter turns malformed or throwing negotiation into diagnostics", async () => {
   const throwing = new OperonDeveloperApiRuntimeAdapter(consumer, {
     getDeveloperApiV1: () => {

--- a/plugins/obsidian-operon-bridge/src/developer-api-adapter.ts
+++ b/plugins/obsidian-operon-bridge/src/developer-api-adapter.ts
@@ -884,6 +884,9 @@ function isDeveloperApiAccessor(value: unknown): value is DeveloperApiAccessor {
   return typeof candidate.getDeveloperApiV1 === "function";
 }
 
+const STARTUP_REFRESH_RETRY_LIMIT = 2;
+const STARTUP_REFRESH_RETRY_MAX_MS = 1_500;
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === "object" && !Array.isArray(value));
 }
@@ -997,12 +1000,43 @@ export class OperonDeveloperApiRuntimeAdapter {
 
   async refresh(includeMutationCapabilities = false): Promise<boolean> {
     if (this.refreshInFlight) return this.refreshInFlight;
-    this.refreshInFlight = this.refreshInternal(
+    this.refreshInFlight = this.refreshWithStartupRetry(
       includeMutationCapabilities,
     ).finally(() => {
       this.refreshInFlight = null;
     });
     return this.refreshInFlight;
+  }
+
+  private async refreshWithStartupRetry(
+    includeMutationCapabilities: boolean,
+  ): Promise<boolean> {
+    for (let attempt = 0; attempt <= STARTUP_REFRESH_RETRY_LIMIT; attempt += 1) {
+      if (await this.refreshInternal(includeMutationCapabilities)) return true;
+      const retryAfterMs = this.startupRetryDelayMs();
+      if (retryAfterMs === null || attempt === STARTUP_REFRESH_RETRY_LIMIT)
+        return false;
+      await new Promise<void>((resolve) => {
+        globalThis.setTimeout(resolve, retryAfterMs);
+      });
+    }
+    return false;
+  }
+
+  private startupRetryDelayMs(): number | null {
+    if (
+      this.channelStatus.availability !== "degraded" ||
+      this.channelStatus.reason !== "cache-ready" ||
+      this.channelStatus.admission?.reads !== true
+    ) {
+      return null;
+    }
+    const requestedDelay = Number(this.channelStatus.retryAfterMs ?? 500);
+    if (!Number.isFinite(requestedDelay)) return 500;
+    return Math.min(
+      STARTUP_REFRESH_RETRY_MAX_MS,
+      Math.max(0, Math.trunc(requestedDelay)),
+    );
   }
 
   private async refreshInternal(

--- a/plugins/obsidian-operon-bridge/src/developer-api-adapter.ts
+++ b/plugins/obsidian-operon-bridge/src/developer-api-adapter.ts
@@ -1,4 +1,5 @@
 import {
+	OPERON_BRIDGE_DEVELOPER_API_CONTRACT,
   type OperonSemanticConfiguration,
   type RuntimeIndexDiagnostics,
   type RuntimeIndexedTask,
@@ -883,6 +884,31 @@ function isDeveloperApiAccessor(value: unknown): value is DeveloperApiAccessor {
   return typeof candidate.getDeveloperApiV1 === "function";
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function isDeveloperApiV1(value: unknown): value is DeveloperApiV1 {
+  if (!isRecord(value)) return false;
+  const channel = isRecord(value.channel) ? value.channel : null;
+  const system = isRecord(value.system) ? value.system : null;
+  const catalog = isRecord(value.catalog) ? value.catalog : null;
+  const tasks = isRecord(value.tasks) ? value.tasks : null;
+  return Boolean(
+    typeof value.hasCapability === "function" &&
+      channel &&
+      typeof channel.status === "function" &&
+      system &&
+      typeof system.health === "function" &&
+      typeof system.capabilities === "function" &&
+      typeof system.diagnostics === "function" &&
+      catalog &&
+      typeof catalog.snapshot === "function" &&
+      tasks &&
+      typeof tasks.query === "function",
+  );
+}
+
 function isTaskWorkflowDeveloperApiAccessor(
   value: unknown,
 ): value is TaskWorkflowDeveloperApiAccessor {
@@ -945,6 +971,7 @@ export class OperonDeveloperApiRuntimeAdapter {
   private filterQueryApi: TaskWorkflowDeveloperApiV1 | null = null;
   private grantedCapabilities: ReadonlySet<string> | null = null;
   private refreshInFlight: Promise<boolean> | null = null;
+  private contractState: "unverified" | "valid" | "invalid" = "unverified";
 
   constructor(
     private readonly consumerPlugin: DeveloperApiConsumerPlugin,
@@ -962,6 +989,10 @@ export class OperonDeveloperApiRuntimeAdapter {
 
   get status(): DeveloperApiChannelStatus {
     return this.channelStatus;
+  }
+
+  get negotiatedContractState(): "unverified" | "valid" | "invalid" {
+    return this.contractState;
   }
 
   async refresh(includeMutationCapabilities = false): Promise<boolean> {
@@ -1338,8 +1369,7 @@ export class OperonDeveloperApiRuntimeAdapter {
     const access = this.taskWorkflowAccessor.getTaskWorkflowDeveloperApiV1(
       this.consumerPlugin,
       {
-        contractVersion: 1,
-        runtimeApi: { min: 1, max: 1 },
+		...OPERON_BRIDGE_DEVELOPER_API_CONTRACT,
         requestedCapabilities: ["tasks.filter-query"],
       },
     );
@@ -1368,25 +1398,63 @@ export class OperonDeveloperApiRuntimeAdapter {
     updateStatus = true,
   ): DeveloperApiV1 | null {
     if (!this.accessor) return null;
-    const access = this.accessor.getDeveloperApiV1(this.consumerPlugin, {
-      contractVersion: 1,
-      runtimeApi: { min: 1, max: 1 },
-      requestedCapabilities,
-    });
-    if (updateStatus) this.channelStatus = access.status;
-    const grant = grantedCapabilitiesFromStatus(access.status);
-    if (grant) this.grantedCapabilities = grant;
-    if (!access.ok || !access.api) {
+    let rawAccess: unknown;
+    try {
+      rawAccess = this.accessor.getDeveloperApiV1(this.consumerPlugin, {
+        ...OPERON_BRIDGE_DEVELOPER_API_CONTRACT,
+        requestedCapabilities,
+      });
+    } catch (error) {
+      this.contractState = "invalid";
+      this.channelStatus = {
+        error: {
+          reason:
+            error instanceof Error
+              ? error.message
+              : "Operon Developer API V1 negotiation threw an unknown error.",
+        },
+      };
       return null;
     }
+    if (!isRecord(rawAccess)) {
+      this.contractState = "invalid";
+      this.channelStatus = {
+        error: {
+          reason: "Operon Developer API V1 negotiation returned an invalid result.",
+        },
+      };
+      return null;
+    }
+    const status = isRecord(rawAccess.status)
+      ? (rawAccess.status as DeveloperApiChannelStatus)
+      : {};
+    if (updateStatus) this.channelStatus = status;
+    const grant = grantedCapabilitiesFromStatus(status);
+    if (grant) this.grantedCapabilities = grant;
+    if (rawAccess.ok !== true) {
+      return null;
+    }
+    if (!isDeveloperApiV1(rawAccess.api)) {
+      this.contractState = "invalid";
+      this.channelStatus = {
+        ...status,
+        error: {
+          reason:
+            "Operon Developer API V1 negotiation returned an incomplete runtime contract.",
+        },
+      };
+      return null;
+    }
+    const api = rawAccess.api;
+    this.contractState = "valid";
     // Keep the channel status aligned with the strongest successful session.
     // Mutation probes intentionally avoid replacing useful read status when a
     // capability is unavailable, but a granted write session must be visible
     // to diagnostics instead of leaving the baseline reads-only admission.
-    if (!updateStatus && access.status.admission?.writes === true) {
-      this.channelStatus = access.status;
+    if (!updateStatus && status.admission?.writes === true) {
+      this.channelStatus = status;
     }
-    return access.api;
+    return api;
   }
 
   private async readAllTasks(api: DeveloperApiV1): Promise<{

--- a/plugins/obsidian-operon-bridge/src/main.ts
+++ b/plugins/obsidian-operon-bridge/src/main.ts
@@ -940,7 +940,7 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
         pluginId: runtime?.pluginId ?? loadedEngine?.id ?? null,
         pluginName: runtime?.pluginName ?? loadedEngine?.name ?? null,
         version: runtime?.version ?? (loadedVersion || null),
-        compatible: Boolean(runtime?.compatible),
+        compatible: Boolean(runtime?.compatible && !contractInvalid),
         compatibilityState: reportedCompatibilityState,
         compatibilityAdmission: reportedCompatibilityAdmission,
         compatibilityReason: reportedCompatibilityReason,

--- a/plugins/obsidian-operon-bridge/src/main.ts
+++ b/plugins/obsidian-operon-bridge/src/main.ts
@@ -1,18 +1,17 @@
 import { App, Plugin, PluginSettingTab, Setting, TFile } from "obsidian";
 import {
   OPERON_BRIDGE_CONTRACT_VERSION,
-  OPERON_BRIDGE_SUPPORTED_VERSIONS,
+  OPERON_BRIDGE_LEGACY_VERSIONS,
   OPERON_BRIDGE_BLOCKED_MUTATIONS,
   OPERON_BRIDGE_TESTED_VERSION,
   isIndexReady,
-  isDeveloperApiVersion,
   isCanonicalVaultRelativePath,
   isCanonicalVaultMarkdownPath,
   mutationPathValidationError,
+  resolveOperonCompatibility,
   resolveMutationPreflight,
   resolvePriorityStableId,
   workflowStatusMatches,
-  isVersionCompatible,
   normalizeTask,
   queryTasks,
   settingsSignature,
@@ -26,6 +25,8 @@ import {
   type RuntimePriorityDefinition,
   type RuntimeFileTaskTemplate,
   type OperonBridgeConfiguration,
+  type OperonCompatibilityAdmission,
+  type OperonCompatibilityState,
   type OperonSemanticConfiguration,
   type OperonWorkflowTaxonomy,
   type CachedMutation,
@@ -82,6 +83,9 @@ interface OperonRuntime {
   api: OperonPublicApiV1 | null;
   version: string;
   compatible: boolean;
+  compatibilityState: OperonCompatibilityState;
+  compatibilityAdmission: OperonCompatibilityAdmission;
+  compatibilityReason: string;
   indexer: {
     getAllTasks: () => RuntimeIndexedTask[];
     getTask: (operonId: string) => RuntimeIndexedTask | undefined;
@@ -438,11 +442,15 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
     if (!resolved) return null;
     const plugin = resolved.plugin as any;
     const version = String(plugin?.manifest?.version ?? "").trim();
-    if (
+    const hasDeveloperApiV1 =
       resolved.id === "operon" &&
-      isDeveloperApiVersion(version) &&
-      OperonDeveloperApiRuntimeAdapter.canHandle(plugin)
-    ) {
+      OperonDeveloperApiRuntimeAdapter.canHandle(plugin);
+    const compatibility = resolveOperonCompatibility({
+      pluginId: resolved.id,
+      version,
+      hasDeveloperApiV1,
+    });
+    if (resolved.id === "operon" && hasDeveloperApiV1) {
       const developerApi = this.getDeveloperApiAdapter(plugin);
       return {
         plugin,
@@ -450,7 +458,10 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
         pluginName: resolved.name,
         api: null,
         version,
-        compatible: true,
+        compatible: compatibility.state !== "incompatible",
+        compatibilityState: compatibility.state,
+        compatibilityAdmission: compatibility.admission,
+        compatibilityReason: compatibility.reason,
         indexer: developerApi.indexer,
         pipelines: developerApi.pipelines,
         keyMappings: developerApi.keyMappings,
@@ -460,7 +471,11 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
         developerApi,
       };
     }
-    if (resolved.id === "operon" && isDeveloperApiVersion(version)) {
+    if (
+      resolved.id === "operon" &&
+      compatibility.state === "incompatible" &&
+      !plugin?.indexer
+    ) {
       return null;
     }
     const indexer = plugin?.indexer;
@@ -479,7 +494,10 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       pluginName: resolved.name,
       api: this.readPublicApi(plugin),
       version,
-      compatible: isVersionCompatible(resolved.id, version),
+      compatible: compatibility.state !== "incompatible",
+      compatibilityState: compatibility.state,
+      compatibilityAdmission: compatibility.admission,
+      compatibilityReason: compatibility.reason,
       indexer,
       pipelines: Array.isArray(plugin?.settings?.pipelines)
         ? plugin.settings.pipelines
@@ -686,7 +704,7 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
         runtime.developerApi!.hasMutationCapability(capability);
       return {
         status: true,
-        configuration: Boolean(runtime.compatible),
+        configuration: readable,
         list: readable,
         get: readable,
         query: readable,
@@ -851,6 +869,22 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
 
   private async statusPayload(): Promise<Record<string, unknown>> {
     const runtime = this.getOperonRuntime();
+    const loadedEngine = runtime
+      ? null
+      : resolveTaskEnginePlugin((this.app as any).plugins);
+    const loadedVersion = String(
+      (loadedEngine?.plugin as { manifest?: { version?: unknown } } | undefined)
+        ?.manifest?.version ?? "",
+    ).trim();
+    const unavailableCompatibility = loadedEngine
+      ? resolveOperonCompatibility({
+          pluginId: loadedEngine.id,
+          version: loadedVersion,
+          hasDeveloperApiV1:
+            loadedEngine.id === "operon" &&
+            OperonDeveloperApiRuntimeAdapter.canHandle(loadedEngine.plugin),
+        })
+      : null;
     const indexState = await this.indexState(runtime);
     const registry = runtime?.indexer.getDuplicateRegistry?.();
     const taskCount = runtime
@@ -862,8 +896,30 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       indexState.ready && indexState.diagnostics?.taskCount === taskCount,
     );
     const capabilities = this.capabilities(runtime, ready);
+    const contractInvalid =
+      runtime?.developerApi?.negotiatedContractState === "invalid";
+    const compatibilityReason = contractInvalid
+      ? (runtime?.developerApi?.status.error?.reason ??
+        "Operon Developer API V1 contract validation failed.")
+      : (runtime?.compatibilityReason ??
+        "No compatible task-engine runtime is currently available.");
+    const reportedCompatibilityState = contractInvalid
+      ? "incompatible"
+      : (runtime?.compatibilityState ??
+        unavailableCompatibility?.state ??
+        "incompatible");
+    const reportedCompatibilityAdmission = contractInvalid
+      ? "none"
+      : (runtime?.compatibilityAdmission ??
+        unavailableCompatibility?.admission ??
+        "none");
+    const reportedCompatibilityReason = contractInvalid
+      ? compatibilityReason
+      : (runtime?.compatibilityReason ??
+        unavailableCompatibility?.reason ??
+        compatibilityReason);
     return {
-      ok: Boolean(runtime?.compatible && ready),
+      ok: Boolean(runtime?.compatible && !contractInvalid && ready),
       contractVersion: OPERON_BRIDGE_CONTRACT_VERSION,
       bridge: {
         id: this.manifest.id,
@@ -880,15 +936,16 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
             : "read-only",
       },
       operon: {
-        present: Boolean(runtime),
-        pluginId: runtime?.pluginId ?? null,
-        pluginName: runtime?.pluginName ?? null,
-        version: runtime?.version ?? null,
+        present: Boolean(runtime || loadedEngine),
+        pluginId: runtime?.pluginId ?? loadedEngine?.id ?? null,
+        pluginName: runtime?.pluginName ?? loadedEngine?.name ?? null,
+        version: runtime?.version ?? (loadedVersion || null),
         compatible: Boolean(runtime?.compatible),
+        compatibilityState: reportedCompatibilityState,
+        compatibilityAdmission: reportedCompatibilityAdmission,
+        compatibilityReason: reportedCompatibilityReason,
         testedAgainst: OPERON_BRIDGE_TESTED_VERSION,
-        supportedRange: Object.entries(OPERON_BRIDGE_SUPPORTED_VERSIONS)
-          .map(([pluginId, versions]) => `${pluginId}: ${versions.join(", ")}`)
-          .join("; "),
+        supportedRange: `operon: Developer API V1 (contractVersion 1, runtimeApi 1) or certified legacy ${OPERON_BRIDGE_LEGACY_VERSIONS.operon.join(", ")}; kairelys legacy: ${OPERON_BRIDGE_LEGACY_VERSIONS.kairelys.join(", ")}`,
       },
       developerApi: runtime?.developerApi?.status ?? null,
       index: {
@@ -918,11 +975,7 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
     }
     if (!runtime.compatible) {
       throw new Error(
-        `${runtime.pluginName} ${runtime.version || "unknown"} is not in the tested Bridge allowlist (${Object.entries(
-          OPERON_BRIDGE_SUPPORTED_VERSIONS,
-        )
-          .map(([pluginId, versions]) => `${pluginId}: ${versions.join(", ")}`)
-          .join("; ")}).`,
+        `${runtime.pluginName} ${runtime.version || "unknown"} is incompatible with the Bridge: ${runtime.compatibilityReason}`,
       );
     }
     return runtime;
@@ -2354,7 +2407,12 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       .get(async (_req: any, res: any) => {
         try {
           const runtime = this.requireRuntime();
-          await this.indexState(runtime);
+          const state = await this.indexState(runtime);
+          if (!state.ready) {
+            throw new Error(
+              "Operon Developer API V1 negotiation or live verification did not produce a ready configuration.",
+            );
+          }
           sendJson(res, 200, this.configurationPayload(runtime));
         } catch (error) {
           sendJson(

--- a/scripts/test-operon-contract.mjs
+++ b/scripts/test-operon-contract.mjs
@@ -193,6 +193,9 @@ const status = OperonStatusSchema.parse({
     present: true,
     version: "2.4.0",
     compatible: true,
+    compatibilityState: "certified",
+    compatibilityAdmission: "legacy-version",
+    compatibilityReason: "Certified fixture runtime.",
     testedAgainst: "2.4.0",
     supportedRange: "2.4.0",
   },
@@ -231,6 +234,17 @@ const status = OperonStatusSchema.parse({
   limitations: ["read-only"],
 });
 assert.equal(status.index.generation, 42);
+const {
+  compatibilityState: _legacyCompatibilityState,
+  compatibilityAdmission: _legacyCompatibilityAdmission,
+  compatibilityReason: _legacyCompatibilityReason,
+  ...legacyOperonStatus
+} = status.operon;
+const legacyBridgeStatus = OperonStatusSchema.parse({
+  ...status,
+  operon: legacyOperonStatus,
+});
+assert.equal(legacyBridgeStatus.operon.compatibilityState, undefined);
 
 const bridgePage = OperonBridgePageSchema.parse({
   ok: true,

--- a/scripts/test-operon-service.mjs
+++ b/scripts/test-operon-service.mjs
@@ -189,6 +189,14 @@ function statusPayload() {
       present: state.mode !== "absent",
       version: "2.4.0",
       compatible: state.mode !== "incompatible",
+      compatibilityState:
+        state.mode === "incompatible" ? "incompatible" : "certified",
+      compatibilityAdmission:
+        state.mode === "incompatible" ? "none" : "legacy-version",
+      compatibilityReason:
+        state.mode === "incompatible"
+          ? "Incompatible fixture runtime."
+          : "Certified fixture runtime.",
       testedAgainst: "2.4.0",
       supportedRange: "2.4.0",
     },

--- a/src/services/operon/contract.ts
+++ b/src/services/operon/contract.ts
@@ -270,6 +270,17 @@ export const OperonStatusSchema = z.object({
     pluginName: z.string().nullable().optional(),
     version: z.string().nullable(),
     compatible: z.boolean(),
+    compatibilityState: z.enum([
+      "certified",
+      "compatible-provisional",
+      "incompatible",
+    ]).optional(),
+    compatibilityAdmission: z.enum([
+      "developer-api-v1",
+      "legacy-version",
+      "none",
+    ]).optional(),
+    compatibilityReason: z.string().min(1).optional(),
     testedAgainst: z.string(),
     supportedRange: z.string(),
   }),


### PR DESCRIPTION
## Summary

- admit unknown Operon 3.x releases by negotiated Developer API V1 contract instead of an exact product-version allowlist
- expose `certified`, `compatible-provisional`, and `incompatible` diagnostics
- keep exact version denylisting for proven regressions and capability-level fail-closed behavior
- validate malformed or throwing V1 negotiation before reads or mutations
- bump the bundled Bridge to `0.7.0` and document the vacation-safe contract in EN/FR

## Safety boundary

- no Markdown, private API, or command fallback
- writes still require the existing Bridge setting, MCP opt-in, grants, sealed preview/apply, revision locking, idempotency, postflight, and recovery
- no live plugin installation or Operon upgrade is included

## Verification

- `plugins/obsidian-operon-bridge`: `npm run check` (32 tests, typecheck, build)
- root: `npm run build`
- root: `npm run test:operon-contract`
- root: `npm run test:operon-service`
- root: `npm run test:runtime`
- root: `npm run test:docs`
- root: `npm pack --dry-run`
- root: `npm audit --omit=dev` (0 vulnerabilities)

## Live baseline preserved

Before this PR: Operon `3.2.0`, Bridge `0.6.0`, 30 tasks, non-stale snapshot, `P0/P1/P2 = 0/0/0`, no pending recoveries. The candidate has not been installed live.