### PR TITLE
Add common governed operation runtime

### DIFF
--- a/docs/adr/ADR-Common-Operation-Runtime.md
+++ b/docs/adr/ADR-Common-Operation-Runtime.md
@@ -1,0 +1,108 @@
+# ADR: Common governed operation runtime
+
+## Status
+
+Accepted for internal adapter pilots. The first implementation binds the existing
+`external_move` transaction to this contract; it does not add a generic public
+write tool or widen any write permission.
+
+## Context
+
+Operon already provides sealed mutation plans, durable receipts, idempotent
+replay, postflight verification, and same-plan recovery. The MCP's
+`external_move` path independently provides immutable inventory, CAS
+preconditions, a SQLite WAL journal, and compensation. Other Obsidian writes do
+not all share those guarantees, especially when Local REST cannot atomically
+enforce `If-Match`.
+
+Keeping a separate transaction vocabulary for every writer makes uncertain
+outcomes harder to reconcile and encourages callers to retry the original
+mutation. A common control-plane contract is needed without replacing domain
+validation or pretending that every backend has the same atomicity.
+
+## Decision
+
+Governed non-Operon writes may implement the internal `OperationAdapter`
+contract with four transitions:
+
+1. `plan` admits a canonical request, assigns a server `operationId`, binds the
+   caller's `idempotencyKey`, and returns an opaque `planRef` plus a stable
+   `planDigest`.
+2. `apply` accepts only that sealed `planRef` and the matching idempotency key.
+   The adapter must durably record the applying state before its first effect
+   and revalidate all backend-specific preconditions.
+3. `status` reads durable state and evidence without executing an effect.
+4. `recover` reconciles or compensates the exact same plan. It never accepts a
+   replacement mutation specification.
+
+The common state model separates progress from result:
+
+- `phase`: `planned | applying | terminal`;
+- `outcome`: `committed | conflict | rejected | failed | outcome_unknown |
+compensated | expired`, or `null` before a terminal result is known.
+
+Every receipt carries the contract version, operation and idempotency
+identities, operation kind, sealed plan identity, logical backend and target,
+before proof, optional after proof, postflight state, timestamps, and an exact
+recovery reference when recovery is allowed.
+
+## Identifier rules
+
+- `idempotencyKey` belongs to the caller and binds one canonical request.
+- `operationId` belongs to the server and identifies the durable operation.
+- `planRef` is an opaque adapter-bound handle; callers must not parse or rebuild
+  it.
+- `planDigest` is a stable digest of immutable admitted inputs and proofs. It is
+  not an authorization token.
+- `recoveryRef` points to the same plan. Recovery never creates a new plan.
+
+## Adapter requirements
+
+An adapter must:
+
+- validate its backend result at runtime before projecting a common receipt;
+- preserve the backend's stricter capability, write-mode, consent, and CAS
+  gates;
+- persist intent and intermediate state before effects;
+- make `status` read-only and replay-safe;
+- return `outcome_unknown` rather than invite blind retry when final state
+  cannot be proven;
+- expose only the evidence the backend can actually prove.
+
+Domain tools remain the public MCP surface for now. A future generic operation
+surface may be added only after at least two adapters demonstrate the same
+semantics without weakening their domain contracts.
+
+## First adapter
+
+`ExternalMoveOperationAdapter` reuses the existing `external_move` coordinator
+and journal as the sole durable authority. It maps the existing plan ID to an
+opaque versioned plan reference, binds the plan digest to source CAS, complete
+reference inventory, backend/vault/root identity, target, and repair set, and
+maps rollback to exact-plan recovery/compensation.
+
+The disposable fixture covers:
+
+- planning and stable status replay;
+- source drift rejected before any move;
+- commit and idempotent apply replay;
+- completed apply with a lost caller response reconciled through `status`;
+- an interrupted move recovered from the persisted intermediate state;
+- verified compensation back to the original file placement.
+
+## Explicit exclusions
+
+- Operon keeps its official Developer API plan and recovery contract; this
+  runtime does not wrap or replace it.
+- Local REST note, frontmatter, Bases, and Canvas writes are not upgraded by
+  declaration. They need an atomic expected-hash write surface before claiming
+  the same guarantee.
+- A receipt is evidence of the adapter's checks, not evidence of business
+  correctness outside its domain validator.
+
+## Consequences
+
+The MCP gains one shared operation vocabulary and a tested non-Operon adapter
+without creating a second journal. Future adapters can reuse the contract, but
+admission remains fail-closed whenever the backend cannot prove CAS, durable
+status, or postflight. Public tool expansion is deliberately deferred.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,6 +9,7 @@ setup or operations guides, not in this index.
 | [Governed HTTP delivery](ADR-HTTP-External-Artifact-Delivery.md)                                                   | Accepted and implemented on `main` for authenticated loopback; remote remains pilot | Adds `http_ticket`; HTTP mutation remains denied                         |
 | [External reference integrity](ADR-External-Reference-Integrity.md) / [FR](ADR-External-Reference-Integrity.fr.md) | Accepted and implemented for a local stdio pilot                                    | Same-root file move, exact ÉLYSIA reference repair, journal and rollback |
 | [Operon Bridge](ADR-Operon-Bridge.md)                                                                              | Accepted for bounded pilot                                                          | Versioned task-domain bridge and guarded mutation contract               |
+| [Common governed operation runtime](ADR-Common-Operation-Runtime.md)                                               | Accepted for internal adapter pilots; first external-move adapter implemented       | Shared plan, apply, status, receipt and exact-plan recovery vocabulary   |
 
 ## Status vocabulary
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "docs/adr/ADR-External-Reference-Integrity.md",
     "docs/adr/ADR-External-Reference-Integrity.fr.md",
     "docs/adr/ADR-Operon-Bridge.md",
+    "docs/adr/ADR-Common-Operation-Runtime.md",
     "docs/adr/README.md",
     "docs/operon-decision-report.md",
     "docs/operon-local-validation.md",
@@ -132,7 +133,8 @@
     "test:launchers": "npm run build && node scripts/test-launchers.mjs",
     "test:external-reference-parser": "node scripts/test-external-reference-parser.mjs",
     "test:obsidian-cas": "node scripts/test-obsidian-cas.mjs && node scripts/test-obsidian-search-replace-cas.mjs",
-    "test:external-move": "node scripts/test-external-move-integrity.mjs"
+    "test:external-move": "node scripts/test-external-move-integrity.mjs",
+    "test:operation-runtime": "npm run build && node scripts/test-external-move-integrity.mjs"
   },
   "dependencies": {
     "@hono/node-server": "^2.0.12",

--- a/scripts/test-external-move-integrity.mjs
+++ b/scripts/test-external-move-integrity.mjs
@@ -28,6 +28,9 @@ const { ExternalMoveCoordinator } = await import(
 const { ExternalMoveJournal } = await import(
   "../dist/services/externalReferences/externalMoveJournal.js"
 );
+const { ExternalMoveOperationAdapter } = await import(
+  "../dist/services/operations/externalMoveOperationAdapter.js"
+);
 
 const sandbox = await mkdtemp(
   path.join(os.tmpdir(), "optimike-external-move-integrity-"),
@@ -678,6 +681,184 @@ try {
   );
   assert.equal(await readFile(manualSource, "utf8"), "manual");
   assert.equal(await exists(path.join(archivePath, "manual.txt")), false);
+
+  // The common operation adapter keeps the existing external-move journal as
+  // its durable authority while projecting plan/apply/status/recover receipts.
+  const operationDriftSource = path.join(rootPath, "operation-drift.txt");
+  const operationDriftTarget = path.join(archivePath, "operation-drift.txt");
+  await writeFile(operationDriftSource, "operation drift v1", "utf8");
+  const operationDriftJournal = new ExternalMoveJournal(
+    path.join(sandbox, "operation-drift.sqlite"),
+  );
+  const operationDriftCoordinator = new ExternalMoveCoordinator(
+    service,
+    new FakeVault(),
+    operationDriftJournal,
+  );
+  const operationDriftAdapter = new ExternalMoveOperationAdapter(
+    operationDriftCoordinator,
+  );
+  const operationDriftPlan = await operationDriftAdapter.plan({
+    rootId: "pilot.move",
+    sourceRelativePath: "operation-drift.txt",
+    targetRelativePath: "archive/operation-drift.txt",
+    idempotencyKey: "operation-runtime-drift",
+  });
+  assert.equal(operationDriftPlan.phase, "planned");
+  assert.equal(operationDriftPlan.outcome, null);
+  assert.equal(operationDriftPlan.applyAllowed, true);
+  assert.match(operationDriftPlan.planRef, /^external-move:v1:/u);
+  assert.match(operationDriftPlan.planDigest, /^[a-f0-9]{64}$/u);
+  assert.equal(
+    (await operationDriftAdapter.status(operationDriftPlan.planRef)).planDigest,
+    operationDriftPlan.planDigest,
+  );
+  await writeFile(operationDriftSource, "operation drift v2", "utf8");
+  await expectExternalCode(
+    () =>
+      operationDriftAdapter.apply(
+        operationDriftPlan.planRef,
+        "operation-runtime-drift",
+      ),
+    "precondition_failed",
+  );
+  assert.equal(
+    await readFile(operationDriftSource, "utf8"),
+    "operation drift v2",
+  );
+  assert.equal(await exists(operationDriftTarget), false);
+  operationDriftJournal.close();
+
+  const operationCommitSource = path.join(rootPath, "operation-commit.txt");
+  const operationCommitTarget = path.join(archivePath, "operation-commit.txt");
+  await writeFile(operationCommitSource, "operation commit", "utf8");
+  const operationCommitJournal = new ExternalMoveJournal(
+    path.join(sandbox, "operation-commit.sqlite"),
+  );
+  const operationCommitAdapter = new ExternalMoveOperationAdapter(
+    new ExternalMoveCoordinator(
+      service,
+      new FakeVault(),
+      operationCommitJournal,
+    ),
+  );
+  const operationCommitPlan = await operationCommitAdapter.plan({
+    rootId: "pilot.move",
+    sourceRelativePath: "operation-commit.txt",
+    targetRelativePath: "archive/operation-commit.txt",
+    idempotencyKey: "operation-runtime-commit",
+  });
+  const operationCommitted = await operationCommitAdapter.apply(
+    operationCommitPlan.planRef,
+    "operation-runtime-commit",
+  );
+  assert.equal(operationCommitted.phase, "terminal");
+  assert.equal(operationCommitted.outcome, "committed");
+  assert.equal(operationCommitted.postflight.status, "verified");
+  assert.equal(
+    await readFile(operationCommitTarget, "utf8"),
+    "operation commit",
+  );
+  const operationReplay = await operationCommitAdapter.apply(
+    operationCommitPlan.planRef,
+    "operation-runtime-commit",
+  );
+  assert.equal(operationReplay.operationId, operationCommitted.operationId);
+  assert.equal(operationReplay.planDigest, operationCommitted.planDigest);
+  assert.equal(operationReplay.outcome, "committed");
+  assert.equal(await exists(operationCommitSource), false);
+  operationCommitJournal.close();
+
+  // Dropping the successful apply response does not authorize a retry: status
+  // reconciles the durable committed receipt without another file effect.
+  const operationLostSource = path.join(rootPath, "operation-lost.txt");
+  const operationLostTarget = path.join(archivePath, "operation-lost.txt");
+  await writeFile(operationLostSource, "operation lost response", "utf8");
+  const operationLostJournal = new ExternalMoveJournal(
+    path.join(sandbox, "operation-lost.sqlite"),
+  );
+  const operationLostAdapter = new ExternalMoveOperationAdapter(
+    new ExternalMoveCoordinator(service, new FakeVault(), operationLostJournal),
+  );
+  const operationLostPlan = await operationLostAdapter.plan({
+    rootId: "pilot.move",
+    sourceRelativePath: "operation-lost.txt",
+    targetRelativePath: "archive/operation-lost.txt",
+    idempotencyKey: "operation-runtime-lost-response",
+  });
+  await operationLostAdapter.apply(
+    operationLostPlan.planRef,
+    "operation-runtime-lost-response",
+  );
+  const operationLostStatus = await operationLostAdapter.status(
+    operationLostPlan.planRef,
+  );
+  assert.equal(operationLostStatus.outcome, "committed");
+  assert.equal(operationLostStatus.planDigest, operationLostPlan.planDigest);
+  assert.equal(
+    await readFile(operationLostTarget, "utf8"),
+    "operation lost response",
+  );
+  operationLostJournal.close();
+
+  // An interrupted apply is recovered only through the same persisted plan.
+  const operationRecoverySource = path.join(rootPath, "operation-recovery.txt");
+  const operationRecoveryTarget = path.join(
+    archivePath,
+    "operation-recovery.txt",
+  );
+  await writeFile(operationRecoverySource, "operation recovery", "utf8");
+  const operationRecoveryJournal = new ExternalMoveJournal(
+    path.join(sandbox, "operation-recovery.sqlite"),
+  );
+  const operationRecoveryCoordinator = new ExternalMoveCoordinator(
+    service,
+    new FakeVault(),
+    operationRecoveryJournal,
+  );
+  const operationRecoveryAdapter = new ExternalMoveOperationAdapter(
+    operationRecoveryCoordinator,
+  );
+  const operationRecoveryPlan = await operationRecoveryAdapter.plan({
+    rootId: "pilot.move",
+    sourceRelativePath: "operation-recovery.txt",
+    targetRelativePath: "archive/operation-recovery.txt",
+    idempotencyKey: "operation-runtime-recovery",
+  });
+  const operationRecoveryStored = operationRecoveryJournal.get(
+    operationRecoveryPlan.operationId,
+  );
+  await service.applyMove(operationRecoveryStored.snapshot);
+  operationRecoveryJournal.transition(
+    operationRecoveryPlan.operationId,
+    ["planned"],
+    "applying_file",
+  );
+  operationRecoveryJournal.transition(
+    operationRecoveryPlan.operationId,
+    ["applying_file"],
+    "file_moved",
+  );
+  const interruptedStatus = await operationRecoveryAdapter.status(
+    operationRecoveryPlan.planRef,
+  );
+  assert.equal(interruptedStatus.phase, "applying");
+  assert.equal(interruptedStatus.outcome, null);
+  assert.equal(interruptedStatus.recoveryAllowed, true);
+  assert.equal(interruptedStatus.recoveryRef, operationRecoveryPlan.planRef);
+  const operationRecovered = await operationRecoveryAdapter.recover(
+    operationRecoveryPlan.planRef,
+    "operation-runtime-recovery",
+  );
+  assert.equal(operationRecovered.phase, "terminal");
+  assert.equal(operationRecovered.outcome, "compensated");
+  assert.equal(operationRecovered.postflight.status, "compensated");
+  assert.equal(
+    await readFile(operationRecoverySource, "utf8"),
+    "operation recovery",
+  );
+  assert.equal(await exists(operationRecoveryTarget), false);
+  operationRecoveryJournal.close();
 
   console.log("External move integrity tests passed.");
 } finally {

--- a/scripts/test-external-move-integrity.mjs
+++ b/scripts/test-external-move-integrity.mjs
@@ -774,8 +774,9 @@ try {
   const operationLostSource = path.join(rootPath, "operation-lost.txt");
   const operationLostTarget = path.join(archivePath, "operation-lost.txt");
   await writeFile(operationLostSource, "operation lost response", "utf8");
+  const operationLostJournalPath = path.join(sandbox, "operation-lost.sqlite");
   const operationLostJournal = new ExternalMoveJournal(
-    path.join(sandbox, "operation-lost.sqlite"),
+    operationLostJournalPath,
   );
   const operationLostAdapter = new ExternalMoveOperationAdapter(
     new ExternalMoveCoordinator(service, new FakeVault(), operationLostJournal),
@@ -790,7 +791,18 @@ try {
     operationLostPlan.planRef,
     "operation-runtime-lost-response",
   );
-  const operationLostStatus = await operationLostAdapter.status(
+  operationLostJournal.close();
+  const operationLostRestartedJournal = new ExternalMoveJournal(
+    operationLostJournalPath,
+  );
+  const operationLostRestartedAdapter = new ExternalMoveOperationAdapter(
+    new ExternalMoveCoordinator(
+      service,
+      new FakeVault(),
+      operationLostRestartedJournal,
+    ),
+  );
+  const operationLostStatus = await operationLostRestartedAdapter.status(
     operationLostPlan.planRef,
   );
   assert.equal(operationLostStatus.outcome, "committed");
@@ -799,7 +811,7 @@ try {
     await readFile(operationLostTarget, "utf8"),
     "operation lost response",
   );
-  operationLostJournal.close();
+  operationLostRestartedJournal.close();
 
   // An interrupted apply is recovered only through the same persisted plan.
   const operationRecoverySource = path.join(rootPath, "operation-recovery.txt");
@@ -808,8 +820,12 @@ try {
     "operation-recovery.txt",
   );
   await writeFile(operationRecoverySource, "operation recovery", "utf8");
+  const operationRecoveryJournalPath = path.join(
+    sandbox,
+    "operation-recovery.sqlite",
+  );
   const operationRecoveryJournal = new ExternalMoveJournal(
-    path.join(sandbox, "operation-recovery.sqlite"),
+    operationRecoveryJournalPath,
   );
   const operationRecoveryCoordinator = new ExternalMoveCoordinator(
     service,
@@ -839,14 +855,25 @@ try {
     ["applying_file"],
     "file_moved",
   );
-  const interruptedStatus = await operationRecoveryAdapter.status(
+  operationRecoveryJournal.close();
+  const operationRecoveryRestartedJournal = new ExternalMoveJournal(
+    operationRecoveryJournalPath,
+  );
+  const operationRecoveryRestartedAdapter = new ExternalMoveOperationAdapter(
+    new ExternalMoveCoordinator(
+      service,
+      new FakeVault(),
+      operationRecoveryRestartedJournal,
+    ),
+  );
+  const interruptedStatus = await operationRecoveryRestartedAdapter.status(
     operationRecoveryPlan.planRef,
   );
   assert.equal(interruptedStatus.phase, "applying");
   assert.equal(interruptedStatus.outcome, null);
   assert.equal(interruptedStatus.recoveryAllowed, true);
   assert.equal(interruptedStatus.recoveryRef, operationRecoveryPlan.planRef);
-  const operationRecovered = await operationRecoveryAdapter.recover(
+  const operationRecovered = await operationRecoveryRestartedAdapter.recover(
     operationRecoveryPlan.planRef,
     "operation-runtime-recovery",
   );
@@ -858,7 +885,7 @@ try {
     "operation recovery",
   );
   assert.equal(await exists(operationRecoveryTarget), false);
-  operationRecoveryJournal.close();
+  operationRecoveryRestartedJournal.close();
 
   console.log("External move integrity tests passed.");
 } finally {

--- a/src/services/externalReferences/externalMoveJournal.ts
+++ b/src/services/externalReferences/externalMoveJournal.ts
@@ -90,6 +90,10 @@ export class ExternalMoveJournal {
     }
   }
 
+  close(): void {
+    this.db.close();
+  }
+
   create(
     input: Omit<
       ExternalMovePlan,

--- a/src/services/operations/contract.ts
+++ b/src/services/operations/contract.ts
@@ -1,0 +1,81 @@
+import { createHash } from "node:crypto";
+
+export const OPERATION_RUNTIME_CONTRACT_VERSION = 1 as const;
+
+export type OperationPhase = "planned" | "applying" | "terminal";
+
+export type OperationOutcome =
+  | "committed"
+  | "conflict"
+  | "rejected"
+  | "failed"
+  | "outcome_unknown"
+  | "compensated"
+  | "expired";
+
+export type OperationProof = {
+  kind: string;
+  digest: string;
+  details?: Record<string, boolean | number | string | null>;
+};
+
+export type OperationReceipt = {
+  contractVersion: typeof OPERATION_RUNTIME_CONTRACT_VERSION;
+  operationId: string;
+  idempotencyKey: string;
+  operationKind: string;
+  planRef: string;
+  planDigest: string;
+  phase: OperationPhase;
+  outcome: OperationOutcome | null;
+  backend: {
+    kind: string;
+    bindingFingerprint?: string;
+  };
+  target: {
+    kind: string;
+    logicalRef: string;
+  };
+  beforeProof: OperationProof;
+  afterProof?: OperationProof;
+  postflight: {
+    status:
+      | "not_started"
+      | "pending"
+      | "verified"
+      | "compensated"
+      | "unverified";
+  };
+  admittedAt: string;
+  updatedAt: string;
+  terminalAt?: string;
+  recoveryRef?: string;
+  recoveryAllowed: boolean;
+  applyAllowed: boolean;
+};
+
+export interface OperationAdapter<TPlanInput> {
+  readonly operationKind: string;
+  plan(input: TPlanInput): Promise<OperationReceipt>;
+  apply(planRef: string, idempotencyKey: string): Promise<OperationReceipt>;
+  status(planRef: string): Promise<OperationReceipt>;
+  recover(planRef: string, idempotencyKey: string): Promise<OperationReceipt>;
+}
+
+function canonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => canonicalize(item));
+  if (value && typeof value === "object") {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .sort(([left], [right]) => left.localeCompare(right))
+        .map(([key, item]) => [key, canonicalize(item)]),
+    );
+  }
+  return value;
+}
+
+export function operationDigest(value: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(canonicalize(value)), "utf8")
+    .digest("hex");
+}

--- a/src/services/operations/externalMoveOperationAdapter.ts
+++ b/src/services/operations/externalMoveOperationAdapter.ts
@@ -1,0 +1,235 @@
+import { z } from "zod";
+import type { ExternalMoveCoordinator } from "../externalReferences/externalMoveCoordinator.js";
+import {
+  OPERATION_RUNTIME_CONTRACT_VERSION,
+  operationDigest,
+  type OperationAdapter,
+  type OperationOutcome,
+  type OperationPhase,
+  type OperationReceipt,
+} from "./contract.js";
+
+const PLAN_REF_PREFIX = "external-move:v1:";
+
+const ExternalMovePlanViewSchema = z
+  .object({
+    planId: z.string().uuid(),
+    idempotencyKey: z.string().min(1),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+    status: z.enum([
+      "planned",
+      "applying_file",
+      "file_moved",
+      "applying_repairs",
+      "applied",
+      "rolling_back_repairs",
+      "rolling_back_file",
+      "rolled_back",
+      "failed_compensated",
+      "recovery_required",
+      "applying",
+      "rolling_back",
+      "failed",
+    ]),
+    rootId: z.string().min(1),
+    sourceRelativePath: z.string().min(1),
+    targetRelativePath: z.string().min(1),
+    sourceSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+    sourceSize: z.number().int().nonnegative(),
+    inventoryDigest: z.string().regex(/^[a-f0-9]{64}$/u),
+    bindingFingerprint: z.string().min(1),
+    bindingVerifiable: z.literal(true),
+    repairs: z.array(
+      z.object({
+        filePath: z.string().min(1),
+        expectedSha256: z.string().regex(/^[a-f0-9]{64}$/u),
+      }),
+    ),
+    manualReview: z.array(
+      z.object({ filePath: z.string().min(1), reason: z.string().min(1) }),
+    ),
+    readyToApply: z.boolean(),
+    recoveryRequired: z.boolean(),
+    recoveryErrors: z.array(z.string()),
+    appliedRepairCount: z.number().int().nonnegative(),
+    restoredRepairCount: z.number().int().nonnegative(),
+    nextAction: z.enum(["apply", "rollback", "none"]),
+    failure: z.string().optional(),
+  })
+  .strict();
+
+type ExternalMovePlanView = z.infer<typeof ExternalMovePlanViewSchema>;
+
+export type ExternalMoveOperationPlanInput = {
+  rootId: string;
+  sourceRelativePath: string;
+  targetRelativePath: string;
+  idempotencyKey: string;
+};
+
+function planRef(planId: string): string {
+  return `${PLAN_REF_PREFIX}${planId}`;
+}
+
+function planIdFromRef(reference: string): string {
+  if (!reference.startsWith(PLAN_REF_PREFIX)) {
+    throw new Error(
+      "The operation plan reference is not an external-move V1 plan.",
+    );
+  }
+  const planId = reference.slice(PLAN_REF_PREFIX.length);
+  if (!z.string().uuid().safeParse(planId).success) {
+    throw new Error("The external-move operation plan reference is malformed.");
+  }
+  return planId;
+}
+
+function state(view: ExternalMovePlanView): {
+  phase: OperationPhase;
+  outcome: OperationOutcome | null;
+} {
+  if (view.status === "applied")
+    return { phase: "terminal", outcome: "committed" };
+  if (view.status === "rolled_back" || view.status === "failed_compensated") {
+    return { phase: "terminal", outcome: "compensated" };
+  }
+  if (view.status === "recovery_required") {
+    return { phase: "terminal", outcome: "outcome_unknown" };
+  }
+  if (view.status === "failed") return { phase: "terminal", outcome: "failed" };
+  if (view.status === "planned") return { phase: "planned", outcome: null };
+  return { phase: "applying", outcome: null };
+}
+
+function receipt(raw: Record<string, unknown>): OperationReceipt {
+  const view = ExternalMovePlanViewSchema.parse(raw);
+  const currentState = state(view);
+  const reference = planRef(view.planId);
+  const digest = operationDigest({
+    contractVersion: OPERATION_RUNTIME_CONTRACT_VERSION,
+    operationKind: "external.move",
+    operationId: view.planId,
+    idempotencyKey: view.idempotencyKey,
+    backendBinding: view.bindingFingerprint,
+    rootId: view.rootId,
+    sourceRelativePath: view.sourceRelativePath,
+    targetRelativePath: view.targetRelativePath,
+    sourceSha256: view.sourceSha256,
+    sourceSize: view.sourceSize,
+    inventoryDigest: view.inventoryDigest,
+    repairs: view.repairs,
+    manualReview: view.manualReview,
+  });
+  const terminal = currentState.phase === "terminal";
+  const recoverable =
+    view.nextAction === "rollback" ||
+    currentState.phase === "applying" ||
+    currentState.outcome === "outcome_unknown";
+  const postflight =
+    currentState.outcome === "committed"
+      ? "verified"
+      : currentState.outcome === "compensated"
+        ? "compensated"
+        : terminal
+          ? "unverified"
+          : currentState.phase === "applying"
+            ? "pending"
+            : "not_started";
+
+  return {
+    contractVersion: OPERATION_RUNTIME_CONTRACT_VERSION,
+    operationId: view.planId,
+    idempotencyKey: view.idempotencyKey,
+    operationKind: "external.move",
+    planRef: reference,
+    planDigest: digest,
+    phase: currentState.phase,
+    outcome: currentState.outcome,
+    backend: {
+      kind: "external-filesystem",
+      bindingFingerprint: view.bindingFingerprint,
+    },
+    target: {
+      kind: "same-root-file-move",
+      logicalRef: `${view.rootId}:${view.sourceRelativePath}->${view.targetRelativePath}`,
+    },
+    beforeProof: {
+      kind: "source-cas-and-reference-inventory",
+      digest: operationDigest({
+        sourceSha256: view.sourceSha256,
+        sourceSize: view.sourceSize,
+        inventoryDigest: view.inventoryDigest,
+        bindingFingerprint: view.bindingFingerprint,
+      }),
+      details: {
+        sourceSha256: view.sourceSha256,
+        inventoryDigest: view.inventoryDigest,
+        repairCount: view.repairs.length,
+        manualReviewCount: view.manualReview.length,
+      },
+    },
+    ...(currentState.outcome === "committed" ||
+    currentState.outcome === "compensated"
+      ? {
+          afterProof: {
+            kind:
+              currentState.outcome === "committed"
+                ? "move-and-repairs-verified"
+                : "compensation-verified",
+            digest: operationDigest({
+              planDigest: digest,
+              outcome: currentState.outcome,
+              appliedRepairCount: view.appliedRepairCount,
+              restoredRepairCount: view.restoredRepairCount,
+            }),
+            details: {
+              appliedRepairCount: view.appliedRepairCount,
+              restoredRepairCount: view.restoredRepairCount,
+            },
+          },
+        }
+      : {}),
+    postflight: { status: postflight },
+    admittedAt: view.createdAt,
+    updatedAt: view.updatedAt,
+    ...(terminal ? { terminalAt: view.updatedAt } : {}),
+    ...(recoverable ? { recoveryRef: reference } : {}),
+    recoveryAllowed: recoverable,
+    applyAllowed: view.readyToApply && view.nextAction === "apply",
+  };
+}
+
+export class ExternalMoveOperationAdapter
+  implements OperationAdapter<ExternalMoveOperationPlanInput>
+{
+  readonly operationKind = "external.move";
+
+  constructor(private readonly coordinator: ExternalMoveCoordinator) {}
+
+  async plan(input: ExternalMoveOperationPlanInput): Promise<OperationReceipt> {
+    return receipt(await this.coordinator.plan(input));
+  }
+
+  async apply(
+    reference: string,
+    idempotencyKey: string,
+  ): Promise<OperationReceipt> {
+    return receipt(
+      await this.coordinator.apply(planIdFromRef(reference), idempotencyKey),
+    );
+  }
+
+  async status(reference: string): Promise<OperationReceipt> {
+    return receipt(this.coordinator.status(planIdFromRef(reference)));
+  }
+
+  async recover(
+    reference: string,
+    idempotencyKey: string,
+  ): Promise<OperationReceipt> {
+    return receipt(
+      await this.coordinator.rollback(planIdFromRef(reference), idempotencyKey),
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- freeze the internal plan → apply → status → recover contract in an accepted ADR;
- add typed common operation receipts with separate phase and outcome;
- adapt the existing external_move coordinator without adding a second journal or widening public write permissions;
- validate drift refusal, commit, idempotent replay, lost-response status reconciliation, interrupted apply, and same-plan compensation on disposable fixtures.

## Validation

- npm run test:operation-runtime
- npm run test:external-roots
- npm run test:docs
- npm run test:package
- npm run audit:production
- git diff --check

All passed on Windows. The package test required building both bundled Bridges in the fresh worktree; package contents then passed with 13 runnable artifacts.