### PR TITLE
feat: add atomic note operation runtime

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -22,6 +22,7 @@ jobs:
       - run: npm ci
       - run: npm run test:runtime
       - run: npm run test:external-roots
+      - run: npm run test:operation-runtime
       - run: npm run test:profiles
       - run: npm run test:tool-annotations
       - run: npm run test:docs
@@ -126,8 +127,13 @@ jobs:
       - name: Install Operon Bridge dependencies
         working-directory: plugins/obsidian-operon-bridge
         run: npm ci
+      - name: Install Atomic Write Bridge dependencies
+        working-directory: plugins/obsidian-atomic-write-bridge
+        run: npm ci
       - name: Test Bases Bridge
         run: npm run check:bases-bridge
+      - name: Test Atomic Write runtime and Bridge
+        run: npm run check:atomic-write
       - name: Build MCP server
         run: npm run build
       - name: Build installable Bridges
@@ -141,4 +147,12 @@ jobs:
           path: |
             plugins/obsidian-bases-bridge/build/main.js
             plugins/obsidian-bases-bridge/build/manifest.json
+          if-no-files-found: error
+      - name: Upload Atomic Write Bridge artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: optimike-atomic-write-bridge
+          path: |
+            plugins/obsidian-atomic-write-bridge/build/main.js
+            plugins/obsidian-atomic-write-bridge/build/manifest.json
           if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Bundled Atomic Write Bridge with a default-off write gate and an Obsidian
+  `Vault.process` SHA-256 compare-and-replace route for existing Markdown notes.
+- Second common-operation-runtime adapter for atomic note replacement, with a
+  private SQLite journal, sealed plan binding, terminal retention, idempotent
+  replay, conflict proof, lost-response reconciliation and exact-plan recovery.
+
 - Operon `3.2.1` / CLI `1.1.0` compatibility through Bridge `0.6.0`, retaining
   explicit `3.2.0` support and including
   native saved-filter execution via the additive `tasks.filter-query` grant and

--- a/README.fr.md
+++ b/README.fr.md
@@ -2,8 +2,7 @@
 
 [![Dernière version](https://img.shields.io/github/v/release/optimikelabs/optimike-obsidian-mcp?display_name=tag&sort=semver)](https://github.com/optimikelabs/optimike-obsidian-mcp/releases/latest)
 
-English version: [README.md](README.md)
-Hub documentaire : [docs/README.fr.md](docs/README.fr.md)
+English version: [README.md](README.md) · Hub documentaire : [docs/README.fr.md](docs/README.fr.md)
 Exploitation : [OPERATIONS.fr.md](OPERATIONS.fr.md)
 Sécurité : [SECURITY.fr.md](SECURITY.fr.md)
 
@@ -92,6 +91,7 @@ Activer seulement les surfaces utilisées :
 - [Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api) :
   notes, métadonnées et tags en live ;
 - **Bases Bridge (REST)** inclus : opérations `.base` en live ;
+- **Optimike Atomic Write Bridge** inclus : compare-and-replace SHA-256 opt-in pour le pilote interne sur les notes ;
 - **Smart Connections** : index sémantique `.smart-env` ;
 - **Operon 3.2.1** et **Optimike Operon Bridge** inclus : tâches live
   gouvernées via la Developer API officielle V1 ;
@@ -107,6 +107,8 @@ OPERON_MUTATIONS_ENABLED=true
 ```
 
 Les snapshots Operon obsolètes restent toujours en lecture seule.
+
+Le remplacement atomique des notes a son propre réglage, désactivé par défaut, et ne requiert pas le grant Developer API d’Operon.
 
 Le MCP expose une surface agentique gouvernée, pas toutes les fonctions de la
 CLI Operon. Les diagnostics natifs, la recherche/résolution, les relations et

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Latest release](https://img.shields.io/github/v/release/optimikelabs/optimike-obsidian-mcp?display_name=tag&sort=semver)](https://github.com/optimikelabs/optimike-obsidian-mcp/releases/latest)
 
-French version: [README.fr.md](README.fr.md)
-Documentation hub: [docs/README.md](docs/README.md)
+French version: [README.fr.md](README.fr.md) · Documentation hub: [docs/README.md](docs/README.md)
 Operations: [OPERATIONS.md](OPERATIONS.md)
 Security: [SECURITY.md](SECURITY.md)
 
@@ -90,6 +89,7 @@ Enable only the surfaces you use:
 - [Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api):
   live note, metadata and tag operations;
 - bundled **Bases Bridge (REST)**: live `.base` operations;
+- bundled **Optimike Atomic Write Bridge**: opt-in SHA-256 compare-and-replace for the internal note-operation pilot;
 - **Smart Connections**: semantic index under `.smart-env`;
 - **Operon Developer API V1** and the bundled **Optimike Operon Bridge**: governed live
   task operations through the official Developer API V1;
@@ -104,7 +104,7 @@ Optimike Operon Bridge setting: Allow task mutations
 OPERON_MUTATIONS_ENABLED=true
 ```
 
-Stale Operon snapshots remain read-only.
+Stale Operon snapshots remain read-only. Atomic note replacement has a separate default-off bridge setting and does not require Operon's Developer API grant.
 
 The MCP exposes a curated agent surface rather than every Operon CLI function.
 Native diagnostics, finder/resolve, bounded relationships/context and timer

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -52,6 +52,7 @@ question.
 - frontière MCP et CLI : [Audit CLI / Developer API](operon-cli-audit.fr.md) ;
 - bridge Operon inclus : [README Operon Bridge](../plugins/obsidian-operon-bridge/README.md) ;
 - bridge Bases inclus : [README Bases Bridge](../plugins/obsidian-bases-bridge/README.md).
+- pilote compare-and-replace Markdown : [README Atomic Write Bridge](../plugins/obsidian-atomic-write-bridge/README.md).
 
 ### Recherche et runtime
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,7 @@ French operator guides are linked alongside their English equivalents.
 - MCP versus CLI boundary: [Operon CLI / Developer API audit](operon-cli-audit.md);
 - bundled bridge implementation: [Operon Bridge README](../plugins/obsidian-operon-bridge/README.md);
 - bundled Bases implementation: [Bases Bridge README](../plugins/obsidian-bases-bridge/README.md).
+- atomic Markdown compare-and-replace pilot: [Atomic Write Bridge README](../plugins/obsidian-atomic-write-bridge/README.md).
 
 ### Search and runtime
 

--- a/docs/adr/ADR-Common-Operation-Runtime.md
+++ b/docs/adr/ADR-Common-Operation-Runtime.md
@@ -2,9 +2,10 @@
 
 ## Status
 
-Accepted for internal adapter pilots. The first implementation binds the existing
-`external_move` transaction to this contract; it does not add a generic public
-write tool or widen any write permission.
+Accepted and implemented for two internal adapter pilots. The implementations
+bind the existing `external_move` transaction and an atomic Markdown note
+replacement to this contract; they do not add a generic public write tool or
+widen any write permission.
 
 ## Context
 
@@ -73,7 +74,7 @@ Domain tools remain the public MCP surface for now. A future generic operation
 surface may be added only after at least two adapters demonstrate the same
 semantics without weakening their domain contracts.
 
-## First adapter
+## First adapter: external move
 
 `ExternalMoveOperationAdapter` reuses the existing `external_move` coordinator
 and journal as the sole durable authority. It maps the existing plan ID to an
@@ -90,19 +91,38 @@ The disposable fixture covers:
 - an interrupted move recovered from the persisted intermediate state;
 - verified compensation back to the original file placement.
 
+## Second adapter: atomic note replacement
+
+`ObsidianNoteReplaceOperationAdapter` uses the bundled Atomic Write Bridge as
+its only effect surface. The bridge binds every response to a hashed
+device/install/vault-root fingerprint and executes SHA-256 compare-and-replace through Obsidian
+`Vault.process`, so the precondition and replacement occur in one atomic
+read-modify-write operation. Its write gate is disabled by default and remains
+independent from Operon's Developer API grant.
+
+The adapter stores the sealed next content in a private SQLite WAL journal so
+the exact plan can be recovered after a lost response. Terminal rows expire
+after 30 days; non-terminal and `outcome_unknown` rows are retained for
+recovery. The disposable fixture covers conflict without write, committed
+replay, idempotency-key binding, lost-response reconciliation, and exact-plan
+recovery after a request failure.
+
 ## Explicit exclusions
 
 - Operon keeps its official Developer API plan and recovery contract; this
   runtime does not wrap or replace it.
-- Local REST note, frontmatter, Bases, and Canvas writes are not upgraded by
-  declaration. They need an atomic expected-hash write surface before claiming
-  the same guarantee.
+- Frontmatter, Bases, and Canvas writes are not upgraded by declaration. The
+  second pilot proves only complete Markdown note replacement through the
+  dedicated atomic bridge.
 - A receipt is evidence of the adapter's checks, not evidence of business
   correctness outside its domain validator.
 
 ## Consequences
 
-The MCP gains one shared operation vocabulary and a tested non-Operon adapter
-without creating a second journal. Future adapters can reuse the contract, but
-admission remains fail-closed whenever the backend cannot prove CAS, durable
-status, or postflight. Public tool expansion is deliberately deferred.
+The MCP now has two tested non-Operon adapters using one shared operation
+vocabulary. Each domain journal remains its sole durable authority; the common
+runtime does not introduce a competing generic journal. Future adapters can
+reuse the contract, but admission remains fail-closed whenever the backend
+cannot prove CAS, durable status, or postflight. A generic public operation
+surface remains deliberately deferred until the live Obsidian pilot confirms
+the second adapter outside the disposable fixture.

--- a/docs/adr/ADR-Common-Operation-Runtime.md
+++ b/docs/adr/ADR-Common-Operation-Runtime.md
@@ -94,8 +94,8 @@ The disposable fixture covers:
 ## Second adapter: atomic note replacement
 
 `ObsidianNoteReplaceOperationAdapter` uses the bundled Atomic Write Bridge as
-its only effect surface. The bridge binds every response to a hashed
-device/install/vault-root fingerprint and executes SHA-256 compare-and-replace through Obsidian
+its only effect surface. The bridge binds every CAS request and response to a
+hashed device/install/vault-root fingerprint and executes SHA-256 compare-and-replace through Obsidian
 `Vault.process`, so the precondition and replacement occur in one atomic
 read-modify-write operation. Its write gate is disabled by default and remains
 independent from Operon's Developer API grant.
@@ -105,7 +105,7 @@ the exact plan can be recovered after a lost response. Terminal rows expire
 after 30 days and their sealed content is redacted as soon as a stable terminal
 state is recorded; non-terminal and `outcome_unknown` rows are retained for
 recovery. The disposable fixture covers conflict without write, committed
-replay, concurrent status reconciliation, idempotency-key binding,
+replay, backend-binding rejection, concurrent status reconciliation, idempotency-key binding,
 lost-response reconciliation, active-daemon retention, and exact-plan recovery
 after a request failure.
 

--- a/docs/adr/ADR-Common-Operation-Runtime.md
+++ b/docs/adr/ADR-Common-Operation-Runtime.md
@@ -102,10 +102,12 @@ independent from Operon's Developer API grant.
 
 The adapter stores the sealed next content in a private SQLite WAL journal so
 the exact plan can be recovered after a lost response. Terminal rows expire
-after 30 days; non-terminal and `outcome_unknown` rows are retained for
+after 30 days and their sealed content is redacted as soon as a stable terminal
+state is recorded; non-terminal and `outcome_unknown` rows are retained for
 recovery. The disposable fixture covers conflict without write, committed
-replay, idempotency-key binding, lost-response reconciliation, and exact-plan
-recovery after a request failure.
+replay, concurrent status reconciliation, idempotency-key binding,
+lost-response reconciliation, active-daemon retention, and exact-plan recovery
+after a request failure.
 
 ## Explicit exclusions
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -9,7 +9,7 @@ setup or operations guides, not in this index.
 | [Governed HTTP delivery](ADR-HTTP-External-Artifact-Delivery.md)                                                   | Accepted and implemented on `main` for authenticated loopback; remote remains pilot | Adds `http_ticket`; HTTP mutation remains denied                         |
 | [External reference integrity](ADR-External-Reference-Integrity.md) / [FR](ADR-External-Reference-Integrity.fr.md) | Accepted and implemented for a local stdio pilot                                    | Same-root file move, exact ÉLYSIA reference repair, journal and rollback |
 | [Operon Bridge](ADR-Operon-Bridge.md)                                                                              | Accepted for bounded pilot                                                          | Versioned task-domain bridge and guarded mutation contract               |
-| [Common governed operation runtime](ADR-Common-Operation-Runtime.md)                                               | Accepted for internal adapter pilots; first external-move adapter implemented       | Shared plan, apply, status, receipt and exact-plan recovery vocabulary   |
+| [Common governed operation runtime](ADR-Common-Operation-Runtime.md)                                               | Accepted for internal pilots; external-move and atomic-note adapters implemented     | Shared plan, apply, status, receipt and exact-plan recovery vocabulary   |
 
 ## Status vocabulary
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,9 @@
     "plugins/obsidian-bases-bridge/build",
     "plugins/obsidian-bases-bridge/manifest.json",
     "plugins/obsidian-bases-bridge/README.md",
+    "plugins/obsidian-atomic-write-bridge/build",
+    "plugins/obsidian-atomic-write-bridge/manifest.json",
+    "plugins/obsidian-atomic-write-bridge/README.md",
     "plugins/obsidian-operon-bridge/build",
     "plugins/obsidian-operon-bridge/manifest.json",
     "plugins/obsidian-operon-bridge/README.md",
@@ -107,9 +110,11 @@
     "test:operon-service": "node scripts/test-operon-service.mjs",
     "build:bases-bridge": "npm --prefix plugins/obsidian-bases-bridge run build",
     "build:operon-bridge": "npm --prefix plugins/obsidian-operon-bridge run build",
-    "build:bridges": "npm run build:bases-bridge && npm run build:operon-bridge",
+    "build:atomic-write-bridge": "npm --prefix plugins/obsidian-atomic-write-bridge run build",
+    "build:bridges": "npm run build:bases-bridge && npm run build:operon-bridge && npm run build:atomic-write-bridge",
     "check:bases-bridge": "npm --prefix plugins/obsidian-bases-bridge run check",
     "check:operon": "npm run build && npm run test:operon-contract && npm run test:operon-service && npm --prefix plugins/obsidian-operon-bridge run check",
+    "check:atomic-write": "npm run build && node scripts/test-obsidian-note-replace-operation.mjs && npm --prefix plugins/obsidian-atomic-write-bridge run check",
     "smoke:operon-mutations": "node scripts/smoke-operon-mutations.mjs",
     "smoke:operon-rich-mutations": "node scripts/smoke-operon-rich-mutations.mjs",
     "test:profiles": "node scripts/test-elysia-task-profile.mjs",
@@ -134,7 +139,7 @@
     "test:external-reference-parser": "node scripts/test-external-reference-parser.mjs",
     "test:obsidian-cas": "node scripts/test-obsidian-cas.mjs && node scripts/test-obsidian-search-replace-cas.mjs",
     "test:external-move": "node scripts/test-external-move-integrity.mjs",
-    "test:operation-runtime": "npm run build && node scripts/test-external-move-integrity.mjs"
+    "test:operation-runtime": "npm run build && node scripts/test-external-move-integrity.mjs && node scripts/test-obsidian-note-replace-operation.mjs"
   },
   "dependencies": {
     "@hono/node-server": "^2.0.12",

--- a/plugins/obsidian-atomic-write-bridge/README.md
+++ b/plugins/obsidian-atomic-write-bridge/README.md
@@ -12,9 +12,9 @@ read-modify-write operation.
 - `POST /extensions/obsidian-atomic-write-bridge/notes/cas`
 
 Every request body is strict and versioned with `contractVersion: 1`. The CAS
-route accepts only an existing Markdown note, its exact lowercase SHA-256, and
-the complete next content. A concurrent change returns HTTP `409` and does not
-write.
+route accepts only an existing Markdown note, the sealed backend binding
+fingerprint, its exact lowercase SHA-256, and the complete next content. A
+backend or content mismatch returns HTTP `409` before `Vault.process` writes.
 
 Writes are disabled by default. The operator must explicitly enable **Allow
 atomic writes** in this bridge's Obsidian settings. Read and status remain

--- a/plugins/obsidian-atomic-write-bridge/README.md
+++ b/plugins/obsidian-atomic-write-bridge/README.md
@@ -1,0 +1,39 @@
+# Optimike Atomic Write Bridge
+
+This bundled Obsidian Desktop plugin adds a deliberately narrow Local REST API
+extension for governed note writes. It uses Obsidian `Vault.process` so the
+SHA-256 precondition and replacement happen inside the same atomic
+read-modify-write operation.
+
+## Routes
+
+- `GET /extensions/obsidian-atomic-write-bridge/status`
+- `POST /extensions/obsidian-atomic-write-bridge/notes/read`
+- `POST /extensions/obsidian-atomic-write-bridge/notes/cas`
+
+Every request body is strict and versioned with `contractVersion: 1`. The CAS
+route accepts only an existing Markdown note, its exact lowercase SHA-256, and
+the complete next content. A concurrent change returns HTTP `409` and does not
+write.
+
+Writes are disabled by default. The operator must explicitly enable **Allow
+atomic writes** in this bridge's Obsidian settings. Read and status remain
+available while the write gate is closed.
+
+The bridge depends on the public extension API of **Local REST API**. It does
+not depend on Operon or on Operon's Developer API grant UI.
+
+## Install from source
+
+```bash
+npm ci
+npm run check
+```
+
+Copy `build/main.js` and `build/manifest.json` to:
+
+```text
+<vault>/.obsidian/plugins/obsidian-atomic-write-bridge/
+```
+
+Enable Local REST API first, then enable Optimike Atomic Write Bridge.

--- a/plugins/obsidian-atomic-write-bridge/esbuild.config.mjs
+++ b/plugins/obsidian-atomic-write-bridge/esbuild.config.mjs
@@ -1,0 +1,71 @@
+import esbuild from "esbuild";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+
+const entryFile = "src/main.ts";
+const outdir = "build";
+const outfile = join(outdir, "main.js");
+const isWatch = process.argv.includes("--watch");
+
+const buildOptions = {
+  entryPoints: [entryFile],
+  bundle: true,
+  sourcemap: "inline",
+  target: "es2020",
+  format: "cjs",
+  platform: "browser",
+  outfile,
+  banner: { js: "/* Optimike Atomic Write Bridge - build via esbuild */" },
+  external: ["obsidian", "node:crypto"],
+  minify: false,
+  logLevel: "info",
+};
+
+function postBuild() {
+  mkdirSync(outdir, { recursive: true });
+  const manifestPath = "manifest.json";
+  if (existsSync(manifestPath)) {
+    const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+    manifest.main = "main.js";
+    writeFileSync(
+      join(outdir, "manifest.json"),
+      JSON.stringify(manifest, null, 2),
+    );
+  }
+  if (existsSync("styles.css")) {
+    copyFileSync("styles.css", join(outdir, "styles.css"));
+  }
+}
+
+async function build() {
+  if (!isWatch) {
+    await esbuild.build(buildOptions);
+    postBuild();
+    return;
+  }
+  const context = await esbuild.context({
+    ...buildOptions,
+    plugins: [
+      {
+        name: "atomic-write-bridge-post-build",
+        setup(build) {
+          build.onEnd((result) => {
+            if (result.errors.length === 0) postBuild();
+          });
+        },
+      },
+    ],
+  });
+  await context.watch();
+}
+
+build().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/plugins/obsidian-atomic-write-bridge/manifest.json
+++ b/plugins/obsidian-atomic-write-bridge/manifest.json
@@ -1,0 +1,10 @@
+{
+  "id": "obsidian-atomic-write-bridge",
+  "name": "Optimike Atomic Write Bridge",
+  "version": "0.1.0",
+  "minAppVersion": "1.1.0",
+  "author": "Optimike",
+  "authorUrl": "https://github.com/optimikelabs",
+  "description": "Expose une écriture atomique SHA-256 pour les notes via l'API d'extension de Local REST API.",
+  "isDesktopOnly": true
+}

--- a/plugins/obsidian-atomic-write-bridge/package-lock.json
+++ b/plugins/obsidian-atomic-write-bridge/package-lock.json
@@ -1,0 +1,1161 @@
+{
+  "name": "optimike-atomic-write-bridge",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "optimike-atomic-write-bridge",
+      "version": "0.1.0",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "esbuild": "^0.25.0",
+        "obsidian": "1.13.0",
+        "tsx": "^4.20.0",
+        "typescript": "^5.9.3"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
+      "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.38.6",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.6.tgz",
+      "integrity": "sha512-qiS0z1bKs5WOvHIAC0Cybmv4AJSkAXgX5aD6Mqd2epSLlVJsQl8NG23jCVouIgkh4All/mrbdsf2UOLFnJw0tw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@codemirror/state": "^6.5.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/codemirror": {
+      "version": "5.60.8",
+      "resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
+      "integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/tern": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/tern": {
+      "version": "0.23.9",
+      "resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.9.tgz",
+      "integrity": "sha512-ypzHFE/wBzh+BlH6rrBgS5I/Z7RD21pGhZ2rltb/+ZrVM1awdZwjx7hE5XfuYgHWk9uvV5HLZN3SloevCAp3Bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.4",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
+      "integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/obsidian": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.13.0.tgz",
+      "integrity": "sha512-PHw5+SAPlJ0S3leFvJ0wgFg63Z3DavxL6+d1ll+8toXR2ZlYKc1rMWqdUv9LgUbTwPQUyY6yfhOMMivampRRiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/codemirror": "5.60.8",
+        "moment": "2.29.4"
+      },
+      "peerDependencies": {
+        "@codemirror/state": "6.5.0",
+        "@codemirror/view": "6.38.6"
+      }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/tsx": {
+      "version": "4.23.12",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+      "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.28.0"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.2.tgz",
+      "integrity": "sha512-XExcO+dvLKvVtNTibSTBej1NCAbaGhWn9Ww1ZPx80qsahhPFe/8jgWP0IchNe0F3HwkU7n8ejhH8bjonqht8mQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.2.tgz",
+      "integrity": "sha512-kXXoiPVVGQcnIYGOeaovwOURpniDBpSq4A03qkQ+BMQqtGG6HYap3xne9C1O1yo4TR3qxlCX5IqqmX6fFo2Lqg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.2.tgz",
+      "integrity": "sha512-5YfKeeI8qWfBZIX+u2xZC3Zlb3Os/gLS2sbEKM+I4ZOcsWmHS2WLysCcQZDAFRslDUU5Oiq44gf6PYN1vGwG5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/android-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.2.tgz",
+      "integrity": "sha512-O387ite7SzUyCcy3JQX4P4bLtEA7bLLkx+esve5JHnyYfNTxcVpXZo9jhdB0lTKN44gztELTdU7nS8Nr16Fs1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.2.tgz",
+      "integrity": "sha512-n4KqkOQrraxHJcgjM1RvwbigfQKIKJVpM7xp+KsxiyUSrRdIXnt73VhrPAx0fV44hgfmIVKjxMN9J1t5jySVkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.2.tgz",
+      "integrity": "sha512-uq6suIWYP37qzGddBKPw5QEQPi6HiLGsO7UmkpfyaYNQ3D+rN6w6WfwH+nuqcGXWvawGwxOEroO4YGnFh95azw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-n+I0BTSRIoy+d6RPKnEVwql5UwBJolytvY4mAOIEJorKlqgPII8ix6slVVrfZ5Tnj7glIZvloylbB/EJPMWEXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.2.tgz",
+      "integrity": "sha512-78XJTJkvPs0kz2w61301PJjXl4g7q3JqiYMZ/M/yVI73EHBrCRTgkhu9oqG7vPqq+a/yadEW8aD+agKlk5xrmg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.2.tgz",
+      "integrity": "sha512-XlDnu2q5yoqems+xay6wSAcg9DDD7K9RLKZEBOMZm3ckNpJBvOX20tSfby8KfrrhINDyv9V2YVZKY/SpoGJI8w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.2.tgz",
+      "integrity": "sha512-pW4AC0P3it8c7do9MVM4p51FzHzdM/TZrerurgRcHJ2WTa1VQ1CIq18xncfpBJw4ojkiZZrKW2yIBWBP92j6Ug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.2.tgz",
+      "integrity": "sha512-CYbnj78HsIeA+DhgUKgFCfvNsTHFhMMrinUrMZpDXJXKN8T3XViTZ/+wtHeVxEWY8ewSzTFN+nRmSwO2tZaLUQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.2.tgz",
+      "integrity": "sha512-buwkd8nsph4R+ajRvw0qM5Hja/TXQow3ptzWO2EbG/cqcIkHloRrdlBtQlshyYGTNFvfkfJ5tpPLVkY4DtsPfQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.2.tgz",
+      "integrity": "sha512-ZVykbDyk7519VwiNb9Lcj9m8XM6v5V9uKPvrEMkkEedVewf+0itkhahp4HDpgERXhwLRpWFypsGbG/J8s0QjJA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.2.tgz",
+      "integrity": "sha512-CAXl+Dtd9UUuJd8pKKdwh6MLm3MUMiqMPmhZ3tTSXPqfyQ3vDl6R5hZdZ/kYojK4ofXtdfSv1tFq8XzWx3heNQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.2.tgz",
+      "integrity": "sha512-GeXCej4IQtU1B+QlDV8W/RRvbzI3O/Stss+/bCXv4lZls5WGRtu2a+3JkA3i4qIUlMXpcHebWpF8AkJhATowuA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.2.tgz",
+      "integrity": "sha512-3H1weTYZPxt/WOhByszQZybS9w5lKzUn1FDMsgEChbHWQwHYQQRfBxgCcZvPhjHfKyJjIievvMmEUawJrdY9Dg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/linux-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.2.tgz",
+      "integrity": "sha512-4xTZr1FUmSoQW4XIWmit3tzQrUTZM+N3P0XV8xROKYF50XfI7xeO90+1bZvNwxIufQ9hDQVRJH5YhgPVF8A/HQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-sSATRjPeDBg3pdgHoQfoYBob11Kk1FGa9lui5RIHZCoCkJa9QKlvl3/vKz2usCmYYjs7ymJR/2Nnsqe+Hjt5nw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-lqnzCV+mM0gIADaKihiCg6ifgfU2L3h5E33rNQBN1Y4MaVGnzryzmvvf7UHxprpQdE8hpqLolJ9Rl+SkIRDpyw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.2.tgz",
+      "integrity": "sha512-AL2qJILH7lNjrDmCQDvdxMfAUIv8KMNZOvrwAQ8i8//ntL9FflhOyMJ8OZSMBb8/AWXe3/5v5S20y3zCoZWKoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.2.tgz",
+      "integrity": "sha512-QtiuPytchRyC4rwUKhexJdQKvDuZ6hWloi3igqPQNUJCS1/v9EiO3UTOXR6A3FoMo4fnAKbWJdqaIwhOzh8qEw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.2.tgz",
+      "integrity": "sha512-WkhYDmpTjLvGlScA1rwjRUmhl4k8oXR3cIbtqWmELgU/dFeHHlEllxDvdWcNJV9rbzCexB5vz8gtNewWLgCT7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.2.tgz",
+      "integrity": "sha512-GPMSkTOtMnv2U2F8gxe4Io6qmVs+YKyp832Etqqxr0hFngmXQ3rzwytelm3GIn7T4VviRUlf3sOgBOiTdvaf7g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.2.tgz",
+      "integrity": "sha512-PIhhEkE9uPBleRBrQEJpUn7MBnibZzbGzYWPmY3x+YoVg/95zbjB4CxPPOQ8l5tYYM4mMaCthF8/1DIfBQQyWQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.2.tgz",
+      "integrity": "sha512-YmJbfTlvU7Sdn9BB+4PRES4oB6pxgS37MAONj+hBr/cpXS1aBPKXxNnDbu+QCWPj0o9dgyxeq79g6c5P8KeuYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/@esbuild/win32-x64": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.2.tgz",
+      "integrity": "sha512-5ebpxr3nWMzrL/rnUI755Jkuee0bHL/Gq0WTF9lvcpv73wAp5eu8MfBUgWK9bhWvZjj7yX8etf/8tI8Ney695g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tsx/node_modules/esbuild": {
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.2.tgz",
+      "integrity": "sha512-HKVLS8dvII+xoKW9kmqxbRKrnWEXfJJr/FZhhJmiqIB0e053QNYFqOBouTMO/k5sID4MvCiUCvv8b9M4h32wIA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.2",
+        "@esbuild/android-arm": "0.28.2",
+        "@esbuild/android-arm64": "0.28.2",
+        "@esbuild/android-x64": "0.28.2",
+        "@esbuild/darwin-arm64": "0.28.2",
+        "@esbuild/darwin-x64": "0.28.2",
+        "@esbuild/freebsd-arm64": "0.28.2",
+        "@esbuild/freebsd-x64": "0.28.2",
+        "@esbuild/linux-arm": "0.28.2",
+        "@esbuild/linux-arm64": "0.28.2",
+        "@esbuild/linux-ia32": "0.28.2",
+        "@esbuild/linux-loong64": "0.28.2",
+        "@esbuild/linux-mips64el": "0.28.2",
+        "@esbuild/linux-ppc64": "0.28.2",
+        "@esbuild/linux-riscv64": "0.28.2",
+        "@esbuild/linux-s390x": "0.28.2",
+        "@esbuild/linux-x64": "0.28.2",
+        "@esbuild/netbsd-arm64": "0.28.2",
+        "@esbuild/netbsd-x64": "0.28.2",
+        "@esbuild/openbsd-arm64": "0.28.2",
+        "@esbuild/openbsd-x64": "0.28.2",
+        "@esbuild/openharmony-arm64": "0.28.2",
+        "@esbuild/sunos-x64": "0.28.2",
+        "@esbuild/win32-arm64": "0.28.2",
+        "@esbuild/win32-ia32": "0.28.2",
+        "@esbuild/win32-x64": "0.28.2"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    }
+  }
+}

--- a/plugins/obsidian-atomic-write-bridge/package.json
+++ b/plugins/obsidian-atomic-write-bridge/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "optimike-atomic-write-bridge",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "node esbuild.config.mjs",
+    "typecheck": "tsc --noEmit",
+    "test": "tsx --test src/*.test.ts",
+    "check": "npm run typecheck && npm run test && npm run build"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "esbuild": "^0.25.0",
+    "obsidian": "1.13.0",
+    "tsx": "^4.20.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/plugins/obsidian-atomic-write-bridge/src/contract.test.ts
+++ b/plugins/obsidian-atomic-write-bridge/src/contract.test.ts
@@ -2,6 +2,8 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import {
   ATOMIC_WRITE_CONTRACT_VERSION,
+  assertBindingFingerprint,
+  BindingConflictError,
   compareAndReplace,
   HashConflictError,
   parseCasRequest,
@@ -32,20 +34,30 @@ test("read and CAS bodies are strict and versioned", () => {
     parseReadRequest({ contractVersion: 1, path: "Test.md", extra: true }),
   );
   const nextContent = "après";
+  const bindingFingerprint = sha256("fixture-backend");
   const expectedSha256 = sha256("avant");
   assert.deepEqual(
     parseCasRequest({
       contractVersion: 1,
       path: "Test.md",
+      bindingFingerprint,
       expectedSha256,
       nextContent,
     }),
     {
       contractVersion: 1,
       path: "Test.md",
+      bindingFingerprint,
       expectedSha256,
       nextContent,
     },
+  );
+  assert.doesNotThrow(() =>
+    assertBindingFingerprint(bindingFingerprint, bindingFingerprint),
+  );
+  assert.throws(
+    () => assertBindingFingerprint(bindingFingerprint, sha256("other-backend")),
+    BindingConflictError,
   );
 });
 

--- a/plugins/obsidian-atomic-write-bridge/src/contract.test.ts
+++ b/plugins/obsidian-atomic-write-bridge/src/contract.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  ATOMIC_WRITE_CONTRACT_VERSION,
+  compareAndReplace,
+  HashConflictError,
+  parseCasRequest,
+  parseReadRequest,
+  sha256,
+  validateVaultMarkdownPath,
+} from "./contract.js";
+
+test("validates bounded vault-relative Markdown paths", () => {
+  assert.equal(validateVaultMarkdownPath("Notes/Test.md"), "Notes/Test.md");
+  for (const value of [
+    "../Test.md",
+    "/Test.md",
+    "Notes\\Test.md",
+    "Test.txt",
+    ".obsidian/Plugins.md",
+  ]) {
+    assert.throws(() => validateVaultMarkdownPath(value));
+  }
+});
+
+test("read and CAS bodies are strict and versioned", () => {
+  assert.deepEqual(parseReadRequest({ contractVersion: 1, path: "Test.md" }), {
+    contractVersion: ATOMIC_WRITE_CONTRACT_VERSION,
+    path: "Test.md",
+  });
+  assert.throws(() =>
+    parseReadRequest({ contractVersion: 1, path: "Test.md", extra: true }),
+  );
+  const nextContent = "après";
+  const expectedSha256 = sha256("avant");
+  assert.deepEqual(
+    parseCasRequest({
+      contractVersion: 1,
+      path: "Test.md",
+      expectedSha256,
+      nextContent,
+    }),
+    {
+      contractVersion: 1,
+      path: "Test.md",
+      expectedSha256,
+      nextContent,
+    },
+  );
+});
+
+test("SHA-256 is stable over UTF-8 content", () => {
+  assert.equal(
+    sha256("ÉLYSIA"),
+    "9a5a69ce1a1a2173564d5e9b02ce92b6c8e347950ead69d2622c536e4f291fda",
+  );
+});
+
+test("compare-and-replace never returns content after a hash conflict", () => {
+  const expected = sha256("before");
+  assert.deepEqual(compareAndReplace("before", expected, "after"), {
+    beforeSha256: expected,
+    content: "after",
+  });
+  assert.throws(
+    () => compareAndReplace("concurrent", expected, "after"),
+    HashConflictError,
+  );
+});

--- a/plugins/obsidian-atomic-write-bridge/src/contract.ts
+++ b/plugins/obsidian-atomic-write-bridge/src/contract.ts
@@ -11,6 +11,7 @@ export type NoteReadRequest = {
 };
 
 export type NoteCasRequest = NoteReadRequest & {
+  bindingFingerprint: string;
   expectedSha256: string;
   nextContent: string;
 };
@@ -18,6 +19,12 @@ export type NoteCasRequest = NoteReadRequest & {
 export class HashConflictError extends Error {
   constructor(readonly actualSha256: string) {
     super("The note changed after the plan was created.");
+  }
+}
+
+export class BindingConflictError extends Error {
+  constructor() {
+    super("The atomic-write backend instance does not match the sealed plan.");
   }
 }
 
@@ -87,6 +94,20 @@ function contractVersion(input: unknown): 1 {
   return ATOMIC_WRITE_CONTRACT_VERSION;
 }
 
+function sha256Digest(input: unknown, field: string): string {
+  if (typeof input !== "string" || !/^[a-f0-9]{64}$/u.test(input)) {
+    throw new Error(`${field} must be a lowercase SHA-256 digest.`);
+  }
+  return input;
+}
+
+export function assertBindingFingerprint(
+  requested: string,
+  current: string,
+): void {
+  if (requested !== current) throw new BindingConflictError();
+}
+
 export function parseReadRequest(input: unknown): NoteReadRequest {
   const body = bodyRecord(input);
   assertExactKeys(body, ["contractVersion", "path"]);
@@ -99,17 +120,12 @@ export function parseReadRequest(input: unknown): NoteReadRequest {
 export function parseCasRequest(input: unknown): NoteCasRequest {
   const body = bodyRecord(input);
   assertExactKeys(body, [
+    "bindingFingerprint",
     "contractVersion",
     "expectedSha256",
     "nextContent",
     "path",
   ]);
-  if (
-    typeof body.expectedSha256 !== "string" ||
-    !/^[a-f0-9]{64}$/u.test(body.expectedSha256)
-  ) {
-    throw new Error("expectedSha256 must be a lowercase SHA-256 digest.");
-  }
   if (typeof body.nextContent !== "string") {
     throw new Error("nextContent must be a string.");
   }
@@ -119,7 +135,11 @@ export function parseCasRequest(input: unknown): NoteCasRequest {
   return {
     contractVersion: contractVersion(body.contractVersion),
     path: validateVaultMarkdownPath(body.path),
-    expectedSha256: body.expectedSha256,
+    bindingFingerprint: sha256Digest(
+      body.bindingFingerprint,
+      "bindingFingerprint",
+    ),
+    expectedSha256: sha256Digest(body.expectedSha256, "expectedSha256"),
     nextContent: body.nextContent,
   };
 }

--- a/plugins/obsidian-atomic-write-bridge/src/contract.ts
+++ b/plugins/obsidian-atomic-write-bridge/src/contract.ts
@@ -1,0 +1,125 @@
+import { createHash } from "node:crypto";
+
+export const ATOMIC_WRITE_CONTRACT_VERSION = 1 as const;
+export const ATOMIC_WRITE_REST_PREFIX =
+  "/extensions/obsidian-atomic-write-bridge" as const;
+export const MAX_NOTE_BYTES = 5 * 1024 * 1024;
+
+export type NoteReadRequest = {
+  contractVersion: typeof ATOMIC_WRITE_CONTRACT_VERSION;
+  path: string;
+};
+
+export type NoteCasRequest = NoteReadRequest & {
+  expectedSha256: string;
+  nextContent: string;
+};
+
+export class HashConflictError extends Error {
+  constructor(readonly actualSha256: string) {
+    super("The note changed after the plan was created.");
+  }
+}
+
+export function sha256(content: string): string {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+export function compareAndReplace(
+  current: string,
+  expectedSha256: string,
+  nextContent: string,
+): { beforeSha256: string; content: string } {
+  const beforeSha256 = sha256(current);
+  if (beforeSha256 !== expectedSha256) {
+    throw new HashConflictError(beforeSha256);
+  }
+  return { beforeSha256, content: nextContent };
+}
+
+export function validateVaultMarkdownPath(input: unknown): string {
+  if (typeof input !== "string") throw new Error("path must be a string.");
+  const value = input.trim();
+  if (!value || value.length > 1024) {
+    throw new Error("path must contain between 1 and 1024 characters.");
+  }
+  if (value.startsWith("/") || value.includes("\\")) {
+    throw new Error("path must be vault-relative and use forward slashes.");
+  }
+  const parts = value.split("/");
+  if (parts.some((part) => !part || part === "." || part === "..")) {
+    throw new Error("path contains an invalid segment.");
+  }
+  if (parts[0]?.toLowerCase() === ".obsidian") {
+    throw new Error("Obsidian configuration files are outside this bridge.");
+  }
+  if (!value.toLowerCase().endsWith(".md")) {
+    throw new Error("Only Markdown notes are supported.");
+  }
+  return value;
+}
+
+function assertExactKeys(
+  value: Record<string, unknown>,
+  expected: readonly string[],
+): void {
+  const actual = Object.keys(value).sort();
+  const wanted = [...expected].sort();
+  if (
+    actual.length !== wanted.length ||
+    actual.some((key, index) => key !== wanted[index])
+  ) {
+    throw new Error(`Body keys must be exactly: ${wanted.join(", ")}.`);
+  }
+}
+
+function bodyRecord(input: unknown): Record<string, unknown> {
+  if (!input || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("Request body must be a JSON object.");
+  }
+  return input as Record<string, unknown>;
+}
+
+function contractVersion(input: unknown): 1 {
+  if (input !== ATOMIC_WRITE_CONTRACT_VERSION) {
+    throw new Error("contractVersion must be 1.");
+  }
+  return ATOMIC_WRITE_CONTRACT_VERSION;
+}
+
+export function parseReadRequest(input: unknown): NoteReadRequest {
+  const body = bodyRecord(input);
+  assertExactKeys(body, ["contractVersion", "path"]);
+  return {
+    contractVersion: contractVersion(body.contractVersion),
+    path: validateVaultMarkdownPath(body.path),
+  };
+}
+
+export function parseCasRequest(input: unknown): NoteCasRequest {
+  const body = bodyRecord(input);
+  assertExactKeys(body, [
+    "contractVersion",
+    "expectedSha256",
+    "nextContent",
+    "path",
+  ]);
+  if (
+    typeof body.expectedSha256 !== "string" ||
+    !/^[a-f0-9]{64}$/u.test(body.expectedSha256)
+  ) {
+    throw new Error("expectedSha256 must be a lowercase SHA-256 digest.");
+  }
+  if (typeof body.nextContent !== "string") {
+    throw new Error("nextContent must be a string.");
+  }
+  if (Buffer.byteLength(body.nextContent, "utf8") > MAX_NOTE_BYTES) {
+    throw new Error(`nextContent exceeds ${MAX_NOTE_BYTES} UTF-8 bytes.`);
+  }
+  return {
+    contractVersion: contractVersion(body.contractVersion),
+    path: validateVaultMarkdownPath(body.path),
+    expectedSha256: body.expectedSha256,
+    nextContent: body.nextContent,
+  };
+}

--- a/plugins/obsidian-atomic-write-bridge/src/main.ts
+++ b/plugins/obsidian-atomic-write-bridge/src/main.ts
@@ -1,0 +1,270 @@
+import { createHash, randomUUID } from "node:crypto";
+import { Plugin, PluginSettingTab, Setting, TFile } from "obsidian";
+import {
+  ATOMIC_WRITE_CONTRACT_VERSION,
+  ATOMIC_WRITE_REST_PREFIX,
+  compareAndReplace,
+  HashConflictError,
+  parseCasRequest,
+  parseReadRequest,
+  sha256,
+} from "./contract.js";
+
+type PluginData = { instanceId: string; allowWrites: boolean };
+
+function responseStatus(res: any, status: number): any {
+  if (typeof res?.status === "function") return res.status(status);
+  if (res && "statusCode" in res) res.statusCode = status;
+  return res;
+}
+
+function sendJson(res: any, status: number, payload: unknown): void {
+  const target = responseStatus(res, status);
+  if (typeof target?.json !== "function") {
+    throw new Error("Local REST API response does not expose json().");
+  }
+  target.json(payload);
+}
+
+function errorPayload(code: string, message: string, details?: object) {
+  return {
+    ok: false,
+    contractVersion: ATOMIC_WRITE_CONTRACT_VERSION,
+    error: { code, message, ...(details ? { details } : {}) },
+  };
+}
+
+export default class OptimikeAtomicWriteBridgePlugin extends Plugin {
+  private instanceId = "";
+  private bindingFingerprint = "";
+  allowWrites = false;
+
+  async onload(): Promise<void> {
+    const stored = (await this.loadData()) as Partial<PluginData> | null;
+    this.instanceId =
+      typeof stored?.instanceId === "string" && stored.instanceId.length > 0
+        ? stored.instanceId
+        : randomUUID();
+    this.allowWrites = stored?.allowWrites === true;
+    const deviceStorageKey = "optimike-atomic-write-bridge:device-id";
+    let deviceId = window.localStorage.getItem(deviceStorageKey);
+    if (!deviceId) {
+      deviceId = randomUUID();
+      window.localStorage.setItem(deviceStorageKey, deviceId);
+    }
+    const adapter = this.app.vault.adapter as { getBasePath?: () => string };
+    const basePath = adapter.getBasePath?.();
+    if (!basePath) {
+      throw new Error(
+        "Atomic Write Bridge requires a desktop filesystem vault identity.",
+      );
+    }
+    this.bindingFingerprint = createHash("sha256")
+      .update(`${deviceId}\0${this.instanceId}\0${basePath}`, "utf8")
+      .digest("hex");
+    if (
+      stored?.instanceId !== this.instanceId ||
+      stored?.allowWrites !== this.allowWrites
+    ) {
+      await this.saveSettings();
+    }
+    this.addSettingTab(new AtomicWriteSettingsTab(this.app, this));
+    void this.registerRestExtension();
+  }
+
+  async saveSettings(): Promise<void> {
+    await this.saveData({
+      instanceId: this.instanceId,
+      allowWrites: this.allowWrites,
+    } satisfies PluginData);
+  }
+
+  private file(path: string): TFile {
+    const file = this.app.vault.getAbstractFileByPath(path);
+    if (!(file instanceof TFile)) throw new Error("Note not found.");
+    return file;
+  }
+
+  private async registerRestExtension(): Promise<void> {
+    await new Promise<void>((resolve) =>
+      this.app.workspace.onLayoutReady(() => resolve()),
+    );
+    let mounted = false;
+    const tryMount = () => {
+      if (mounted) return;
+      const restPlugin: any =
+        (this.app as any).plugins?.plugins?.["obsidian-local-rest-api"] ??
+        (this.app as any).plugins?.getPlugin?.("obsidian-local-rest-api");
+      const getPublicApi =
+        typeof restPlugin?.getPublicApi === "function"
+          ? restPlugin.getPublicApi.bind(restPlugin)
+          : undefined;
+      if (!getPublicApi) return;
+      const api = getPublicApi(this.manifest);
+      if (!api || typeof api.addRoute !== "function") return;
+
+      api
+        .addRoute(`${ATOMIC_WRITE_REST_PREFIX}/status`)
+        .get((_req: any, res: any) =>
+          sendJson(res, 200, {
+            ok: true,
+            contractVersion: ATOMIC_WRITE_CONTRACT_VERSION,
+            plugin: {
+              id: this.manifest.id,
+              version: this.manifest.version,
+            },
+            backend: {
+              kind: "obsidian-vault-process",
+              bindingFingerprint: this.bindingFingerprint,
+              atomicCas: true,
+              writeEnabled: this.allowWrites,
+            },
+            limits: { markdownOnly: true },
+          }),
+        );
+
+      api
+        .addRoute(`${ATOMIC_WRITE_REST_PREFIX}/notes/read`)
+        .post(async (req: any, res: any) => {
+          try {
+            const request = parseReadRequest(req?.body);
+            const content = await this.app.vault.read(this.file(request.path));
+            sendJson(res, 200, {
+              ok: true,
+              contractVersion: ATOMIC_WRITE_CONTRACT_VERSION,
+              path: request.path,
+              content,
+              sha256: sha256(content),
+              size: Buffer.byteLength(content, "utf8"),
+              bindingFingerprint: this.bindingFingerprint,
+            });
+          } catch (error) {
+            const notFound =
+              error instanceof Error && error.message === "Note not found.";
+            sendJson(
+              res,
+              notFound ? 404 : 400,
+              errorPayload(
+                notFound ? "note_not_found" : "invalid_request",
+                error instanceof Error ? error.message : String(error),
+              ),
+            );
+          }
+        });
+
+      api
+        .addRoute(`${ATOMIC_WRITE_REST_PREFIX}/notes/cas`)
+        .post(async (req: any, res: any) => {
+          try {
+            if (!this.allowWrites) {
+              sendJson(
+                res,
+                403,
+                errorPayload(
+                  "writes_disabled",
+                  "Atomic note writes are disabled in the bridge settings.",
+                ),
+              );
+              return;
+            }
+            const request = parseCasRequest(req?.body);
+            let beforeSha256 = "";
+            const written = await this.app.vault.process(
+              this.file(request.path),
+              (current) => {
+                const result = compareAndReplace(
+                  current,
+                  request.expectedSha256,
+                  request.nextContent,
+                );
+                beforeSha256 = result.beforeSha256;
+                return result.content;
+              },
+            );
+            sendJson(res, 200, {
+              ok: true,
+              contractVersion: ATOMIC_WRITE_CONTRACT_VERSION,
+              path: request.path,
+              beforeSha256,
+              afterSha256: sha256(written),
+              size: Buffer.byteLength(written, "utf8"),
+              bindingFingerprint: this.bindingFingerprint,
+            });
+          } catch (error) {
+            if (error instanceof HashConflictError) {
+              sendJson(
+                res,
+                409,
+                errorPayload("hash_conflict", error.message, {
+                  actualSha256: error.actualSha256,
+                }),
+              );
+              return;
+            }
+            const notFound =
+              error instanceof Error && error.message === "Note not found.";
+            sendJson(
+              res,
+              notFound ? 404 : 400,
+              errorPayload(
+                notFound ? "note_not_found" : "invalid_request",
+                error instanceof Error ? error.message : String(error),
+              ),
+            );
+          }
+        });
+
+      this.register(() => {
+        try {
+          api.unregister?.();
+        } catch {
+          // Local REST API owns the route registry lifecycle.
+        }
+      });
+      mounted = true;
+    };
+
+    tryMount();
+    if (!mounted) {
+      const interval = window.setInterval(tryMount, 500);
+      const timeout = window.setTimeout(() => {
+        window.clearInterval(interval);
+        if (!mounted) {
+          console.warn(
+            "[atomic-write-bridge] Local REST API extension API unavailable.",
+          );
+        }
+      }, 30_000);
+      this.register(() => {
+        window.clearInterval(interval);
+        window.clearTimeout(timeout);
+      });
+    }
+  }
+}
+
+class AtomicWriteSettingsTab extends PluginSettingTab {
+  constructor(
+    app: any,
+    private readonly bridge: OptimikeAtomicWriteBridgePlugin,
+  ) {
+    super(app, bridge);
+  }
+
+  display(): void {
+    const { containerEl } = this;
+    containerEl.empty();
+    containerEl.createEl("h3", { text: "Optimike Atomic Write Bridge" });
+    new Setting(containerEl)
+      .setName("Autoriser les écritures atomiques")
+      .setDesc(
+        "Désactivé par défaut. Autorise uniquement les remplacements de notes Markdown avec précondition SHA-256 exacte via Local REST API.",
+      )
+      .addToggle((toggle) =>
+        toggle.setValue(this.bridge.allowWrites).onChange(async (value) => {
+          this.bridge.allowWrites = value;
+          await this.bridge.saveSettings();
+        }),
+      );
+  }
+}

--- a/plugins/obsidian-atomic-write-bridge/src/main.ts
+++ b/plugins/obsidian-atomic-write-bridge/src/main.ts
@@ -3,6 +3,8 @@ import { Plugin, PluginSettingTab, Setting, TFile } from "obsidian";
 import {
   ATOMIC_WRITE_CONTRACT_VERSION,
   ATOMIC_WRITE_REST_PREFIX,
+  assertBindingFingerprint,
+  BindingConflictError,
   compareAndReplace,
   HashConflictError,
   parseCasRequest,
@@ -168,6 +170,10 @@ export default class OptimikeAtomicWriteBridgePlugin extends Plugin {
               return;
             }
             const request = parseCasRequest(req?.body);
+            assertBindingFingerprint(
+              request.bindingFingerprint,
+              this.bindingFingerprint,
+            );
             let beforeSha256 = "";
             const written = await this.app.vault.process(
               this.file(request.path),
@@ -191,6 +197,14 @@ export default class OptimikeAtomicWriteBridgePlugin extends Plugin {
               bindingFingerprint: this.bindingFingerprint,
             });
           } catch (error) {
+            if (error instanceof BindingConflictError) {
+              sendJson(
+                res,
+                409,
+                errorPayload("binding_conflict", error.message),
+              );
+              return;
+            }
             if (error instanceof HashConflictError) {
               sendJson(
                 res,

--- a/plugins/obsidian-atomic-write-bridge/tsconfig.json
+++ b/plugins/obsidian-atomic-write-bridge/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/scripts/test-obsidian-note-replace-operation.mjs
+++ b/scripts/test-obsidian-note-replace-operation.mjs
@@ -18,6 +18,7 @@ class FakeAtomicWriteBackend {
   replaceCalls = 0;
   failBeforeWriteOnce = false;
   loseResponseAfterWriteOnce = false;
+  afterWriteBeforeReturn = undefined;
 
   async status() {
     return {
@@ -61,6 +62,10 @@ class FakeAtomicWriteBackend {
       throw new McpError(BaseErrorCode.CONFLICT, "Fixture hash conflict.");
     }
     this.content = payload.nextContent;
+    if (this.afterWriteBeforeReturn) {
+      await this.afterWriteBeforeReturn();
+      this.afterWriteBeforeReturn = undefined;
+    }
     if (this.loseResponseAfterWriteOnce) {
       this.loseResponseAfterWriteOnce = false;
       throw new McpError(
@@ -147,6 +152,22 @@ try {
   }
 
   {
+    const { backend, adapter } = fixture("concurrent-status");
+    const planned = await adapter.plan({
+      path: backend.path,
+      nextContent: "committed during concurrent status",
+      idempotencyKey: "concurrent-status",
+    });
+    backend.afterWriteBeforeReturn = async () => {
+      const concurrent = await adapter.status(planned.planRef);
+      assert.equal(concurrent.outcome, "committed");
+    };
+    const committed = await adapter.apply(planned.planRef, "concurrent-status");
+    assert.equal(committed.outcome, "committed");
+    assert.equal(backend.replaceCalls, 1);
+  }
+
+  {
     const { backend, adapter } = fixture("recover-same-plan");
     backend.failBeforeWriteOnce = true;
     const planned = await adapter.plan({
@@ -189,6 +210,46 @@ try {
       }),
       /different note replacement/u,
     );
+  }
+
+  {
+    let now = Date.parse("2026-08-13T00:00:00.000Z");
+    const journal = new ObsidianNoteReplaceJournal(
+      path.join(temporaryRoot, "retention.sqlite"),
+      {
+        now: () => now,
+        terminalRetentionMs: 1_000,
+        purgeIntervalMs: 100,
+      },
+    );
+    journals.push(journal);
+    const terminal = journal.create({
+      idempotencyKey: "retention-terminal",
+      requestDigest: sha256("retention-request"),
+      path: "Fixture/Retention.md",
+      beforeSha256: sha256("before"),
+      afterSha256: sha256("after"),
+      nextContent: "sensitive terminal content",
+      bindingFingerprint: sha256("fixture-vault-instance"),
+    });
+    journal.transition(terminal.operationId, ["planned"], "applying");
+    const committed = journal.transition(
+      terminal.operationId,
+      ["applying"],
+      "committed",
+    );
+    assert.equal(committed.nextContent, "");
+    now += 2_000;
+    journal.create({
+      idempotencyKey: "retention-trigger",
+      requestDigest: sha256("retention-trigger"),
+      path: "Fixture/Trigger.md",
+      beforeSha256: sha256("before"),
+      afterSha256: sha256("next"),
+      nextContent: "next",
+      bindingFingerprint: sha256("fixture-vault-instance"),
+    });
+    assert.equal(journal.get(terminal.operationId), undefined);
   }
 
   console.log(

--- a/scripts/test-obsidian-note-replace-operation.mjs
+++ b/scripts/test-obsidian-note-replace-operation.mjs
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { createHash } from "node:crypto";
-import { mkdtempSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { ObsidianNoteReplaceOperationAdapter } from "../dist/services/operations/obsidianNoteReplaceOperationAdapter.js";
@@ -267,14 +267,14 @@ try {
 
   {
     let now = Date.parse("2026-08-13T00:00:00.000Z");
-    const journal = new ObsidianNoteReplaceJournal(
-      path.join(temporaryRoot, "retention.sqlite"),
-      {
-        now: () => now,
-        terminalRetentionMs: 1_000,
-        purgeIntervalMs: 100,
-      },
-    );
+    const retentionPath = path.join(temporaryRoot, "retention.sqlite");
+    const sensitiveTerminalContent =
+      "sensitive-terminal-content-4ec0d4b4-erase-from-wal";
+    const journal = new ObsidianNoteReplaceJournal(retentionPath, {
+      now: () => now,
+      terminalRetentionMs: 1_000,
+      purgeIntervalMs: 100,
+    });
     journals.push(journal);
     const terminal = journal.create({
       idempotencyKey: "retention-terminal",
@@ -282,7 +282,7 @@ try {
       path: "Fixture/Retention.md",
       beforeSha256: sha256("before"),
       afterSha256: sha256("after"),
-      nextContent: "sensitive terminal content",
+      nextContent: sensitiveTerminalContent,
       bindingFingerprint: sha256("fixture-vault-instance"),
     });
     journal.transition(terminal.operationId, ["planned"], "applying");
@@ -292,6 +292,15 @@ try {
       "committed",
     );
     assert.equal(committed.nextContent, "");
+    for (const persistedPath of [retentionPath, `${retentionPath}-wal`]) {
+      if (!existsSync(persistedPath)) continue;
+      assert.equal(
+        readFileSync(persistedPath).includes(
+          Buffer.from(sensitiveTerminalContent, "utf8"),
+        ),
+        false,
+      );
+    }
     now += 2_000;
     journal.create({
       idempotencyKey: "retention-trigger",
@@ -306,7 +315,7 @@ try {
   }
 
   console.log(
-    "Obsidian note replacement operation fixture passed: plan/apply/status/recover, atomic conflict, concurrent replay, redacted logging, and lost-response reconciliation.",
+    "Obsidian note replacement operation fixture passed: plan/apply/status/recover, atomic conflict, concurrent replay, redacted logging/WAL, and lost-response reconciliation.",
   );
 } finally {
   for (const journal of journals) journal.close();

--- a/scripts/test-obsidian-note-replace-operation.mjs
+++ b/scripts/test-obsidian-note-replace-operation.mjs
@@ -1,0 +1,200 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { ObsidianNoteReplaceOperationAdapter } from "../dist/services/operations/obsidianNoteReplaceOperationAdapter.js";
+import { ObsidianNoteReplaceJournal } from "../dist/services/operations/obsidianNoteReplaceJournal.js";
+import { BaseErrorCode, McpError } from "../dist/types-global/errors.js";
+
+function sha256(content) {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+class FakeAtomicWriteBackend {
+  bindingFingerprint = sha256("fixture-vault-instance");
+  path = "Fixture/Note.md";
+  content = "before";
+  replaceCalls = 0;
+  failBeforeWriteOnce = false;
+  loseResponseAfterWriteOnce = false;
+
+  async status() {
+    return {
+      ok: true,
+      contractVersion: 1,
+      plugin: { id: "obsidian-atomic-write-bridge", version: "0.1.0" },
+      backend: {
+        kind: "obsidian-vault-process",
+        bindingFingerprint: this.bindingFingerprint,
+        atomicCas: true,
+        writeEnabled: true,
+      },
+      limits: { markdownOnly: true },
+    };
+  }
+
+  async read(payload) {
+    assert.equal(payload.path, this.path);
+    return {
+      ok: true,
+      contractVersion: 1,
+      path: this.path,
+      content: this.content,
+      sha256: sha256(this.content),
+      size: Buffer.byteLength(this.content, "utf8"),
+      bindingFingerprint: this.bindingFingerprint,
+    };
+  }
+
+  async replace(payload) {
+    this.replaceCalls += 1;
+    if (this.failBeforeWriteOnce) {
+      this.failBeforeWriteOnce = false;
+      throw new McpError(
+        BaseErrorCode.SERVICE_UNAVAILABLE,
+        "Fixture lost the request before the write.",
+      );
+    }
+    const beforeSha256 = sha256(this.content);
+    if (beforeSha256 !== payload.expectedSha256) {
+      throw new McpError(BaseErrorCode.CONFLICT, "Fixture hash conflict.");
+    }
+    this.content = payload.nextContent;
+    if (this.loseResponseAfterWriteOnce) {
+      this.loseResponseAfterWriteOnce = false;
+      throw new McpError(
+        BaseErrorCode.SERVICE_UNAVAILABLE,
+        "Fixture lost the response after the write.",
+      );
+    }
+    return {
+      ok: true,
+      contractVersion: 1,
+      path: this.path,
+      beforeSha256,
+      afterSha256: sha256(this.content),
+      size: Buffer.byteLength(this.content, "utf8"),
+      bindingFingerprint: this.bindingFingerprint,
+    };
+  }
+}
+
+const temporaryRoot = mkdtempSync(path.join(os.tmpdir(), "optimike-note-op-"));
+const journals = [];
+
+function fixture(name) {
+  const backend = new FakeAtomicWriteBackend();
+  const journal = new ObsidianNoteReplaceJournal(
+    path.join(temporaryRoot, `${name}.sqlite`),
+  );
+  journals.push(journal);
+  return {
+    backend,
+    adapter: new ObsidianNoteReplaceOperationAdapter(backend, journal),
+  };
+}
+
+try {
+  {
+    const { backend, adapter } = fixture("commit-replay");
+    const planned = await adapter.plan({
+      path: backend.path,
+      nextContent: "after",
+      idempotencyKey: "commit-replay",
+    });
+    assert.equal(planned.phase, "planned");
+    assert.equal(planned.applyAllowed, true);
+    assert.equal(
+      (await adapter.status(planned.planRef)).planDigest,
+      planned.planDigest,
+    );
+    const committed = await adapter.apply(planned.planRef, "commit-replay");
+    assert.equal(committed.outcome, "committed");
+    assert.equal(committed.postflight.status, "verified");
+    assert.equal(backend.content, "after");
+    assert.equal(backend.replaceCalls, 1);
+    const replay = await adapter.apply(planned.planRef, "commit-replay");
+    assert.equal(replay.outcome, "committed");
+    assert.equal(backend.replaceCalls, 1);
+  }
+
+  {
+    const { backend, adapter } = fixture("conflict");
+    const planned = await adapter.plan({
+      path: backend.path,
+      nextContent: "after",
+      idempotencyKey: "conflict",
+    });
+    backend.content = "concurrent edit";
+    const result = await adapter.apply(planned.planRef, "conflict");
+    assert.equal(result.outcome, "conflict");
+    assert.equal(backend.content, "concurrent edit");
+  }
+
+  {
+    const { backend, adapter } = fixture("lost-response");
+    backend.loseResponseAfterWriteOnce = true;
+    const planned = await adapter.plan({
+      path: backend.path,
+      nextContent: "written despite lost response",
+      idempotencyKey: "lost-response",
+    });
+    const result = await adapter.apply(planned.planRef, "lost-response");
+    assert.equal(result.outcome, "committed");
+    assert.equal(result.postflight.status, "verified");
+    assert.equal(backend.replaceCalls, 1);
+  }
+
+  {
+    const { backend, adapter } = fixture("recover-same-plan");
+    backend.failBeforeWriteOnce = true;
+    const planned = await adapter.plan({
+      path: backend.path,
+      nextContent: "recovered",
+      idempotencyKey: "recover-same-plan",
+    });
+    const unknown = await adapter.apply(planned.planRef, "recover-same-plan");
+    assert.equal(unknown.outcome, "outcome_unknown");
+    assert.equal(unknown.recoveryAllowed, true);
+    assert.equal(backend.content, "before");
+    const recovered = await adapter.recover(
+      planned.planRef,
+      "recover-same-plan",
+    );
+    assert.equal(recovered.outcome, "committed");
+    assert.equal(backend.content, "recovered");
+    assert.equal(backend.replaceCalls, 2);
+  }
+
+  {
+    const { backend, adapter } = fixture("idempotency-binding");
+    await adapter.plan({
+      path: backend.path,
+      nextContent: "first",
+      idempotencyKey: "same-key",
+    });
+    backend.content = "changed after the plan was sealed";
+    const replay = await adapter.plan({
+      path: backend.path,
+      nextContent: "first",
+      idempotencyKey: "same-key",
+    });
+    assert.equal(replay.idempotencyKey, "same-key");
+    await assert.rejects(
+      adapter.plan({
+        path: backend.path,
+        nextContent: "different",
+        idempotencyKey: "same-key",
+      }),
+      /different note replacement/u,
+    );
+  }
+
+  console.log(
+    "Obsidian note replacement operation fixture passed: plan/apply/status/recover, atomic conflict, replay, and lost-response reconciliation.",
+  );
+} finally {
+  for (const journal of journals) journal.close();
+  rmSync(temporaryRoot, { recursive: true, force: true });
+}

--- a/scripts/test-obsidian-note-replace-operation.mjs
+++ b/scripts/test-obsidian-note-replace-operation.mjs
@@ -263,6 +263,40 @@ try {
   }
 
   {
+    const { backend, adapter } = fixture("concurrent-recover");
+    let releaseWrite;
+    let markWriteEntered;
+    const writeEntered = new Promise((resolve) => {
+      markWriteEntered = resolve;
+    });
+    const writeReleased = new Promise((resolve) => {
+      releaseWrite = resolve;
+    });
+    backend.beforeWrite = async () => {
+      markWriteEntered();
+      await writeReleased;
+    };
+    const planned = await adapter.plan({
+      path: backend.path,
+      nextContent: "one write despite concurrent recovery",
+      idempotencyKey: "concurrent-recover",
+    });
+    const firstApply = adapter.apply(planned.planRef, "concurrent-recover");
+    await writeEntered;
+    const recovery = await adapter.recover(
+      planned.planRef,
+      "concurrent-recover",
+    );
+    assert.equal(recovery.phase, "applying");
+    assert.equal(recovery.outcome, null);
+    assert.equal(backend.replaceCalls, 1);
+    releaseWrite();
+    const committed = await firstApply;
+    assert.equal(committed.outcome, "committed");
+    assert.equal(backend.replaceCalls, 1);
+  }
+
+  {
     const { backend, adapter } = fixture("recover-same-plan");
     backend.failBeforeWriteOnce = true;
     const planned = await adapter.plan({
@@ -343,6 +377,28 @@ try {
     assert.equal(metadata.hasBody, true);
     assert.equal(serialized.includes(privateBody), false);
     assert.equal(serialized.includes("private-token"), false);
+  }
+
+  {
+    const restartPath = path.join(temporaryRoot, "restart-interruption.sqlite");
+    const firstJournal = new ObsidianNoteReplaceJournal(restartPath);
+    const applying = firstJournal.create({
+      idempotencyKey: "restart-interruption",
+      requestDigest: sha256("restart-interruption-request"),
+      path: "Fixture/Restart.md",
+      beforeSha256: sha256("before"),
+      afterSha256: sha256("after"),
+      nextContent: "retained exact recovery content",
+      bindingFingerprint: sha256("fixture-vault-instance"),
+    });
+    firstJournal.transition(applying.operationId, ["planned"], "applying");
+    firstJournal.close();
+    const restartedJournal = new ObsidianNoteReplaceJournal(restartPath);
+    journals.push(restartedJournal);
+    const interrupted = restartedJournal.get(applying.operationId);
+    assert.equal(interrupted.status, "outcome_unknown");
+    assert.equal(interrupted.nextContent, "retained exact recovery content");
+    assert.match(interrupted.failure, /process restarted/u);
   }
 
   {

--- a/scripts/test-obsidian-note-replace-operation.mjs
+++ b/scripts/test-obsidian-note-replace-operation.mjs
@@ -18,6 +18,7 @@ class FakeAtomicWriteBackend {
   content = "before";
   replaceCalls = 0;
   failBeforeWriteOnce = false;
+  rejectBeforeWriteOnce = false;
   loseResponseAfterWriteOnce = false;
   afterStatus = undefined;
   afterRead = undefined;
@@ -66,6 +67,13 @@ class FakeAtomicWriteBackend {
 
   async replace(payload) {
     this.replaceCalls += 1;
+    if (this.rejectBeforeWriteOnce) {
+      this.rejectBeforeWriteOnce = false;
+      throw new McpError(
+        BaseErrorCode.FORBIDDEN,
+        "Atomic note writes are disabled in the bridge settings.",
+      );
+    }
     if (payload.bindingFingerprint !== this.bindingFingerprint) {
       throw new McpError(BaseErrorCode.CONFLICT, "Fixture binding conflict.");
     }
@@ -159,6 +167,24 @@ try {
     const result = await adapter.apply(planned.planRef, "conflict");
     assert.equal(result.outcome, "conflict");
     assert.equal(backend.content, "concurrent edit");
+  }
+
+  {
+    const { backend, adapter } = fixture("disabled-between-status-and-cas");
+    const planned = await adapter.plan({
+      path: backend.path,
+      nextContent: "must not be written after disable",
+      idempotencyKey: "disabled-between-status-and-cas",
+    });
+    backend.rejectBeforeWriteOnce = true;
+    const result = await adapter.apply(
+      planned.planRef,
+      "disabled-between-status-and-cas",
+    );
+    assert.equal(result.outcome, "rejected");
+    assert.equal(result.recoveryAllowed, false);
+    assert.equal(backend.content, "before");
+    assert.equal(backend.replaceCalls, 1);
   }
 
   {

--- a/scripts/test-obsidian-note-replace-operation.mjs
+++ b/scripts/test-obsidian-note-replace-operation.mjs
@@ -318,6 +318,68 @@ try {
   }
 
   {
+    const { backend, adapter } = fixture("concurrent-recovery-replay");
+    backend.failBeforeWriteOnce = true;
+    const planned = await adapter.plan({
+      path: backend.path,
+      nextContent: "one write despite concurrent recovery replay",
+      idempotencyKey: "concurrent-recovery-replay",
+    });
+    const unknown = await adapter.apply(
+      planned.planRef,
+      "concurrent-recovery-replay",
+    );
+    assert.equal(unknown.outcome, "outcome_unknown");
+
+    let releaseFirstRead;
+    let markFirstReadEntered;
+    const firstReadEntered = new Promise((resolve) => {
+      markFirstReadEntered = resolve;
+    });
+    const firstReadReleased = new Promise((resolve) => {
+      releaseFirstRead = resolve;
+    });
+    backend.afterRead = async () => {
+      markFirstReadEntered();
+      await firstReadReleased;
+    };
+
+    let releaseWrite;
+    let markWriteEntered;
+    const writeEntered = new Promise((resolve) => {
+      markWriteEntered = resolve;
+    });
+    const writeReleased = new Promise((resolve) => {
+      releaseWrite = resolve;
+    });
+    backend.beforeWrite = async () => {
+      markWriteEntered();
+      await writeReleased;
+    };
+
+    const losingRecovery = adapter.recover(
+      planned.planRef,
+      "concurrent-recovery-replay",
+    );
+    await firstReadEntered;
+    const winningRecovery = adapter.recover(
+      planned.planRef,
+      "concurrent-recovery-replay",
+    );
+    await writeEntered;
+    releaseFirstRead();
+    const replay = await losingRecovery;
+    assert.equal(replay.phase, "applying");
+    assert.equal(replay.outcome, null);
+    assert.equal(backend.replaceCalls, 2);
+    releaseWrite();
+    const committed = await winningRecovery;
+    assert.equal(committed.outcome, "committed");
+    assert.equal(backend.content, "one write despite concurrent recovery replay");
+    assert.equal(backend.replaceCalls, 2);
+  }
+
+  {
     const { backend, adapter } = fixture("recover-race-to-after");
     backend.failBeforeWriteOnce = true;
     const planned = await adapter.plan({

--- a/scripts/test-obsidian-note-replace-operation.mjs
+++ b/scripts/test-obsidian-note-replace-operation.mjs
@@ -19,11 +19,12 @@ class FakeAtomicWriteBackend {
   replaceCalls = 0;
   failBeforeWriteOnce = false;
   loseResponseAfterWriteOnce = false;
+  afterStatus = undefined;
   beforeWrite = undefined;
   afterWriteBeforeReturn = undefined;
 
   async status() {
-    return {
+    const response = {
       ok: true,
       contractVersion: 1,
       plugin: { id: "obsidian-atomic-write-bridge", version: "0.1.0" },
@@ -35,6 +36,12 @@ class FakeAtomicWriteBackend {
       },
       limits: { markdownOnly: true },
     };
+    if (this.afterStatus) {
+      const afterStatus = this.afterStatus;
+      this.afterStatus = undefined;
+      await afterStatus();
+    }
+    return response;
   }
 
   async read(payload) {
@@ -52,6 +59,9 @@ class FakeAtomicWriteBackend {
 
   async replace(payload) {
     this.replaceCalls += 1;
+    if (payload.bindingFingerprint !== this.bindingFingerprint) {
+      throw new McpError(BaseErrorCode.CONFLICT, "Fixture binding conflict.");
+    }
     if (this.failBeforeWriteOnce) {
       this.failBeforeWriteOnce = false;
       throw new McpError(
@@ -142,6 +152,22 @@ try {
     const result = await adapter.apply(planned.planRef, "conflict");
     assert.equal(result.outcome, "conflict");
     assert.equal(backend.content, "concurrent edit");
+  }
+
+  {
+    const { backend, adapter } = fixture("binding-conflict");
+    const planned = await adapter.plan({
+      path: backend.path,
+      nextContent: "must not reach another vault",
+      idempotencyKey: "binding-conflict",
+    });
+    backend.afterStatus = async () => {
+      backend.bindingFingerprint = sha256("different-vault-instance");
+    };
+    const result = await adapter.apply(planned.planRef, "binding-conflict");
+    assert.equal(result.outcome, "conflict");
+    assert.equal(backend.content, "before");
+    assert.equal(backend.replaceCalls, 1);
   }
 
   {
@@ -315,7 +341,7 @@ try {
   }
 
   console.log(
-    "Obsidian note replacement operation fixture passed: plan/apply/status/recover, atomic conflict, concurrent replay, redacted logging/WAL, and lost-response reconciliation.",
+    "Obsidian note replacement operation fixture passed: plan/apply/status/recover, backend binding, atomic conflict, concurrent replay, redacted logging/WAL, and lost-response reconciliation.",
   );
 } finally {
   for (const journal of journals) journal.close();

--- a/scripts/test-obsidian-note-replace-operation.mjs
+++ b/scripts/test-obsidian-note-replace-operation.mjs
@@ -20,6 +20,7 @@ class FakeAtomicWriteBackend {
   failBeforeWriteOnce = false;
   loseResponseAfterWriteOnce = false;
   afterStatus = undefined;
+  afterRead = undefined;
   beforeWrite = undefined;
   afterWriteBeforeReturn = undefined;
 
@@ -46,7 +47,7 @@ class FakeAtomicWriteBackend {
 
   async read(payload) {
     assert.equal(payload.path, this.path);
-    return {
+    const response = {
       ok: true,
       contractVersion: 1,
       path: this.path,
@@ -55,6 +56,12 @@ class FakeAtomicWriteBackend {
       size: Buffer.byteLength(this.content, "utf8"),
       bindingFingerprint: this.bindingFingerprint,
     };
+    if (this.afterRead) {
+      const afterRead = this.afterRead;
+      this.afterRead = undefined;
+      await afterRead();
+    }
+    return response;
   }
 
   async replace(payload) {
@@ -185,6 +192,29 @@ try {
   }
 
   {
+    const { backend, adapter } = fixture("lost-response-then-drift");
+    backend.loseResponseAfterWriteOnce = true;
+    backend.afterWriteBeforeReturn = async () => {
+      backend.content = "third-party edit after successful hidden write";
+    };
+    const planned = await adapter.plan({
+      path: backend.path,
+      nextContent: "written before subsequent drift",
+      idempotencyKey: "lost-response-then-drift",
+    });
+    const result = await adapter.apply(
+      planned.planRef,
+      "lost-response-then-drift",
+    );
+    assert.equal(result.outcome, "outcome_unknown");
+    assert.equal(result.recoveryAllowed, true);
+    assert.equal(
+      backend.content,
+      "third-party edit after successful hidden write",
+    );
+  }
+
+  {
     const { backend, adapter } = fixture("concurrent-status");
     const planned = await adapter.plan({
       path: backend.path,
@@ -251,6 +281,30 @@ try {
     assert.equal(recovered.outcome, "committed");
     assert.equal(backend.content, "recovered");
     assert.equal(backend.replaceCalls, 2);
+  }
+
+  {
+    const { backend, adapter } = fixture("recover-race-to-after");
+    backend.failBeforeWriteOnce = true;
+    const planned = await adapter.plan({
+      path: backend.path,
+      nextContent: "appeared between recovery reads",
+      idempotencyKey: "recover-race-to-after",
+    });
+    const unknown = await adapter.apply(
+      planned.planRef,
+      "recover-race-to-after",
+    );
+    assert.equal(unknown.outcome, "outcome_unknown");
+    backend.afterRead = async () => {
+      backend.content = "appeared between recovery reads";
+    };
+    const recovered = await adapter.recover(
+      planned.planRef,
+      "recover-race-to-after",
+    );
+    assert.equal(recovered.outcome, "committed");
+    assert.equal(backend.replaceCalls, 1);
   }
 
   {

--- a/scripts/test-obsidian-note-replace-operation.mjs
+++ b/scripts/test-obsidian-note-replace-operation.mjs
@@ -5,6 +5,7 @@ import os from "node:os";
 import path from "node:path";
 import { ObsidianNoteReplaceOperationAdapter } from "../dist/services/operations/obsidianNoteReplaceOperationAdapter.js";
 import { ObsidianNoteReplaceJournal } from "../dist/services/operations/obsidianNoteReplaceJournal.js";
+import { requestLogMetadata } from "../dist/services/obsidianRestAPI/requestLogMetadata.js";
 import { BaseErrorCode, McpError } from "../dist/types-global/errors.js";
 
 function sha256(content) {
@@ -18,6 +19,7 @@ class FakeAtomicWriteBackend {
   replaceCalls = 0;
   failBeforeWriteOnce = false;
   loseResponseAfterWriteOnce = false;
+  beforeWrite = undefined;
   afterWriteBeforeReturn = undefined;
 
   async status() {
@@ -56,6 +58,11 @@ class FakeAtomicWriteBackend {
         BaseErrorCode.SERVICE_UNAVAILABLE,
         "Fixture lost the request before the write.",
       );
+    }
+    if (this.beforeWrite) {
+      const beforeWrite = this.beforeWrite;
+      this.beforeWrite = undefined;
+      await beforeWrite();
     }
     const beforeSha256 = sha256(this.content);
     if (beforeSha256 !== payload.expectedSha256) {
@@ -168,6 +175,38 @@ try {
   }
 
   {
+    const { backend, adapter } = fixture("concurrent-apply");
+    let releaseWrite;
+    let markWriteEntered;
+    const writeEntered = new Promise((resolve) => {
+      markWriteEntered = resolve;
+    });
+    const writeReleased = new Promise((resolve) => {
+      releaseWrite = resolve;
+    });
+    backend.beforeWrite = async () => {
+      markWriteEntered();
+      await writeReleased;
+    };
+    const planned = await adapter.plan({
+      path: backend.path,
+      nextContent: "one write despite concurrent apply",
+      idempotencyKey: "concurrent-apply",
+    });
+    const firstApply = adapter.apply(planned.planRef, "concurrent-apply");
+    await writeEntered;
+    const replay = await adapter.apply(planned.planRef, "concurrent-apply");
+    assert.equal(replay.phase, "applying");
+    assert.equal(replay.outcome, null);
+    assert.equal(backend.replaceCalls, 1);
+    releaseWrite();
+    const committed = await firstApply;
+    assert.equal(committed.outcome, "committed");
+    assert.equal(backend.content, "one write despite concurrent apply");
+    assert.equal(backend.replaceCalls, 1);
+  }
+
+  {
     const { backend, adapter } = fixture("recover-same-plan");
     backend.failBeforeWriteOnce = true;
     const planned = await adapter.plan({
@@ -213,6 +252,20 @@ try {
   }
 
   {
+    const privateBody = "private vault content that must not be logged";
+    const metadata = requestLogMetadata({
+      method: "POST",
+      url: "/extensions/obsidian-atomic-write-bridge/notes/cas",
+      data: { nextContent: privateBody },
+      headers: { Authorization: "Bearer private-token" },
+    });
+    const serialized = JSON.stringify(metadata);
+    assert.equal(metadata.hasBody, true);
+    assert.equal(serialized.includes(privateBody), false);
+    assert.equal(serialized.includes("private-token"), false);
+  }
+
+  {
     let now = Date.parse("2026-08-13T00:00:00.000Z");
     const journal = new ObsidianNoteReplaceJournal(
       path.join(temporaryRoot, "retention.sqlite"),
@@ -253,7 +306,7 @@ try {
   }
 
   console.log(
-    "Obsidian note replacement operation fixture passed: plan/apply/status/recover, atomic conflict, replay, and lost-response reconciliation.",
+    "Obsidian note replacement operation fixture passed: plan/apply/status/recover, atomic conflict, concurrent replay, redacted logging, and lost-response reconciliation.",
   );
 } finally {
   for (const journal of journals) journal.close();

--- a/scripts/test-package-contents.mjs
+++ b/scripts/test-package-contents.mjs
@@ -27,6 +27,8 @@ const requiredFiles = [
   "docs/adr/README.md",
   "plugins/obsidian-bases-bridge/build/main.js",
   "plugins/obsidian-bases-bridge/build/manifest.json",
+  "plugins/obsidian-atomic-write-bridge/build/main.js",
+  "plugins/obsidian-atomic-write-bridge/build/manifest.json",
   "plugins/obsidian-operon-bridge/build/main.js",
   "plugins/obsidian-operon-bridge/build/manifest.json",
 ];

--- a/src/services/obsidianRestAPI/index.ts
+++ b/src/services/obsidianRestAPI/index.ts
@@ -9,6 +9,7 @@ export * from "./types.js"; // Export all types
 export { ObsidianRestApiService } from "./service.js"; // Export the class itself
 // Export method modules if direct access is desired, though typically accessed via service instance
 export * as activeFileMethods from "./methods/activeFileMethods.js";
+export * as atomicWriteMethods from "./methods/atomicWriteMethods.js";
 export * as basesMethods from "./methods/basesMethods.js";
 export * as commandMethods from "./methods/commandMethods.js";
 export * as openMethods from "./methods/openMethods.js";

--- a/src/services/obsidianRestAPI/methods/atomicWriteMethods.ts
+++ b/src/services/obsidianRestAPI/methods/atomicWriteMethods.ts
@@ -1,0 +1,46 @@
+import type { RequestContext } from "../../../utils/index.js";
+import type {
+  AtomicWriteCasRequest,
+  AtomicWriteCasResponse,
+  AtomicWriteReadRequest,
+  AtomicWriteReadResponse,
+  AtomicWriteStatusResponse,
+  RequestFunction,
+} from "../types.js";
+
+const PREFIX = "/extensions/obsidian-atomic-write-bridge";
+
+export async function getAtomicWriteStatus(
+  request: RequestFunction,
+  context: RequestContext,
+): Promise<AtomicWriteStatusResponse> {
+  return request<AtomicWriteStatusResponse>(
+    { method: "GET", url: `${PREFIX}/status` },
+    context,
+    "getAtomicWriteStatus",
+  );
+}
+
+export async function readAtomicWriteNote(
+  request: RequestFunction,
+  payload: AtomicWriteReadRequest,
+  context: RequestContext,
+): Promise<AtomicWriteReadResponse> {
+  return request<AtomicWriteReadResponse>(
+    { method: "POST", url: `${PREFIX}/notes/read`, data: payload },
+    context,
+    "readAtomicWriteNote",
+  );
+}
+
+export async function replaceAtomicWriteNote(
+  request: RequestFunction,
+  payload: AtomicWriteCasRequest,
+  context: RequestContext,
+): Promise<AtomicWriteCasResponse> {
+  return request<AtomicWriteCasResponse>(
+    { method: "POST", url: `${PREFIX}/notes/cas`, data: payload },
+    context,
+    "replaceAtomicWriteNote",
+  );
+}

--- a/src/services/obsidianRestAPI/requestLogMetadata.ts
+++ b/src/services/obsidianRestAPI/requestLogMetadata.ts
@@ -1,0 +1,21 @@
+import type { AxiosRequestConfig } from "axios";
+
+export interface ObsidianRequestLogMetadata {
+  method?: string;
+  url?: string;
+  hasBody: boolean;
+}
+
+/**
+ * Keep request logging deliberately body-free. Note replacement bodies can
+ * contain private vault content and must never reach the shared error logger.
+ */
+export function requestLogMetadata(
+  requestConfig: AxiosRequestConfig,
+): ObsidianRequestLogMetadata {
+  return {
+    method: requestConfig.method,
+    url: requestConfig.url,
+    hasBody: requestConfig.data !== undefined,
+  };
+}

--- a/src/services/obsidianRestAPI/service.ts
+++ b/src/services/obsidianRestAPI/service.ts
@@ -23,6 +23,7 @@ import * as openMethods from "./methods/openMethods.js";
 import * as patchMethods from "./methods/patchMethods.js";
 import * as searchMethods from "./methods/searchMethods.js";
 import * as vaultMethods from "./methods/vaultMethods.js";
+import { requestLogMetadata } from "./requestLogMetadata.js";
 import {
   ApiStatusResponse, // Import PatchOptions type
   AtomicWriteCasRequest,
@@ -216,7 +217,7 @@ export class ObsidianRestApiService {
       {
         operation: `ObsidianAPI_${operationName}_Wrapper`,
         context: context,
-        input: requestConfig, // Log request config (sanitized by ErrorHandler)
+        input: requestLogMetadata(requestConfig),
         errorCode: BaseErrorCode.INTERNAL_ERROR, // Default if wrapper itself fails
       },
     );

--- a/src/services/obsidianRestAPI/service.ts
+++ b/src/services/obsidianRestAPI/service.ts
@@ -16,6 +16,7 @@ import {
   requestContextService,
 } from "../../utils/index.js"; // Added requestContextService
 import * as activeFileMethods from "./methods/activeFileMethods.js";
+import * as atomicWriteMethods from "./methods/atomicWriteMethods.js";
 import * as basesMethods from "./methods/basesMethods.js";
 import * as commandMethods from "./methods/commandMethods.js";
 import * as openMethods from "./methods/openMethods.js";
@@ -24,6 +25,11 @@ import * as searchMethods from "./methods/searchMethods.js";
 import * as vaultMethods from "./methods/vaultMethods.js";
 import {
   ApiStatusResponse, // Import PatchOptions type
+  AtomicWriteCasRequest,
+  AtomicWriteCasResponse,
+  AtomicWriteReadRequest,
+  AtomicWriteReadResponse,
+  AtomicWriteStatusResponse,
   BaseConfigResponse,
   BaseConfigUpsertRequest,
   BaseConfigUpsertResponse,
@@ -234,6 +240,37 @@ export class ObsidianRestApiService {
       },
       context,
       "checkStatus",
+    );
+  }
+
+  async getAtomicWriteStatus(
+    context: RequestContext,
+  ): Promise<AtomicWriteStatusResponse> {
+    return atomicWriteMethods.getAtomicWriteStatus(
+      this._request.bind(this),
+      context,
+    );
+  }
+
+  async readAtomicWriteNote(
+    payload: AtomicWriteReadRequest,
+    context: RequestContext,
+  ): Promise<AtomicWriteReadResponse> {
+    return atomicWriteMethods.readAtomicWriteNote(
+      this._request.bind(this),
+      payload,
+      context,
+    );
+  }
+
+  async replaceAtomicWriteNote(
+    payload: AtomicWriteCasRequest,
+    context: RequestContext,
+  ): Promise<AtomicWriteCasResponse> {
+    return atomicWriteMethods.replaceAtomicWriteNote(
+      this._request.bind(this),
+      payload,
+      context,
     );
   }
 

--- a/src/services/obsidianRestAPI/types.ts
+++ b/src/services/obsidianRestAPI/types.ts
@@ -25,6 +25,49 @@ export type RequestFunction = <T = any>(
   operationName: string,
 ) => Promise<T>;
 
+export type AtomicWriteReadRequest = {
+  contractVersion: 1;
+  path: string;
+};
+
+export type AtomicWriteCasRequest = AtomicWriteReadRequest & {
+  expectedSha256: string;
+  nextContent: string;
+};
+
+export type AtomicWriteStatusResponse = {
+  ok: true;
+  contractVersion: 1;
+  plugin: { id: string; version: string };
+  backend: {
+    kind: "obsidian-vault-process";
+    bindingFingerprint: string;
+    atomicCas: true;
+    writeEnabled: boolean;
+  };
+  limits: { markdownOnly: true };
+};
+
+export type AtomicWriteReadResponse = {
+  ok: true;
+  contractVersion: 1;
+  path: string;
+  content: string;
+  sha256: string;
+  size: number;
+  bindingFingerprint: string;
+};
+
+export type AtomicWriteCasResponse = {
+  ok: true;
+  contractVersion: 1;
+  path: string;
+  beforeSha256: string;
+  afterSha256: string;
+  size: number;
+  bindingFingerprint: string;
+};
+
 /**
  * Filesystem metadata for a note.
  */

--- a/src/services/obsidianRestAPI/types.ts
+++ b/src/services/obsidianRestAPI/types.ts
@@ -31,6 +31,7 @@ export type AtomicWriteReadRequest = {
 };
 
 export type AtomicWriteCasRequest = AtomicWriteReadRequest & {
+  bindingFingerprint: string;
   expectedSha256: string;
   nextContent: string;
 };

--- a/src/services/operations/obsidianNoteReplaceJournal.ts
+++ b/src/services/operations/obsidianNoteReplaceJournal.ts
@@ -27,10 +27,40 @@ export type ObsidianNoteReplacePlan = {
   failure?: string;
 };
 
+export class ObsidianNoteReplaceConcurrencyError extends Error {
+  constructor() {
+    super("The note replacement state changed concurrently.");
+  }
+}
+
+export type ObsidianNoteReplaceJournalOptions = {
+  now?: () => number;
+  terminalRetentionMs?: number;
+  purgeIntervalMs?: number;
+};
+
+const STABLE_TERMINAL = new Set<ObsidianNoteReplaceStatus>([
+  "committed",
+  "conflict",
+  "rejected",
+  "failed",
+]);
+
 export class ObsidianNoteReplaceJournal {
   private readonly db: DatabaseSync;
+  private readonly now: () => number;
+  private readonly terminalRetentionMs: number;
+  private readonly purgeIntervalMs: number;
+  private nextPurgeAt = 0;
 
-  constructor(databasePath: string) {
+  constructor(
+    databasePath: string,
+    options: ObsidianNoteReplaceJournalOptions = {},
+  ) {
+    this.now = options.now ?? Date.now;
+    this.terminalRetentionMs =
+      options.terminalRetentionMs ?? 30 * 24 * 60 * 60 * 1000;
+    this.purgeIntervalMs = options.purgeIntervalMs ?? 60 * 60 * 1000;
     mkdirSync(path.dirname(databasePath), { recursive: true, mode: 0o700 });
     this.db = new DatabaseSync(databasePath);
     this.db.exec("PRAGMA journal_mode=WAL");
@@ -46,16 +76,7 @@ export class ObsidianNoteReplaceJournal {
         updated_at TEXT NOT NULL
       )
     `);
-    const terminalRetentionCutoff = new Date(
-      Date.now() - 30 * 24 * 60 * 60 * 1000,
-    ).toISOString();
-    this.db
-      .prepare(
-        `DELETE FROM obsidian_note_replace_plans
-         WHERE status IN ('committed', 'conflict', 'rejected', 'failed')
-           AND updated_at < ?`,
-      )
-      .run(terminalRetentionCutoff);
+    this.maybePurgeTerminalPlans();
     for (const privatePath of [
       databasePath,
       `${databasePath}-wal`,
@@ -80,6 +101,7 @@ export class ObsidianNoteReplaceJournal {
       "operationId" | "status" | "createdAt" | "updatedAt"
     >,
   ): ObsidianNoteReplacePlan {
+    this.maybePurgeTerminalPlans();
     const existing = this.getByIdempotencyKey(input.idempotencyKey);
     if (existing) {
       if (existing.requestDigest !== input.requestDigest) {
@@ -89,7 +111,7 @@ export class ObsidianNoteReplaceJournal {
       }
       return existing;
     }
-    const now = new Date().toISOString();
+    const now = new Date(this.now()).toISOString();
     const plan: ObsidianNoteReplacePlan = {
       ...input,
       operationId: randomUUID(),
@@ -115,6 +137,7 @@ export class ObsidianNoteReplaceJournal {
   }
 
   get(operationId: string): ObsidianNoteReplacePlan | undefined {
+    this.maybePurgeTerminalPlans();
     const row = this.db
       .prepare(
         "SELECT payload_json FROM obsidian_note_replace_plans WHERE operation_id = ?",
@@ -126,6 +149,7 @@ export class ObsidianNoteReplaceJournal {
   }
 
   getByIdempotencyKey(key: string): ObsidianNoteReplacePlan | undefined {
+    this.maybePurgeTerminalPlans();
     const row = this.db
       .prepare(
         "SELECT payload_json FROM obsidian_note_replace_plans WHERE idempotency_key = ?",
@@ -142,14 +166,16 @@ export class ObsidianNoteReplaceJournal {
     next: ObsidianNoteReplaceStatus,
     failure?: string,
   ): ObsidianNoteReplacePlan {
+    this.maybePurgeTerminalPlans();
     const current = this.get(operationId);
     if (!current || !expected.includes(current.status)) {
-      throw new Error("The note replacement state changed concurrently.");
+      throw new ObsidianNoteReplaceConcurrencyError();
     }
     const updated: ObsidianNoteReplacePlan = {
       ...current,
       status: next,
-      updatedAt: new Date().toISOString(),
+      updatedAt: new Date(this.now()).toISOString(),
+      ...(STABLE_TERMINAL.has(next) ? { nextContent: "" } : {}),
       ...(failure ? { failure } : { failure: undefined }),
     };
     const placeholders = expected.map(() => "?").join(", ");
@@ -167,8 +193,22 @@ export class ObsidianNoteReplaceJournal {
         ...expected,
       );
     if (Number(result.changes) !== 1) {
-      throw new Error("The note replacement state changed concurrently.");
+      throw new ObsidianNoteReplaceConcurrencyError();
     }
     return updated;
+  }
+
+  private maybePurgeTerminalPlans(): void {
+    const now = this.now();
+    if (now < this.nextPurgeAt) return;
+    const cutoff = new Date(now - this.terminalRetentionMs).toISOString();
+    this.db
+      .prepare(
+        `DELETE FROM obsidian_note_replace_plans
+         WHERE status IN ('committed', 'conflict', 'rejected', 'failed')
+           AND updated_at < ?`,
+      )
+      .run(cutoff);
+    this.nextPurgeAt = now + this.purgeIntervalMs;
   }
 }

--- a/src/services/operations/obsidianNoteReplaceJournal.ts
+++ b/src/services/operations/obsidianNoteReplaceJournal.ts
@@ -77,6 +77,7 @@ export class ObsidianNoteReplaceJournal {
         updated_at TEXT NOT NULL
       )
     `);
+    this.markInterruptedPlans();
     this.maybePurgeTerminalPlans();
     for (const privatePath of [
       databasePath,
@@ -220,6 +221,39 @@ export class ObsidianNoteReplaceJournal {
       this.checkpointSensitiveFrames();
     }
     this.nextPurgeAt = now + this.purgeIntervalMs;
+  }
+
+  private markInterruptedPlans(): void {
+    const rows = this.db
+      .prepare(
+        "SELECT operation_id, payload_json FROM obsidian_note_replace_plans WHERE status = 'applying'",
+      )
+      .all() as Array<{ operation_id: string; payload_json: string }>;
+    if (rows.length === 0) return;
+    const updatedAt = new Date(this.now()).toISOString();
+    const update = this.db.prepare(
+      `UPDATE obsidian_note_replace_plans
+       SET status = 'outcome_unknown', payload_json = ?, updated_at = ?
+       WHERE operation_id = ? AND status = 'applying'`,
+    );
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      for (const row of rows) {
+        const current = JSON.parse(row.payload_json) as ObsidianNoteReplacePlan;
+        const interrupted: ObsidianNoteReplacePlan = {
+          ...current,
+          status: "outcome_unknown",
+          updatedAt,
+          failure:
+            "The process restarted while apply was in progress; exact-plan recovery is required.",
+        };
+        update.run(JSON.stringify(interrupted), updatedAt, row.operation_id);
+      }
+      this.db.exec("COMMIT");
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
   }
 
   private checkpointSensitiveFrames(): void {

--- a/src/services/operations/obsidianNoteReplaceJournal.ts
+++ b/src/services/operations/obsidianNoteReplaceJournal.ts
@@ -52,6 +52,7 @@ export class ObsidianNoteReplaceJournal {
   private readonly terminalRetentionMs: number;
   private readonly purgeIntervalMs: number;
   private nextPurgeAt = 0;
+  private walCheckpointRequired = false;
 
   constructor(
     databasePath: string,
@@ -195,20 +196,36 @@ export class ObsidianNoteReplaceJournal {
     if (Number(result.changes) !== 1) {
       throw new ObsidianNoteReplaceConcurrencyError();
     }
+    if (STABLE_TERMINAL.has(next)) {
+      this.walCheckpointRequired = true;
+      this.checkpointSensitiveFrames();
+    }
     return updated;
   }
 
   private maybePurgeTerminalPlans(): void {
+    if (this.walCheckpointRequired) this.checkpointSensitiveFrames();
     const now = this.now();
     if (now < this.nextPurgeAt) return;
     const cutoff = new Date(now - this.terminalRetentionMs).toISOString();
-    this.db
+    const result = this.db
       .prepare(
         `DELETE FROM obsidian_note_replace_plans
          WHERE status IN ('committed', 'conflict', 'rejected', 'failed')
            AND updated_at < ?`,
       )
       .run(cutoff);
+    if (Number(result.changes) > 0) {
+      this.walCheckpointRequired = true;
+      this.checkpointSensitiveFrames();
+    }
     this.nextPurgeAt = now + this.purgeIntervalMs;
+  }
+
+  private checkpointSensitiveFrames(): void {
+    const result = this.db.prepare("PRAGMA wal_checkpoint(TRUNCATE)").get() as {
+      busy?: number;
+    };
+    this.walCheckpointRequired = Number(result.busy ?? 0) !== 0;
   }
 }

--- a/src/services/operations/obsidianNoteReplaceJournal.ts
+++ b/src/services/operations/obsidianNoteReplaceJournal.ts
@@ -1,0 +1,174 @@
+import { randomUUID } from "node:crypto";
+import { chmodSync, existsSync, mkdirSync } from "node:fs";
+import path from "node:path";
+import { DatabaseSync } from "node:sqlite";
+
+export type ObsidianNoteReplaceStatus =
+  | "planned"
+  | "applying"
+  | "committed"
+  | "conflict"
+  | "rejected"
+  | "failed"
+  | "outcome_unknown";
+
+export type ObsidianNoteReplacePlan = {
+  operationId: string;
+  idempotencyKey: string;
+  requestDigest: string;
+  path: string;
+  beforeSha256: string;
+  afterSha256: string;
+  nextContent: string;
+  bindingFingerprint: string;
+  status: ObsidianNoteReplaceStatus;
+  createdAt: string;
+  updatedAt: string;
+  failure?: string;
+};
+
+export class ObsidianNoteReplaceJournal {
+  private readonly db: DatabaseSync;
+
+  constructor(databasePath: string) {
+    mkdirSync(path.dirname(databasePath), { recursive: true, mode: 0o700 });
+    this.db = new DatabaseSync(databasePath);
+    this.db.exec("PRAGMA journal_mode=WAL");
+    this.db.exec("PRAGMA synchronous=FULL");
+    this.db.exec("PRAGMA secure_delete=ON");
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS obsidian_note_replace_plans (
+        operation_id TEXT PRIMARY KEY,
+        idempotency_key TEXT NOT NULL UNIQUE,
+        status TEXT NOT NULL,
+        payload_json TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      )
+    `);
+    const terminalRetentionCutoff = new Date(
+      Date.now() - 30 * 24 * 60 * 60 * 1000,
+    ).toISOString();
+    this.db
+      .prepare(
+        `DELETE FROM obsidian_note_replace_plans
+         WHERE status IN ('committed', 'conflict', 'rejected', 'failed')
+           AND updated_at < ?`,
+      )
+      .run(terminalRetentionCutoff);
+    for (const privatePath of [
+      databasePath,
+      `${databasePath}-wal`,
+      `${databasePath}-shm`,
+    ]) {
+      if (!existsSync(privatePath)) continue;
+      try {
+        chmodSync(privatePath, 0o600);
+      } catch {
+        // Windows ACLs remain authoritative when POSIX modes are unavailable.
+      }
+    }
+  }
+
+  close(): void {
+    this.db.close();
+  }
+
+  create(
+    input: Omit<
+      ObsidianNoteReplacePlan,
+      "operationId" | "status" | "createdAt" | "updatedAt"
+    >,
+  ): ObsidianNoteReplacePlan {
+    const existing = this.getByIdempotencyKey(input.idempotencyKey);
+    if (existing) {
+      if (existing.requestDigest !== input.requestDigest) {
+        throw new Error(
+          "The idempotency key is already bound to a different note replacement.",
+        );
+      }
+      return existing;
+    }
+    const now = new Date().toISOString();
+    const plan: ObsidianNoteReplacePlan = {
+      ...input,
+      operationId: randomUUID(),
+      status: "planned",
+      createdAt: now,
+      updatedAt: now,
+    };
+    this.db
+      .prepare(
+        `INSERT INTO obsidian_note_replace_plans
+         (operation_id, idempotency_key, status, payload_json, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        plan.operationId,
+        plan.idempotencyKey,
+        plan.status,
+        JSON.stringify(plan),
+        plan.createdAt,
+        plan.updatedAt,
+      );
+    return plan;
+  }
+
+  get(operationId: string): ObsidianNoteReplacePlan | undefined {
+    const row = this.db
+      .prepare(
+        "SELECT payload_json FROM obsidian_note_replace_plans WHERE operation_id = ?",
+      )
+      .get(operationId) as { payload_json: string } | undefined;
+    return row
+      ? (JSON.parse(row.payload_json) as ObsidianNoteReplacePlan)
+      : undefined;
+  }
+
+  getByIdempotencyKey(key: string): ObsidianNoteReplacePlan | undefined {
+    const row = this.db
+      .prepare(
+        "SELECT payload_json FROM obsidian_note_replace_plans WHERE idempotency_key = ?",
+      )
+      .get(key) as { payload_json: string } | undefined;
+    return row
+      ? (JSON.parse(row.payload_json) as ObsidianNoteReplacePlan)
+      : undefined;
+  }
+
+  transition(
+    operationId: string,
+    expected: ObsidianNoteReplaceStatus[],
+    next: ObsidianNoteReplaceStatus,
+    failure?: string,
+  ): ObsidianNoteReplacePlan {
+    const current = this.get(operationId);
+    if (!current || !expected.includes(current.status)) {
+      throw new Error("The note replacement state changed concurrently.");
+    }
+    const updated: ObsidianNoteReplacePlan = {
+      ...current,
+      status: next,
+      updatedAt: new Date().toISOString(),
+      ...(failure ? { failure } : { failure: undefined }),
+    };
+    const placeholders = expected.map(() => "?").join(", ");
+    const result = this.db
+      .prepare(
+        `UPDATE obsidian_note_replace_plans
+         SET status = ?, payload_json = ?, updated_at = ?
+         WHERE operation_id = ? AND status IN (${placeholders})`,
+      )
+      .run(
+        next,
+        JSON.stringify(updated),
+        updated.updatedAt,
+        operationId,
+        ...expected,
+      );
+    if (Number(result.changes) !== 1) {
+      throw new Error("The note replacement state changed concurrently.");
+    }
+    return updated;
+  }
+}

--- a/src/services/operations/obsidianNoteReplaceOperationAdapter.ts
+++ b/src/services/operations/obsidianNoteReplaceOperationAdapter.ts
@@ -414,6 +414,16 @@ export class ObsidianNoteReplaceOperationAdapter
           error.message,
         );
       }
+      const rejected =
+        error instanceof McpError && error.code === BaseErrorCode.FORBIDDEN;
+      if (rejected) {
+        return this.transitionOrReload(
+          plan.operationId,
+          ["applying"],
+          "rejected",
+          error.message,
+        );
+      }
       const reconciled = await this.reconcile(plan).catch(() => plan);
       if (reconciled.status !== "applying") {
         return reconciled;

--- a/src/services/operations/obsidianNoteReplaceOperationAdapter.ts
+++ b/src/services/operations/obsidianNoteReplaceOperationAdapter.ts
@@ -299,16 +299,26 @@ export class ObsidianNoteReplaceOperationAdapter
     const read = ReadSchema.parse(
       await this.backend.read({ contractVersion: 1, path: plan.path }),
     );
-    if (
-      read.bindingFingerprint !== plan.bindingFingerprint ||
-      read.sha256 !== plan.beforeSha256
-    ) {
+    if (read.bindingFingerprint !== plan.bindingFingerprint) {
       return receipt(
         this.transitionOrReload(
           plan.operationId,
           [plan.status],
           "conflict",
-          "Recovery found a different backend instance or note hash.",
+          "Recovery found a different backend instance.",
+        ),
+      );
+    }
+    if (read.sha256 === plan.afterSha256) {
+      return receipt(
+        this.transitionOrReload(plan.operationId, [plan.status], "committed"),
+      );
+    }
+    if (read.sha256 !== plan.beforeSha256) {
+      return receipt(
+        this.uncertain(
+          plan,
+          "Recovery found a hash matching neither sealed proof after the original request may have been sent.",
         ),
       );
     }
@@ -381,19 +391,22 @@ export class ObsidianNoteReplaceOperationAdapter
         "committed",
       );
     } catch (error) {
-      const reconciled = await this.reconcile(plan).catch(() => plan);
-      if (
-        reconciled.status === "committed" ||
-        reconciled.status === "conflict"
-      ) {
-        return reconciled;
-      }
       const conflict =
         error instanceof McpError && error.code === BaseErrorCode.CONFLICT;
-      return this.transitionOrReload(
-        plan.operationId,
-        ["applying"],
-        conflict ? "conflict" : "outcome_unknown",
+      if (conflict) {
+        return this.transitionOrReload(
+          plan.operationId,
+          ["applying"],
+          "conflict",
+          error.message,
+        );
+      }
+      const reconciled = await this.reconcile(plan).catch(() => plan);
+      if (reconciled.status !== "applying") {
+        return reconciled;
+      }
+      return this.uncertain(
+        plan,
         error instanceof Error ? error.message : String(error),
       );
     }
@@ -421,14 +434,25 @@ export class ObsidianNoteReplaceOperationAdapter
       );
     }
     if (read.sha256 !== plan.beforeSha256) {
-      return this.transitionOrReload(
-        plan.operationId,
-        [plan.status],
-        "conflict",
+      return this.uncertain(
+        plan,
         "The note hash matches neither the sealed before nor after proof.",
       );
     }
     return plan;
+  }
+
+  private uncertain(
+    plan: ObsidianNoteReplacePlan,
+    failure: string,
+  ): ObsidianNoteReplacePlan {
+    if (plan.status === "outcome_unknown") return plan;
+    return this.transitionOrReload(
+      plan.operationId,
+      ["applying"],
+      "outcome_unknown",
+      failure,
+    );
   }
 
   private transitionOrReload(

--- a/src/services/operations/obsidianNoteReplaceOperationAdapter.ts
+++ b/src/services/operations/obsidianNoteReplaceOperationAdapter.ts
@@ -327,11 +327,19 @@ export class ObsidianNoteReplaceOperationAdapter
         ),
       );
     }
-    const applying = this.journal.transition(
-      plan.operationId,
-      [plan.status],
-      "applying",
-    );
+    let applying: ObsidianNoteReplacePlan;
+    try {
+      applying = this.journal.transition(
+        plan.operationId,
+        [plan.status],
+        "applying",
+      );
+    } catch (error) {
+      if (!(error instanceof ObsidianNoteReplaceConcurrencyError)) throw error;
+      const current = this.journal.get(plan.operationId);
+      if (!current) throw error;
+      return receipt(current);
+    }
     return receipt(await this.execute(applying));
   }
 

--- a/src/services/operations/obsidianNoteReplaceOperationAdapter.ts
+++ b/src/services/operations/obsidianNoteReplaceOperationAdapter.ts
@@ -1,0 +1,442 @@
+import { z } from "zod";
+import { createHash } from "node:crypto";
+import type {
+  AtomicWriteCasRequest,
+  AtomicWriteCasResponse,
+  AtomicWriteReadRequest,
+  AtomicWriteReadResponse,
+  AtomicWriteStatusResponse,
+} from "../obsidianRestAPI/types.js";
+import { BaseErrorCode, McpError } from "../../types-global/errors.js";
+import {
+  OPERATION_RUNTIME_CONTRACT_VERSION,
+  operationDigest,
+  type OperationAdapter,
+  type OperationOutcome,
+  type OperationPhase,
+  type OperationReceipt,
+} from "./contract.js";
+import {
+  ObsidianNoteReplaceJournal,
+  type ObsidianNoteReplacePlan,
+} from "./obsidianNoteReplaceJournal.js";
+
+const PLAN_REF_PREFIX = "obsidian-note-replace:v1:";
+const SHA256 = /^[a-f0-9]{64}$/u;
+
+const StatusSchema = z
+  .object({
+    ok: z.literal(true),
+    contractVersion: z.literal(1),
+    plugin: z.object({ id: z.string().min(1), version: z.string().min(1) }),
+    backend: z.object({
+      kind: z.literal("obsidian-vault-process"),
+      bindingFingerprint: z.string().regex(SHA256),
+      atomicCas: z.literal(true),
+      writeEnabled: z.boolean(),
+    }),
+    limits: z.object({ markdownOnly: z.literal(true) }),
+  })
+  .passthrough();
+
+const ReadSchema = z
+  .object({
+    ok: z.literal(true),
+    contractVersion: z.literal(1),
+    path: z.string().min(1),
+    content: z.string(),
+    sha256: z.string().regex(SHA256),
+    size: z.number().int().nonnegative(),
+    bindingFingerprint: z.string().regex(SHA256),
+  })
+  .passthrough();
+
+const CasSchema = z
+  .object({
+    ok: z.literal(true),
+    contractVersion: z.literal(1),
+    path: z.string().min(1),
+    beforeSha256: z.string().regex(SHA256),
+    afterSha256: z.string().regex(SHA256),
+    size: z.number().int().nonnegative(),
+    bindingFingerprint: z.string().regex(SHA256),
+  })
+  .passthrough();
+
+export interface AtomicWriteBackend {
+  status(): Promise<AtomicWriteStatusResponse>;
+  read(payload: AtomicWriteReadRequest): Promise<AtomicWriteReadResponse>;
+  replace(payload: AtomicWriteCasRequest): Promise<AtomicWriteCasResponse>;
+}
+
+export type ObsidianNoteReplacePlanInput = {
+  path: string;
+  nextContent: string;
+  idempotencyKey: string;
+};
+
+function planRef(operationId: string): string {
+  return `${PLAN_REF_PREFIX}${operationId}`;
+}
+
+function operationIdFromRef(reference: string): string {
+  if (!reference.startsWith(PLAN_REF_PREFIX)) {
+    throw new Error(
+      "The operation plan reference is not a note-replace V1 plan.",
+    );
+  }
+  const operationId = reference.slice(PLAN_REF_PREFIX.length);
+  if (!z.string().uuid().safeParse(operationId).success) {
+    throw new Error("The note-replace operation plan reference is malformed.");
+  }
+  return operationId;
+}
+
+function state(plan: ObsidianNoteReplacePlan): {
+  phase: OperationPhase;
+  outcome: OperationOutcome | null;
+} {
+  if (plan.status === "planned") return { phase: "planned", outcome: null };
+  if (plan.status === "applying") return { phase: "applying", outcome: null };
+  return { phase: "terminal", outcome: plan.status };
+}
+
+function planDigest(plan: ObsidianNoteReplacePlan): string {
+  return operationDigest({
+    contractVersion: OPERATION_RUNTIME_CONTRACT_VERSION,
+    operationKind: "obsidian.note.replace",
+    operationId: plan.operationId,
+    idempotencyKey: plan.idempotencyKey,
+    backendBinding: plan.bindingFingerprint,
+    path: plan.path,
+    beforeSha256: plan.beforeSha256,
+    afterSha256: plan.afterSha256,
+    requestDigest: plan.requestDigest,
+  });
+}
+
+function receipt(plan: ObsidianNoteReplacePlan): OperationReceipt {
+  const current = state(plan);
+  const terminal = current.phase === "terminal";
+  const recoverable =
+    plan.status === "applying" || plan.status === "outcome_unknown";
+  const digest = planDigest(plan);
+  return {
+    contractVersion: OPERATION_RUNTIME_CONTRACT_VERSION,
+    operationId: plan.operationId,
+    idempotencyKey: plan.idempotencyKey,
+    operationKind: "obsidian.note.replace",
+    planRef: planRef(plan.operationId),
+    planDigest: digest,
+    phase: current.phase,
+    outcome: current.outcome,
+    backend: {
+      kind: "obsidian-vault-process",
+      bindingFingerprint: plan.bindingFingerprint,
+    },
+    target: { kind: "vault-markdown-note", logicalRef: plan.path },
+    beforeProof: {
+      kind: "note-sha256",
+      digest: operationDigest({
+        path: plan.path,
+        sha256: plan.beforeSha256,
+        bindingFingerprint: plan.bindingFingerprint,
+      }),
+      details: { sha256: plan.beforeSha256 },
+    },
+    ...(plan.status === "committed"
+      ? {
+          afterProof: {
+            kind: "atomic-note-replacement-verified",
+            digest: operationDigest({
+              path: plan.path,
+              sha256: plan.afterSha256,
+              bindingFingerprint: plan.bindingFingerprint,
+            }),
+            details: { sha256: plan.afterSha256 },
+          },
+        }
+      : {}),
+    postflight: {
+      status:
+        plan.status === "committed"
+          ? "verified"
+          : plan.status === "applying"
+            ? "pending"
+            : terminal
+              ? "unverified"
+              : "not_started",
+    },
+    admittedAt: plan.createdAt,
+    updatedAt: plan.updatedAt,
+    ...(terminal ? { terminalAt: plan.updatedAt } : {}),
+    ...(recoverable ? { recoveryRef: planRef(plan.operationId) } : {}),
+    recoveryAllowed: recoverable,
+    applyAllowed: plan.status === "planned",
+  };
+}
+
+function validateInput(input: ObsidianNoteReplacePlanInput): void {
+  if (!input.path || !input.path.toLowerCase().endsWith(".md")) {
+    throw new Error("path must identify a Markdown note.");
+  }
+  if (!input.idempotencyKey.trim()) {
+    throw new Error("idempotencyKey is required.");
+  }
+  if (Buffer.byteLength(input.nextContent, "utf8") > 5 * 1024 * 1024) {
+    throw new Error("nextContent exceeds the bridge limit.");
+  }
+}
+
+export class ObsidianNoteReplaceOperationAdapter
+  implements OperationAdapter<ObsidianNoteReplacePlanInput>
+{
+  readonly operationKind = "obsidian.note.replace";
+
+  constructor(
+    private readonly backend: AtomicWriteBackend,
+    private readonly journal: ObsidianNoteReplaceJournal,
+  ) {}
+
+  async plan(input: ObsidianNoteReplacePlanInput): Promise<OperationReceipt> {
+    validateInput(input);
+    const afterSha256 = createHash("sha256")
+      .update(input.nextContent, "utf8")
+      .digest("hex");
+    const existing = this.journal.getByIdempotencyKey(input.idempotencyKey);
+    if (existing) {
+      if (
+        existing.path !== input.path ||
+        existing.afterSha256 !== afterSha256
+      ) {
+        throw new Error(
+          "The idempotency key is already bound to a different note replacement.",
+        );
+      }
+      return receipt(existing);
+    }
+    const status = StatusSchema.parse(await this.backend.status());
+    if (!status.backend.writeEnabled) {
+      throw new Error(
+        "Atomic note writes are disabled in the bridge settings.",
+      );
+    }
+    const read = ReadSchema.parse(
+      await this.backend.read({ contractVersion: 1, path: input.path }),
+    );
+    if (
+      read.bindingFingerprint !== status.backend.bindingFingerprint ||
+      read.path !== input.path
+    ) {
+      throw new Error(
+        "Atomic-write backend identity or target changed during planning.",
+      );
+    }
+    const requestDigest = operationDigest({
+      operationKind: this.operationKind,
+      path: input.path,
+      beforeSha256: read.sha256,
+      afterSha256,
+      bindingFingerprint: read.bindingFingerprint,
+    });
+    return receipt(
+      this.journal.create({
+        idempotencyKey: input.idempotencyKey,
+        requestDigest,
+        path: input.path,
+        beforeSha256: read.sha256,
+        afterSha256,
+        nextContent: input.nextContent,
+        bindingFingerprint: read.bindingFingerprint,
+      }),
+    );
+  }
+
+  async apply(
+    reference: string,
+    idempotencyKey: string,
+  ): Promise<OperationReceipt> {
+    const plan = this.required(reference, idempotencyKey);
+    if (plan.status === "committed") return receipt(plan);
+    if (plan.status !== "planned") {
+      if (plan.status === "applying") {
+        return receipt(await this.reconcileApplying(plan));
+      }
+      return receipt(plan);
+    }
+    const applying = this.journal.transition(
+      plan.operationId,
+      ["planned"],
+      "applying",
+    );
+    return receipt(await this.execute(applying));
+  }
+
+  async status(reference: string): Promise<OperationReceipt> {
+    const plan = this.required(reference);
+    if (plan.status === "applying" || plan.status === "outcome_unknown") {
+      return receipt(await this.reconcile(plan));
+    }
+    return receipt(plan);
+  }
+
+  async recover(
+    reference: string,
+    idempotencyKey: string,
+  ): Promise<OperationReceipt> {
+    let plan = this.required(reference, idempotencyKey);
+    if (plan.status === "committed") return receipt(plan);
+    if (plan.status !== "applying" && plan.status !== "outcome_unknown") {
+      return receipt(plan);
+    }
+    plan = await this.reconcile(plan);
+    if (plan.status !== "applying" && plan.status !== "outcome_unknown") {
+      return receipt(plan);
+    }
+    const read = ReadSchema.parse(
+      await this.backend.read({ contractVersion: 1, path: plan.path }),
+    );
+    if (
+      read.bindingFingerprint !== plan.bindingFingerprint ||
+      read.sha256 !== plan.beforeSha256
+    ) {
+      return receipt(
+        this.journal.transition(
+          plan.operationId,
+          [plan.status],
+          "conflict",
+          "Recovery found a different backend instance or note hash.",
+        ),
+      );
+    }
+    const applying = this.journal.transition(
+      plan.operationId,
+      [plan.status],
+      "applying",
+    );
+    return receipt(await this.execute(applying));
+  }
+
+  private required(
+    reference: string,
+    idempotencyKey?: string,
+  ): ObsidianNoteReplacePlan {
+    const plan = this.journal.get(operationIdFromRef(reference));
+    if (!plan) throw new Error("Unknown note-replace operation plan.");
+    if (
+      idempotencyKey !== undefined &&
+      plan.idempotencyKey !== idempotencyKey
+    ) {
+      throw new Error("The idempotency key does not match the sealed plan.");
+    }
+    return plan;
+  }
+
+  private async execute(
+    plan: ObsidianNoteReplacePlan,
+  ): Promise<ObsidianNoteReplacePlan> {
+    try {
+      const status = StatusSchema.parse(await this.backend.status());
+      if (status.backend.bindingFingerprint !== plan.bindingFingerprint) {
+        return this.journal.transition(
+          plan.operationId,
+          ["applying"],
+          "rejected",
+          "The atomic-write backend instance no longer matches the sealed plan.",
+        );
+      }
+      if (!status.backend.writeEnabled) {
+        return this.journal.transition(
+          plan.operationId,
+          ["applying"],
+          "rejected",
+          "Atomic note writes were disabled before apply.",
+        );
+      }
+      const result = CasSchema.parse(
+        await this.backend.replace({
+          contractVersion: 1,
+          path: plan.path,
+          expectedSha256: plan.beforeSha256,
+          nextContent: plan.nextContent,
+        }),
+      );
+      if (
+        result.bindingFingerprint !== plan.bindingFingerprint ||
+        result.path !== plan.path ||
+        result.beforeSha256 !== plan.beforeSha256 ||
+        result.afterSha256 !== plan.afterSha256
+      ) {
+        throw new Error(
+          "Atomic-write postflight did not match the sealed plan.",
+        );
+      }
+      return this.journal.transition(
+        plan.operationId,
+        ["applying"],
+        "committed",
+      );
+    } catch (error) {
+      const reconciled = await this.reconcile(plan).catch(() => plan);
+      if (
+        reconciled.status === "committed" ||
+        reconciled.status === "conflict"
+      ) {
+        return reconciled;
+      }
+      const conflict =
+        error instanceof McpError && error.code === BaseErrorCode.CONFLICT;
+      return this.journal.transition(
+        plan.operationId,
+        ["applying"],
+        conflict ? "conflict" : "outcome_unknown",
+        error instanceof Error ? error.message : String(error),
+      );
+    }
+  }
+
+  private async reconcileApplying(
+    plan: ObsidianNoteReplacePlan,
+  ): Promise<ObsidianNoteReplacePlan> {
+    const reconciled = await this.reconcile(plan);
+    if (reconciled.status !== "applying") return reconciled;
+    return this.journal.transition(
+      plan.operationId,
+      ["applying"],
+      "outcome_unknown",
+      "A previous apply reached the backend without a durable terminal receipt.",
+    );
+  }
+
+  private async reconcile(
+    plan: ObsidianNoteReplacePlan,
+  ): Promise<ObsidianNoteReplacePlan> {
+    const read = ReadSchema.parse(
+      await this.backend.read({ contractVersion: 1, path: plan.path }),
+    );
+    if (read.bindingFingerprint !== plan.bindingFingerprint) {
+      return this.journal.transition(
+        plan.operationId,
+        [plan.status],
+        "conflict",
+        "The atomic-write backend instance changed.",
+      );
+    }
+    if (read.sha256 === plan.afterSha256) {
+      return this.journal.transition(
+        plan.operationId,
+        [plan.status],
+        "committed",
+      );
+    }
+    if (read.sha256 !== plan.beforeSha256) {
+      return this.journal.transition(
+        plan.operationId,
+        [plan.status],
+        "conflict",
+        "The note hash matches neither the sealed before nor after proof.",
+      );
+    }
+    return plan;
+  }
+}

--- a/src/services/operations/obsidianNoteReplaceOperationAdapter.ts
+++ b/src/services/operations/obsidianNoteReplaceOperationAdapter.ts
@@ -293,7 +293,12 @@ export class ObsidianNoteReplaceOperationAdapter
       return receipt(plan);
     }
     plan = await this.reconcile(plan);
-    if (plan.status !== "applying" && plan.status !== "outcome_unknown") {
+    if (plan.status === "applying") {
+      // A live executor still owns this plan. Only a persisted interruption
+      // marker (outcome_unknown) authorizes exact-plan re-execution.
+      return receipt(plan);
+    }
+    if (plan.status !== "outcome_unknown") {
       return receipt(plan);
     }
     const read = ReadSchema.parse(

--- a/src/services/operations/obsidianNoteReplaceOperationAdapter.ts
+++ b/src/services/operations/obsidianNoteReplaceOperationAdapter.ts
@@ -17,6 +17,7 @@ import {
   type OperationReceipt,
 } from "./contract.js";
 import {
+  ObsidianNoteReplaceConcurrencyError,
   ObsidianNoteReplaceJournal,
   type ObsidianNoteReplacePlan,
 } from "./obsidianNoteReplaceJournal.js";
@@ -301,7 +302,7 @@ export class ObsidianNoteReplaceOperationAdapter
       read.sha256 !== plan.beforeSha256
     ) {
       return receipt(
-        this.journal.transition(
+        this.transitionOrReload(
           plan.operationId,
           [plan.status],
           "conflict",
@@ -338,7 +339,7 @@ export class ObsidianNoteReplaceOperationAdapter
     try {
       const status = StatusSchema.parse(await this.backend.status());
       if (status.backend.bindingFingerprint !== plan.bindingFingerprint) {
-        return this.journal.transition(
+        return this.transitionOrReload(
           plan.operationId,
           ["applying"],
           "rejected",
@@ -346,7 +347,7 @@ export class ObsidianNoteReplaceOperationAdapter
         );
       }
       if (!status.backend.writeEnabled) {
-        return this.journal.transition(
+        return this.transitionOrReload(
           plan.operationId,
           ["applying"],
           "rejected",
@@ -371,7 +372,7 @@ export class ObsidianNoteReplaceOperationAdapter
           "Atomic-write postflight did not match the sealed plan.",
         );
       }
-      return this.journal.transition(
+      return this.transitionOrReload(
         plan.operationId,
         ["applying"],
         "committed",
@@ -386,7 +387,7 @@ export class ObsidianNoteReplaceOperationAdapter
       }
       const conflict =
         error instanceof McpError && error.code === BaseErrorCode.CONFLICT;
-      return this.journal.transition(
+      return this.transitionOrReload(
         plan.operationId,
         ["applying"],
         conflict ? "conflict" : "outcome_unknown",
@@ -400,7 +401,7 @@ export class ObsidianNoteReplaceOperationAdapter
   ): Promise<ObsidianNoteReplacePlan> {
     const reconciled = await this.reconcile(plan);
     if (reconciled.status !== "applying") return reconciled;
-    return this.journal.transition(
+    return this.transitionOrReload(
       plan.operationId,
       ["applying"],
       "outcome_unknown",
@@ -415,7 +416,7 @@ export class ObsidianNoteReplaceOperationAdapter
       await this.backend.read({ contractVersion: 1, path: plan.path }),
     );
     if (read.bindingFingerprint !== plan.bindingFingerprint) {
-      return this.journal.transition(
+      return this.transitionOrReload(
         plan.operationId,
         [plan.status],
         "conflict",
@@ -423,14 +424,14 @@ export class ObsidianNoteReplaceOperationAdapter
       );
     }
     if (read.sha256 === plan.afterSha256) {
-      return this.journal.transition(
+      return this.transitionOrReload(
         plan.operationId,
         [plan.status],
         "committed",
       );
     }
     if (read.sha256 !== plan.beforeSha256) {
-      return this.journal.transition(
+      return this.transitionOrReload(
         plan.operationId,
         [plan.status],
         "conflict",
@@ -438,5 +439,21 @@ export class ObsidianNoteReplaceOperationAdapter
       );
     }
     return plan;
+  }
+
+  private transitionOrReload(
+    operationId: string,
+    expected: ObsidianNoteReplacePlan["status"][],
+    next: ObsidianNoteReplacePlan["status"],
+    failure?: string,
+  ): ObsidianNoteReplacePlan {
+    try {
+      return this.journal.transition(operationId, expected, next, failure);
+    } catch (error) {
+      if (!(error instanceof ObsidianNoteReplaceConcurrencyError)) throw error;
+      const current = this.journal.get(operationId);
+      if (!current) throw error;
+      return current;
+    }
   }
 }

--- a/src/services/operations/obsidianNoteReplaceOperationAdapter.ts
+++ b/src/services/operations/obsidianNoteReplaceOperationAdapter.ts
@@ -261,7 +261,9 @@ export class ObsidianNoteReplaceOperationAdapter
     if (plan.status === "committed") return receipt(plan);
     if (plan.status !== "planned") {
       if (plan.status === "applying") {
-        return receipt(await this.reconcileApplying(plan));
+        // A second caller may be observing a live executor. Reconcile only
+        // terminal proof; never classify an in-flight apply as interrupted.
+        return receipt(await this.reconcile(plan));
       }
       return receipt(plan);
     }
@@ -394,19 +396,6 @@ export class ObsidianNoteReplaceOperationAdapter
         error instanceof Error ? error.message : String(error),
       );
     }
-  }
-
-  private async reconcileApplying(
-    plan: ObsidianNoteReplacePlan,
-  ): Promise<ObsidianNoteReplacePlan> {
-    const reconciled = await this.reconcile(plan);
-    if (reconciled.status !== "applying") return reconciled;
-    return this.transitionOrReload(
-      plan.operationId,
-      ["applying"],
-      "outcome_unknown",
-      "A previous apply reached the backend without a durable terminal receipt.",
-    );
   }
 
   private async reconcile(

--- a/src/services/operations/obsidianNoteReplaceOperationAdapter.ts
+++ b/src/services/operations/obsidianNoteReplaceOperationAdapter.ts
@@ -360,6 +360,7 @@ export class ObsidianNoteReplaceOperationAdapter
         await this.backend.replace({
           contractVersion: 1,
           path: plan.path,
+          bindingFingerprint: plan.bindingFingerprint,
           expectedSha256: plan.beforeSha256,
           nextContent: plan.nextContent,
         }),

--- a/src/services/operations/restAtomicWriteBackend.ts
+++ b/src/services/operations/restAtomicWriteBackend.ts
@@ -1,0 +1,40 @@
+import type { ObsidianRestApiService } from "../obsidianRestAPI/service.js";
+import type {
+  AtomicWriteCasRequest,
+  AtomicWriteCasResponse,
+  AtomicWriteReadRequest,
+  AtomicWriteReadResponse,
+  AtomicWriteStatusResponse,
+} from "../obsidianRestAPI/types.js";
+import { requestContextService } from "../../utils/index.js";
+import type { AtomicWriteBackend } from "./obsidianNoteReplaceOperationAdapter.js";
+
+export class RestAtomicWriteBackend implements AtomicWriteBackend {
+  constructor(private readonly rest: ObsidianRestApiService) {}
+
+  status(): Promise<AtomicWriteStatusResponse> {
+    return this.rest.getAtomicWriteStatus(
+      requestContextService.createRequestContext({
+        operation: "AtomicWriteStatus",
+      }),
+    );
+  }
+
+  read(payload: AtomicWriteReadRequest): Promise<AtomicWriteReadResponse> {
+    return this.rest.readAtomicWriteNote(
+      payload,
+      requestContextService.createRequestContext({
+        operation: "AtomicWriteRead",
+      }),
+    );
+  }
+
+  replace(payload: AtomicWriteCasRequest): Promise<AtomicWriteCasResponse> {
+    return this.rest.replaceAtomicWriteNote(
+      payload,
+      requestContextService.createRequestContext({
+        operation: "AtomicWriteReplace",
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## Outcome

Adds the second internal adapter for the common governed operation runtime and the missing atomic expected-hash write surface for existing Markdown notes.

## Design

- bundled `obsidian-atomic-write-bridge` uses Obsidian `Vault.process` for one-step SHA-256 compare-and-replace;
- writes are explicitly disabled by default in the bridge settings;
- backend receipts are bound to a hashed device/install/vault-root fingerprint;
- `obsidian.note.replace` implements sealed `plan -> apply -> status -> recover` semantics;
- a private SQLite WAL journal persists the exact plan before effects, retains uncertain operations, and expires terminal rows after 30 days;
- additive bridge response fields remain forward-compatible;
- this remains an internal pilot: no generic public MCP write tool is added.

## Proof

- `npm run check:atomic-write`
- `npm run test:operation-runtime`
- `npm run test:runtime`
- `npm --prefix plugins/obsidian-operon-bridge run check`
- `npm run test:docs`
- `npm run build:bridges`
- `npm run test:package`

The disposable fixture covers conflict without write, idempotent committed replay, idempotency-key binding after target drift, lost-response reconciliation, and exact-plan recovery after a pre-write failure.

## Remaining live gate

A disposable Obsidian Desktop vault with Local REST API must still validate the installable bridge routes and actual `Vault.process` behavior before promoting the adapter beyond internal pilot status.