### PR TITLE
Prevent compensated operation reapply

### DIFF
--- a/scripts/test-external-move-integrity.mjs
+++ b/scripts/test-external-move-integrity.mjs
@@ -880,12 +880,81 @@ try {
   assert.equal(operationRecovered.phase, "terminal");
   assert.equal(operationRecovered.outcome, "compensated");
   assert.equal(operationRecovered.postflight.status, "compensated");
+  assert.equal(operationRecovered.applyAllowed, false);
   assert.equal(
     await readFile(operationRecoverySource, "utf8"),
     "operation recovery",
   );
   assert.equal(await exists(operationRecoveryTarget), false);
+  await assert.rejects(
+    operationRecoveryRestartedAdapter.apply(
+      operationRecoveryPlan.planRef,
+      "operation-runtime-recovery",
+    ),
+    /rolled_back, not applicable/u,
+  );
+  assert.equal(
+    await readFile(operationRecoverySource, "utf8"),
+    "operation recovery",
+  );
+  assert.equal(await exists(operationRecoveryTarget), false);
+  const operationRecoveredStatus =
+    await operationRecoveryRestartedAdapter.status(
+      operationRecoveryPlan.planRef,
+    );
+  assert.equal(operationRecoveredStatus.applyAllowed, false);
   operationRecoveryRestartedJournal.close();
+
+  // Admission is atomic when apply preflight overlaps recovery.
+  const operationRaceSource = path.join(rootPath, "operation-race.txt");
+  const operationRaceTarget = path.join(archivePath, "operation-race.txt");
+  await writeFile(operationRaceSource, "operation race", "utf8");
+  const operationRaceJournal = new ExternalMoveJournal(
+    path.join(sandbox, "operation-race.sqlite"),
+  );
+  const operationRaceVault = new FakeVault();
+  const operationRaceCoordinator = new ExternalMoveCoordinator(
+    service,
+    operationRaceVault,
+    operationRaceJournal,
+  );
+  const operationRaceAdapter = new ExternalMoveOperationAdapter(
+    operationRaceCoordinator,
+  );
+  const operationRacePlan = await operationRaceAdapter.plan({
+    rootId: "pilot.move",
+    sourceRelativePath: "operation-race.txt",
+    targetRelativePath: "archive/operation-race.txt",
+    idempotencyKey: "operation-runtime-race",
+  });
+  let releaseApplyPreflight;
+  let signalApplyPreflight;
+  const applyPreflightReached = new Promise((resolve) => {
+    signalApplyPreflight = resolve;
+  });
+  operationRaceVault.assertConditionalWritesSupported = async () => {
+    signalApplyPreflight();
+    await new Promise((resolve) => {
+      releaseApplyPreflight = resolve;
+    });
+  };
+  const racedApply = operationRaceAdapter.apply(
+    operationRacePlan.planRef,
+    "operation-runtime-race",
+  );
+  await applyPreflightReached;
+  const racedRecovery = await operationRaceAdapter.recover(
+    operationRacePlan.planRef,
+    "operation-runtime-race",
+  );
+  assert.equal(racedRecovery.phase, "terminal");
+  assert.equal(racedRecovery.outcome, "compensated");
+  assert.equal(racedRecovery.applyAllowed, false);
+  releaseApplyPreflight();
+  await assert.rejects(racedApply, /state changed concurrently/u);
+  assert.equal(await readFile(operationRaceSource, "utf8"), "operation race");
+  assert.equal(await exists(operationRaceTarget), false);
+  operationRaceJournal.close();
 
   console.log("External move integrity tests passed.");
 } finally {

--- a/src/services/externalReferences/externalMoveCoordinator.ts
+++ b/src/services/externalReferences/externalMoveCoordinator.ts
@@ -334,10 +334,15 @@ export class ExternalMoveCoordinator {
   async apply(
     planId: string,
     idempotencyKey: string,
+    options: { allowCompensatedReapply?: boolean } = {},
   ): Promise<Record<string, unknown>> {
     let plan = this.requirePlan(planId, idempotencyKey);
     if (plan.status === "applied") return publicPlan(plan);
-    if (plan.status !== "planned" && plan.status !== "rolled_back") {
+    const applicableStatuses: ExternalMovePlan["status"][] =
+      options.allowCompensatedReapply === false
+        ? ["planned"]
+        : ["planned", "rolled_back"];
+    if (!applicableStatuses.includes(plan.status)) {
       throw new ExternalRootError(
         "precondition_failed",
         `External move plan is ${plan.status}, not applicable.`,
@@ -399,7 +404,7 @@ export class ExternalMoveCoordinator {
 
     plan = this.journal.transition(
       plan.planId,
-      ["planned", "rolled_back"],
+      applicableStatuses,
       "applying_file",
       {
         appliedRepairPaths: [],

--- a/src/services/operations/externalMoveOperationAdapter.ts
+++ b/src/services/operations/externalMoveOperationAdapter.ts
@@ -196,7 +196,10 @@ function receipt(raw: Record<string, unknown>): OperationReceipt {
     ...(terminal ? { terminalAt: view.updatedAt } : {}),
     ...(recoverable ? { recoveryRef: reference } : {}),
     recoveryAllowed: recoverable,
-    applyAllowed: view.readyToApply && view.nextAction === "apply",
+    applyAllowed:
+      currentState.phase !== "terminal" &&
+      view.readyToApply &&
+      view.nextAction === "apply",
   };
 }
 
@@ -215,8 +218,11 @@ export class ExternalMoveOperationAdapter
     reference: string,
     idempotencyKey: string,
   ): Promise<OperationReceipt> {
+    const planId = planIdFromRef(reference);
     return receipt(
-      await this.coordinator.apply(planIdFromRef(reference), idempotencyKey),
+      await this.coordinator.apply(planId, idempotencyKey, {
+        allowCompensatedReapply: false,
+      }),
     );
   }
 


### PR DESCRIPTION
## Summary
- reject apply at the common adapter boundary once an external move has a terminal compensated receipt
- preserve historical coordinator behavior and committed idempotent replay
- add a recovery regression test proving a delayed apply cannot recreate effects

## Verification
- npm run test:operation-runtime
- npm run test:external-roots
- npm run test:docs
- git diff --check

Follow-up to #43 and its Codex review.