### PR TITLE
chore: prepare release 2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.5.0] - 2026-08-13
+
 ### Added
 
 - Operon `3.2.1` / CLI `1.1.0` compatibility through Bridge `0.6.0`, retaining
@@ -17,6 +19,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   approved core reads or mutations.
 - Saved-filter pagination and Bridge HTTP error mapping coverage, preserving
   typed `404`/`422` failures instead of reporting generic internal errors.
+- Contract-negotiated Operon compatibility: unknown releases such as `3.3.0`
+  are admitted as `compatible-provisional` only when Developer API V1
+  negotiation and runtime schema validation succeed.
+- Complete live acceptance of Operon `3.3.0` with Bridge `0.7.0`: persisted
+  grants, bounded startup retry, governed apply/replay/conflict/postflight,
+  thirty tasks, zero validation violations and zero pending recoveries.
+- Common governed operation runtime contract with `plan`, `apply`, `status`,
+  durable receipts and exact-plan `recover`, proven first through the existing
+  `external_move` transaction and disposable restart fixtures.
 
 ### Changed
 
@@ -26,6 +37,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ÉLYSIA Task Gouverneur active skill `2.2` and distributed profile skill
   `1.3.0` align with the 3.2 capability boundary. Adoption remains unavailable
   without a Markdown or CLI fallback.
+- Optimike Operon Bridge `0.7.0` no longer blocks all users on an unknown Operon
+  product version when the negotiated Developer API contract remains valid;
+  malformed or unavailable contracts still fail closed.
+- Transient Operon startup states are retried for a bounded window before the
+  Bridge reports structured unavailability.
+- Compensated terminal `external_move` plans reject delayed apply retries and
+  cannot be reactivated after rollback.
 
 ## [2.4.0] - 2026-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Saved-filter pagination and Bridge HTTP error mapping coverage, preserving
   typed `404`/`422` failures instead of reporting generic internal errors.
 - Contract-negotiated Operon compatibility: unknown releases such as `3.3.0`
-  are admitted as `compatible-provisional` only when Developer API V1
-  negotiation and runtime schema validation succeed.
+  receive version/accessor admission as `compatible-provisional` when they are
+  not denied and expose `getDeveloperApiV1()`. Actual use still requires a
+  valid `developerApi` status, top-level `ok`, `index.ready`, and the exact
+  advertised capability.
 - Complete live acceptance of Operon `3.3.0` with Bridge `0.7.0`: persisted
   grants, bounded startup retry, governed apply/replay/conflict/postflight,
   thirty tasks, zero validation violations and zero pending recoveries.

--- a/README.fr.md
+++ b/README.fr.md
@@ -2,8 +2,7 @@
 
 [![Dernière version](https://img.shields.io/github/v/release/optimikelabs/optimike-obsidian-mcp?display_name=tag&sort=semver)](https://github.com/optimikelabs/optimike-obsidian-mcp/releases/latest)
 
-English version: [README.md](README.md)
-Hub documentaire : [docs/README.fr.md](docs/README.fr.md)
+English version: [README.md](README.md) · Hub documentaire : [docs/README.fr.md](docs/README.fr.md)
 Exploitation : [OPERATIONS.fr.md](OPERATIONS.fr.md)
 Sécurité : [SECURITY.fr.md](SECURITY.fr.md)
 
@@ -21,7 +20,7 @@ documents autorisés hors du coffre.
 | ----------------------- | -------------------------------------------------------------------- | ----------------------------------------------------- |
 | Notes                   | Lecture, liste, recherche, mise à jour, frontmatter et tags          | Coffre ; Local REST API pour la surface live complète |
 | Bases et Canvas         | Requêtes/écritures Bases, validation et helpers Canvas bornés        | Bases Bridge pour Bases en live                       |
-| Tâches                  | Lecture/requête Tasks + 23 outils Operon gouvernés                   | Operon 3.2.1 Developer API V1 via le Bridge           |
+| Tâches                  | Lecture/requête Tasks + 23 outils Operon gouvernés                   | Operon Developer API V1 via le Bridge                 |
 | Recherche sémantique    | Recherche Smart Connections avec cache de métadonnées durable        | `.smart-env` + embedding Ollama ou OpenAI             |
 | Runtime                 | Cache SQLite partagé, santé, maintenance, mode dégradé et exclusions | Filesystem local                                      |
 | Documents externes      | Lectures/handoff gouvernés + move local opt-in avec réparation       | Allowlist ; stdio local pour le move                  |
@@ -93,7 +92,7 @@ Activer seulement les surfaces utilisées :
   notes, métadonnées et tags en live ;
 - **Bases Bridge (REST)** inclus : opérations `.base` en live ;
 - **Smart Connections** : index sémantique `.smart-env` ;
-- **Operon 3.2.1** et **Optimike Operon Bridge** inclus : tâches live
+- **Operon Developer API V1** et **Optimike Operon Bridge** inclus : tâches live
   gouvernées via la Developer API officielle V1 ;
 - la compatibilité Kairélys reste disponible comme chemin legacy/rollback
   borné, mais n’est plus le moteur de production ;
@@ -120,15 +119,17 @@ destructives ou d’administration restent dans la CLI. Voir le
 [contrat MCP Operon](docs/operon-mcp-contract.fr.md) et
 l’[audit CLI / Developer API](docs/operon-cli-audit.fr.md).
 
-Note de compatibilité : l’adaptateur cible Operon officiel `3.2.1` et le Bridge
-`0.6.0` ; `3.2.0` reste explicitement compatible et porte le pilote live complet.
+Note de compatibilité : le Bridge `0.7.0` certifie les versions déjà validées
+jusqu’à `3.2.1` ; `3.2.0` reste la baseline certifiée antérieure. Operon `3.3.0` est admis
+en `compatible-provisional` lorsque la négociation Developer API V1 réussit ;
+son pilote live complet est validé, sans revenir à une allowlist produit.
 Le settlement des frontmatters de date et le consentement multi-fenêtres
 ont été fusionnés upstream avant ces versions. L’exécution des filtres
 sauvegardés est maintenant disponible via la Developer API task-workflow après
 un grant exact, mais l’API officielle ne publie pas leur catalogue : il faut
 fournir un `filterSetId` exact obtenu dans l’UI/configuration d’Operon ou par un
 workflow opérateur. L’adoption reste indisponible dans l’API officielle. Operon
-3.2.1 omet encore le renderer déclaratif des contrôles de grant Developer API ;
+omet encore le renderer déclaratif des contrôles de grant Developer API ;
 le correctif est suivi dans [#145](https://github.com/hasanyilmaz/operon/issues/145)
 et [#146](https://github.com/hasanyilmaz/operon/pull/146).
 Le MCP ne bascule jamais vers Markdown ou des API privées. Les renommages

--- a/README.fr.md
+++ b/README.fr.md
@@ -121,8 +121,9 @@ l’[audit CLI / Developer API](docs/operon-cli-audit.fr.md).
 
 Note de compatibilité : le Bridge `0.7.0` certifie les versions déjà validées
 jusqu’à `3.2.1` ; `3.2.0` reste la baseline certifiée antérieure. Operon `3.3.0` est admis
-en `compatible-provisional` lorsque la négociation Developer API V1 réussit ;
-son pilote live complet est validé, sans revenir à une allowlist produit.
+en `compatible-provisional` comme version non refusée exposant l’accesseur.
+L’usage live exige aussi `developerApi`, `ok`, `index.ready` et la capacité
+exacte. Son pilote complet est validé sans revenir à une allowlist produit.
 Le settlement des frontmatters de date et le consentement multi-fenêtres
 ont été fusionnés upstream avant ces versions. L’exécution des filtres
 sauvegardés est maintenant disponible via la Developer API task-workflow après

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 [![Latest release](https://img.shields.io/github/v/release/optimikelabs/optimike-obsidian-mcp?display_name=tag&sort=semver)](https://github.com/optimikelabs/optimike-obsidian-mcp/releases/latest)
 
-French version: [README.fr.md](README.fr.md)
-Documentation hub: [docs/README.md](docs/README.md)
+French version: [README.fr.md](README.fr.md) · Documentation hub: [docs/README.md](docs/README.md)
 Operations: [OPERATIONS.md](OPERATIONS.md)
 Security: [SECURITY.md](SECURITY.md)
 
@@ -121,18 +120,19 @@ still require fresh confirmation in the owning Obsidian vault window and fail
 closed after 45 seconds when no confirmation can be presented.
 
 Compatibility note: the adapter negotiates Operon Developer API V1 with
-`contractVersion: 1` and `runtimeApi: 1`. Versions proven by a complete live
-acceptance run are `certified`; an otherwise unknown Operon release exposing
-the same validated contract is `compatible-provisional` instead of being
+`contractVersion: 1` and `runtimeApi: 1`. Versions in the explicit certified
+set report `certified`; an otherwise unknown Operon release exposing the same
+validated contract is `compatible-provisional` instead of being
 blocked by its product version alone. Missing capabilities fail closed only for
 the affected tools, while known regressions remain explicitly denied.
-Operon `3.2.0` is the version used by the complete live acceptance run. Modified-time frontmatter settlement and
+Operon `3.2.0` remains the earlier certified pilot baseline. Modified-time frontmatter settlement and
 multi-window consent were merged upstream before these releases. Saved-filter execution is available
 through the additive task-workflow Developer API after an exact grant, but the
 official API does not expose the saved-filter catalog: callers must supply an
 exact `filterSetId` obtained from Operon's UI/configuration or an operator
 workflow. Adoption remains unavailable on the official Developer API. Operon
-3.2.1 still omits the declarative Settings renderer for Developer API grant
+`3.3.0` passed the complete live pilot and remains admitted as
+`compatible-provisional` by the contract-first policy rather than a product-version allowlist. Operon still omits the declarative Settings renderer for Developer API grant
 controls; the fix is tracked in [#145](https://github.com/hasanyilmaz/operon/issues/145)
 and [#146](https://github.com/hasanyilmaz/operon/pull/146).
 No MCP route falls back to Markdown or private APIs. Implicit File Task renames

--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ closed after 45 seconds when no confirmation can be presented.
 
 Compatibility note: the adapter negotiates Operon Developer API V1 with
 `contractVersion: 1` and `runtimeApi: 1`. Versions in the explicit certified
-set report `certified`; an otherwise unknown Operon release exposing the same
-validated contract is `compatible-provisional` instead of being
-blocked by its product version alone. Missing capabilities fail closed only for
-the affected tools, while known regressions remain explicitly denied.
+set report `certified`; unknown non-denied versions exposing the accessor report
+`compatible-provisional`. Live use still requires `developerApi`, `ok`,
+`index.ready`, and the exact capability. Missing capabilities fail closed only
+for affected tools; known regressions remain denied.
 Operon `3.2.0` remains the earlier certified pilot baseline. Modified-time frontmatter settlement and
 multi-window consent were merged upstream before these releases. Saved-filter execution is available
 through the additive task-workflow Developer API after an exact grant, but the

--- a/docs/operon-cli-audit.fr.md
+++ b/docs/operon-cli-audit.fr.md
@@ -2,15 +2,16 @@
 
 English version: [operon-cli-audit.md](operon-cli-audit.md)
 
-Date : 2026-08-09
+Date : 2026-08-13
 
-Référence : Operon officiel `3.2.1`, Operon CLI `1.1.0`, Developer API V1 et
+Référence : Operon officiel `3.3.0` admis provisoirement par contrat, Operon
+`3.2.1` certifié, Operon CLI `1.1.0`, Developer API V1 et
 `cli-manifest-v1.json`.
 
 Les observations CLI initiales du 1er août 2026 utilisaient Operon `3.0.1` et
-restent des preuves historiques. L’adaptateur MCP cible `3.2.1`, tandis que le
-pilote live complet reste porté par le build local `3.2.0`, compatible au niveau
-du contrat. Le renderer manquant en 3.2.1 est suivi dans
+restent des preuves historiques. L’adaptateur MCP certifie `3.2.1` et admet
+`3.3.0` provisoirement après négociation du contrat. Le pilote live complet
+`3.3.0` est vert ; le renderer manquant est suivi dans
 [#145](https://github.com/hasanyilmaz/operon/issues/145) et
 [#146](https://github.com/hasanyilmaz/operon/pull/146). Les correctifs #135 et #137 sont déjà fusionnés. La sécurité
 de renommage File Task reste suivie dans #139 et le cas de transition incertain
@@ -35,8 +36,8 @@ un agent.
 ## Comparaison des surfaces
 
 Le MCP enregistre vingt-trois outils gouvernés, dont six lectures de raisonnement
-Developer API bornées. L’exécution des filtres sauvegardés fonctionne sur Operon
-`3.2.x` après un grant exact `tasks.filter-query`, mais l’API officielle ne
+Developer API bornées. L’exécution des filtres sauvegardés fonctionne lorsque
+le contrat négocié annonce `tasks.filter-query`, après un grant exact, mais l’API officielle ne
 publie pas leur catalogue. L’adoption reste un outil de compatibilité
 indisponible :
 

--- a/docs/operon-cli-audit.md
+++ b/docs/operon-cli-audit.md
@@ -2,13 +2,13 @@
 
 French version: [operon-cli-audit.fr.md](operon-cli-audit.fr.md)
 
-Date: 2026-08-09
-Reference: official Operon `3.2.1`, Operon CLI `1.1.0`, Developer API V1 and `cli-manifest-v1.json`.
+Date: 2026-08-13
+Reference: official Operon `3.3.0` provisionally admitted by contract, certified Operon `3.2.1`, Operon CLI `1.1.0`, Developer API V1 and `cli-manifest-v1.json`.
 
 The original 2026-08-01 CLI observations were made against Operon `3.0.1` and
-remain historical evidence. The current MCP adapter targets `3.2.1` while the
-complete live acceptance evidence remains on the contract-compatible local
-`3.2.0` build. The missing 3.2.1 settings renderer is tracked in
+remain historical evidence. The current MCP adapter certifies `3.2.1` and
+admits `3.3.0` provisionally after contract negotiation. The complete `3.3.0`
+live acceptance run is green; the missing settings renderer is tracked in
 [#145](https://github.com/hasanyilmaz/operon/issues/145) and
 [#146](https://github.com/hasanyilmaz/operon/pull/146). Fixes #135 and #137 are already merged. File Task rename safety
 remains tracked in [#139](https://github.com/hasanyilmaz/operon/pull/139), and
@@ -31,7 +31,8 @@ Do not expose a generic CLI passthrough through MCP.
 ## Surface comparison
 
 The MCP registers twenty-three governed tools, including six bounded Developer
-API reasoning reads. Saved-filter execution is available on Operon `3.2.x`
+API reasoning reads. Saved-filter execution is available when the negotiated
+task-workflow contract advertises it
 after an exact `tasks.filter-query` grant, but the official API does not expose
 the saved-filter catalog. Adoption remains an unavailable compatibility tool:
 

--- a/docs/operon-decision-report.md
+++ b/docs/operon-decision-report.md
@@ -3,10 +3,11 @@
 ## Current status — 2026-08-13
 
 Optimike Obsidian MCP Bridge `0.7.0` certifies Operon through `3.2.1` and admits
-Operon `3.3.0` as `compatible-provisional` only after successful Developer API
-V1 negotiation and schema validation. The canonical server registers twenty-three
-governed Operon tools. Kairélys remains disabled and retained only for bounded
-rollback compatibility.
+the non-denied Operon `3.3.0` version with its Developer API V1 accessor as
+`compatible-provisional`. Developer API status, schema, index readiness, and
+capabilities remain separate live-use gates. The canonical server registers
+twenty-three governed Operon tools. Kairélys remains disabled and retained only
+for bounded rollback compatibility.
 
 The complete local acceptance run is green on Operon `3.3.0` with Bridge
 `0.7.0`: persisted grants, governed apply/replay/conflict/postflight, thirty
@@ -79,6 +80,28 @@ legacy Public API v1 only. It proved file/inline creation, managed and unmanaged
 properties, hierarchy/dependencies, blocked/released transitions, conversion,
 idempotency, stale-revision conflict, reindex/restart, stale cache and duplicate
 ID refusal. It is not presented as Developer API V1 evidence.
+
+## Operon 3.3.0 acceptance evidence
+
+The 2026-08-13 production-shaped ÉLYSIA run used official Operon `3.3.0`,
+Bridge `0.7.0`, both mutation opt-ins, and Developer API V1. A pre-cutover
+backup and rollback path were verified before installation.
+
+Observed results:
+
+- two complete Obsidian restarts retained the active Bridge consumer grant at
+  revision 6 with no pending capability and required no manual re-exposure;
+- Bridge status reported `compatible-provisional`, a valid V1 channel, a ready
+  live index, and 30 tasks;
+- `operon_validate` returned `P0/P1/P2 = 0/0/0`, and the exact saved-filter
+  route `fs_elysia_now` executed successfully;
+- smoke task `1dbefy1` passed sealed preview/apply, idempotent replay,
+  stale-revision conflict, semantic restoration, and postflight re-read;
+- final pending recovery inventory was empty after restoration.
+
+The lost-response path was not forced against the live vault. Its exact-plan
+reconciliation remains fixture evidence, not part of this live acceptance
+claim.
 
 The 2026-08-01 Operon `3.0.1` cutover and CLI `1.0.0` Windows observations also
 remain historical. The current runtime target is Operon `3.3.0` with Bridge

--- a/docs/operon-decision-report.md
+++ b/docs/operon-decision-report.md
@@ -1,15 +1,17 @@
 # Operon integration decision report
 
-## Current status — 2026-08-09
+## Current status — 2026-08-13
 
-Optimike Obsidian MCP targets official Operon `3.2.1` through Bridge `0.6.0`
-and Developer API V1. The canonical server registers twenty-three
+Optimike Obsidian MCP Bridge `0.7.0` certifies Operon through `3.2.1` and admits
+Operon `3.3.0` as `compatible-provisional` only after successful Developer API
+V1 negotiation and schema validation. The canonical server registers twenty-three
 governed Operon tools. Kairélys remains disabled and retained only for bounded
 rollback compatibility.
 
-The complete local acceptance run is green on a contract-compatible Operon `3.2.0` build carrying
-only the settings-renderer fix that restores Developer API grant controls. The
-equivalent 3.2.1 fix is tracked in upstream #145/#146. Remaining fail-closed
+The complete local acceptance run is green on Operon `3.3.0` with Bridge
+`0.7.0`: persisted grants, governed apply/replay/conflict/postflight, thirty
+tasks, zero validation violations and zero recovery. The Settings fix remains
+tracked in upstream #145/#146. Remaining fail-closed
 limitations are tracked in:
 
 - transition settlement: [#99](https://github.com/hasanyilmaz/operon/issues/99)

--- a/docs/operon-decision-report.md
+++ b/docs/operon-decision-report.md
@@ -81,7 +81,8 @@ idempotency, stale-revision conflict, reindex/restart, stale cache and duplicate
 ID refusal. It is not presented as Developer API V1 evidence.
 
 The 2026-08-01 Operon `3.0.1` cutover and CLI `1.0.0` Windows observations also
-remain historical. Current targets are Operon `3.2.0` and CLI `1.1.0`.
+remain historical. The current runtime target is Operon `3.3.0` with Bridge
+`0.7.0`; CLI `1.1.0` remains the documented operator-reference target.
 
 ## Deliberately excluded or unavailable
 

--- a/docs/operon-local-validation.md
+++ b/docs/operon-local-validation.md
@@ -247,12 +247,21 @@ FAIL if cached data is presented as live.
 
 ## 11. Incompatibility test
 
-Disable Operon or use any test manifest version outside the explicit allowlist
-(`2.4.0`, `2.5.0`, `3.0.1`, `3.1.0`, `3.1.1`, and official `3.2.0`).
+Use one of these disposable-vault fixtures:
+
+- disable Operon to exercise the unavailable path;
+- set the test manifest to `3.0.0`, which is explicitly denied; or
+- remove, break, or return a malformed `getDeveloperApiV1()` contract to make
+  Developer API V1 negotiation fail.
+
+Do not use a merely unknown product version as the incompatibility fixture. A
+non-denied release exposing the validated Developer API V1 contract is admitted
+as `compatible-provisional` by design.
 
 PASS:
 
-- Bridge status becomes unavailable/incompatible;
+- Bridge status becomes unavailable for the disabled fixture or incompatible
+  for the denied/broken-contract fixture;
 - no exception crashes Obsidian;
 - the MCP either serves a stale prior snapshot or returns a structured unavailable error.
 

--- a/docs/operon-local-validation.md
+++ b/docs/operon-local-validation.md
@@ -7,13 +7,15 @@ This recipe is the Desktop proof. Run destructive fixtures only in a disposable 
 - Node.js `>=22.7.5`
 - Obsidian Desktop
 - Local REST API enabled
-- Operon `3.2.1` enabled for current compatibility checks; `3.2.0` remains the complete live-pilot baseline and `2.4.0` / `2.5.0` remain legacy-read fixtures
+- Operon `3.3.0` for the completed contract-first live pilot; `3.2.1` remains in the explicit certified set, and `2.4.0` / `2.5.0` remain legacy-read fixtures
 - Optimike Operon Bridge built from this branch
 - Optimike Obsidian MCP built from this branch
 - a backup or disposable vault
 
-The adapter targets official Operon `3.2.1`; the complete live acceptance run
-used the contract-compatible local `3.2.0` build. The missing 3.2.1 grant-control
+The adapter certifies through Operon `3.2.1` and provisionally admits `3.3.0`
+only when contract negotiation succeeds. The `3.3.0` live acceptance run is
+complete and green; keeping its runtime state provisional preserves the
+contract-first policy. The missing grant-control
 renderer is tracked in upstream #145/#146. Fixes #135 and #137 are already merged. File Task rename safety remains
 tracked by [#139](https://github.com/hasanyilmaz/operon/pull/139), and transition
 settlement by #99/#101. Unsupported or uncertain paths stay fail-closed; this

--- a/docs/operon-local-validation.md
+++ b/docs/operon-local-validation.md
@@ -12,8 +12,9 @@ This recipe is the Desktop proof. Run destructive fixtures only in a disposable 
 - Optimike Obsidian MCP built from this branch
 - a backup or disposable vault
 
-The adapter certifies through Operon `3.2.1` and provisionally admits `3.3.0`
-only when contract negotiation succeeds. The `3.3.0` live acceptance run is
+The adapter certifies through Operon `3.2.1` and gives `3.3.0` provisional
+version/accessor admission. The `3.3.0` live acceptance run separately proves
+the Developer API, schema, index, capability, and readiness gates and is
 complete and green; keeping its runtime state provisional preserves the
 contract-first policy. The missing grant-control
 renderer is tracked in upstream #145/#146. Fixes #135 and #137 are already merged. File Task rename safety remains
@@ -255,8 +256,9 @@ Use one of these disposable-vault fixtures:
   Developer API V1 negotiation fail.
 
 Do not use a merely unknown product version as the incompatibility fixture. A
-non-denied release exposing the validated Developer API V1 contract is admitted
-as `compatible-provisional` by design.
+non-denied release exposing the Developer API V1 accessor is admitted as
+`compatible-provisional` by design. It is not usable until `developerApi`,
+top-level `ok`, `index.ready`, and the requested capability also pass.
 
 PASS:
 
@@ -412,6 +414,41 @@ OPEN BOUNDARIES:
 - #99/#101 and #139 remain fail-closed paths;
 - no deletion tool, generic CLI passthrough, raw Markdown or private API exists
   in the MCP.
+
+## 19. Official Operon 3.3.0 contract-first acceptance — 2026-08-13
+
+Inputs:
+
+- official Operon `3.3.0`;
+- Optimike Operon Bridge `0.7.0`;
+- Local REST API and both mutation opt-ins enabled;
+- pre-cutover backup and rollback path verified;
+- existing ÉLYSIA task corpus, plus one bounded smoke task `1dbefy1` restored
+  after the run.
+
+PASS:
+
+- two complete Obsidian restarts retained the active
+  `optimike-operon-bridge` Developer API consumer at grant revision 6, with no
+  pending capability and no manual re-exposure;
+- the first live status recovered through the bounded `cache-ready` startup
+  retry and then reported `compatible-provisional`, a valid Developer API V1
+  channel, `index.ready=true`, and 30 tasks;
+- `operon_validate` returned `P0/P1/P2 = 0/0/0`;
+- saved-filter execution for exact ID `fs_elysia_now` succeeded;
+- smoke task `1dbefy1` passed sealed preview/apply, idempotent replay
+  (`replayed=true`), stale-revision conflict, semantic restoration, and
+  postflight re-read;
+- `operon_list_pending_recoveries` returned an empty list after restoration.
+
+NOT RUN LIVE:
+
+- forced response loss after apply. This remains covered by the disposable
+  operation fixtures; it was not induced against the production vault.
+
+The `compatible-provisional` label records version/accessor admission only.
+The successful Developer API status, schema, index, capability, and readiness
+checks above are the independent evidence that authorized this pilot.
 
 ## Executed pilot result — 2026-07-21
 

--- a/docs/operon-mcp-contract.fr.md
+++ b/docs/operon-mcp-contract.fr.md
@@ -86,10 +86,14 @@ catalogue, la pagination complète des tâches et les diagnostics d’index.
 Le statut distingue :
 
 - `certified` : version produit appartenant à l’ensemble certifié explicite du
-  Bridge et dont les contrôles runtime négociés passent ;
-- `compatible-provisional` : release inconnue dont la frontière Developer API
-  V1 passe les mêmes contrôles runtime ;
+  Bridge et dont la frontière Developer API est admise ;
+- `compatible-provisional` : release non refusée hors de cet ensemble et dont
+  la frontière Developer API V1 est admise ;
 - `incompatible` : frontière absente, explicitement refusée ou invalide.
+
+Cet état de compatibilité est indépendant de la disponibilité live de l’index.
+Avant d’utiliser une route, le client doit aussi exiger `ok`, `index.ready` et
+la capacité exacte annoncée.
 
 Une régression comportementale connue peut rester bloquée par version et par
 opération. Une capacité optionnelle absente désactive seulement les outils qui

--- a/docs/operon-mcp-contract.fr.md
+++ b/docs/operon-mcp-contract.fr.md
@@ -86,9 +86,9 @@ catalogue, la pagination complète des tâches et les diagnostics d’index.
 Le statut distingue :
 
 - `certified` : version produit appartenant à l’ensemble certifié explicite du
-  Bridge et dont la frontière Developer API est admise ;
+  Bridge et dont l’accesseur Developer API est présent ;
 - `compatible-provisional` : release non refusée hors de cet ensemble et dont
-  la frontière Developer API V1 est admise ;
+  l’accesseur Developer API V1 est présent ;
 - `incompatible` : frontière absente, explicitement refusée ou invalide.
 
 Cet état de compatibilité est indépendant de la disponibilité live de l’index.

--- a/docs/operon-mcp-contract.fr.md
+++ b/docs/operon-mcp-contract.fr.md
@@ -85,7 +85,8 @@ catalogue, la pagination complète des tâches et les diagnostics d’index.
 
 Le statut distingue :
 
-- `certified` : release ayant passé l’acceptation live ;
+- `certified` : version produit appartenant à l’ensemble certifié explicite du
+  Bridge et dont les contrôles runtime négociés passent ;
 - `compatible-provisional` : release inconnue dont la frontière Developer API
   V1 passe les mêmes contrôles runtime ;
 - `incompatible` : frontière absente, explicitement refusée ou invalide.

--- a/docs/operon-mcp-contract.md
+++ b/docs/operon-mcp-contract.md
@@ -61,7 +61,8 @@ negotiates `contractVersion: 1` with `runtimeApi: 1`, and validates the granted
 capabilities, response shapes, live health, catalog, complete task pagination,
 and index diagnostics. Status distinguishes:
 
-- `certified`: a release that completed live acceptance;
+- `certified`: a product version in the Bridge's explicit certified set whose
+  negotiated runtime checks pass;
 - `compatible-provisional`: an unknown release whose Developer API V1 boundary
   passes the same runtime checks;
 - `incompatible`: an absent, denied, or invalid contract boundary.

--- a/docs/operon-mcp-contract.md
+++ b/docs/operon-mcp-contract.md
@@ -62,9 +62,9 @@ capabilities, response shapes, live health, catalog, complete task pagination,
 and index diagnostics. Status distinguishes:
 
 - `certified`: a product version in the Bridge's explicit certified set whose
-  Developer API boundary is admitted;
+  Developer API accessor is present;
 - `compatible-provisional`: a non-denied release outside that set whose
-  Developer API V1 boundary is admitted;
+  Developer API V1 accessor is present;
 - `incompatible`: an absent, denied, or invalid contract boundary.
 
 This compatibility state is independent from live index readiness. Callers

--- a/docs/operon-mcp-contract.md
+++ b/docs/operon-mcp-contract.md
@@ -62,10 +62,14 @@ capabilities, response shapes, live health, catalog, complete task pagination,
 and index diagnostics. Status distinguishes:
 
 - `certified`: a product version in the Bridge's explicit certified set whose
-  negotiated runtime checks pass;
-- `compatible-provisional`: an unknown release whose Developer API V1 boundary
-  passes the same runtime checks;
+  Developer API boundary is admitted;
+- `compatible-provisional`: a non-denied release outside that set whose
+  Developer API V1 boundary is admitted;
 - `incompatible`: an absent, denied, or invalid contract boundary.
+
+This compatibility state is independent from live index readiness. Callers
+must also require top-level `ok`, `index.ready`, and the exact advertised
+capability before using a route.
 
 Known behavioral regressions may remain denied by exact version and operation.
 Missing optional capabilities disable only dependent tools. A future contract

--- a/docs/operon-rest-contract.md
+++ b/docs/operon-rest-contract.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-The Bridge projects the active Operon-compatible engine's live index through Obsidian Local REST API. Reads work with official Operon `2.4.0` and `2.5.0`, with official Operon `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, and `3.2.1` through Developer API V1, with Kairélys `2.5.1` through `2.5.3` (based on Operon `2.5.0`), and with Kairélys `2.6.1` through `2.6.3` (based on Operon `2.6.0`). Compatibility is decided by plugin ID and version together. Operon 3.2.x mutations use the official Developer API V1 preview/apply/recovery surface; legacy Kairélys mutations use Public API v1. There is no raw Markdown or private-reflection fallback.
+The Bridge projects the active Operon-compatible engine's live index through Obsidian Local REST API. Reads work with official Operon `2.4.0` and `2.5.0`, with certified official Operon `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, and `3.2.1`, and provisionally with `3.3.0` after successful Developer API V1 negotiation. Kairélys legacy support remains bounded to the documented allowlist. Developer API mutations use the official preview/apply/recovery surface; legacy Kairélys mutations use Public API v1. There is no raw Markdown or private-reflection fallback.
 
 Prefix:
 
@@ -15,7 +15,7 @@ All routes inherit Local REST API authentication and TLS behavior.
 ## Compatibility and capabilities
 
 - Bridge contract: `1`
-- Latest contract compatibility target: official Operon `3.2.1`; complete live read/write pilot: `3.2.0`
+- Certified compatibility through official Operon `3.2.1`; provisional contract admission and complete live read/write pilot: `3.3.0`
 - Official Operon legacy read allowlist: `2.4.0`, `2.5.0`
 - Official Operon Developer API V1 allowlist: `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, `3.2.1`
 - Kairélys read allowlist: `2.5.1`, `2.5.2`, `2.5.3`, `2.6.1`, `2.6.2`, `2.6.3`
@@ -24,9 +24,9 @@ All routes inherit Local REST API authentication and TLS behavior.
 - Official Operon `3.2.x`: typed create/update/transition/relationship/recurrence/convert/relocate through Developer API V1, plus saved-filter execution through the additive task-workflow API, when the exact grants are active. The grant state and capability advertisement are both reported in `/status`; an uncertain apply is returned as such and is never retried blindly.
 - Kairélys `2.5.1` through `2.5.3` and `2.6.1` through `2.6.3` with Public API v1: read-write
 
-`GET /status` reports `bridge.mode` as `read-only` or `read-write` and exposes each capability independently. A future Operon version is not assumed compatible merely because its Markdown looks similar.
+`GET /status` reports `bridge.mode` as `read-only` or `read-write` and exposes each capability independently. A future Operon version is admitted provisionally only after Developer API V1 negotiation and schema validation; Markdown similarity is irrelevant.
 
-The adapter targets the official `3.2.1` contract while the complete live acceptance evidence remains on the compatible local `3.2.0` build. The missing 3.2.1 settings renderer is tracked by [#145](https://github.com/hasanyilmaz/operon/issues/145) and [#146](https://github.com/hasanyilmaz/operon/pull/146). Modified-time settlement and multi-window consent fixes from #135 and #137 are already merged. File Task rename safety remains tracked by [#139](https://github.com/hasanyilmaz/operon/pull/139), and the transition investigation by [#99](https://github.com/hasanyilmaz/operon/issues/99) and [#101](https://github.com/hasanyilmaz/operon/pull/101). Those paths stay fail-closed. No Markdown or private-API fallback is introduced.
+The adapter certifies official `3.2.1` and provisionally admits `3.3.0`; the complete `3.3.0` live acceptance run is green. The missing Settings renderer is tracked by [#145](https://github.com/hasanyilmaz/operon/issues/145) and [#146](https://github.com/hasanyilmaz/operon/pull/146). Modified-time settlement and multi-window consent fixes from #135 and #137 are already merged. File Task rename safety remains tracked by [#139](https://github.com/hasanyilmaz/operon/pull/139), and the transition investigation by [#99](https://github.com/hasanyilmaz/operon/issues/99) and [#101](https://github.com/hasanyilmaz/operon/pull/101). Those paths stay fail-closed. No Markdown or private-API fallback is introduced.
 
 Readiness requires a compatible plugin, positive generation, healthy idle V8 index, zero dirty sources, and a task count matching diagnostics. A duplicate-ID conflict is reported separately and causes MCP snapshot refresh refusal.
 

--- a/docs/operon-rest-contract.md
+++ b/docs/operon-rest-contract.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-The Bridge projects the active Operon-compatible engine's live index through Obsidian Local REST API. Reads work with official Operon `2.4.0` and `2.5.0`, with certified official Operon `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, and `3.2.1`, and provisionally with `3.3.0` after successful Developer API V1 negotiation. Kairélys legacy support remains bounded to the documented allowlist. Developer API mutations use the official preview/apply/recovery surface; legacy Kairélys mutations use Public API v1. There is no raw Markdown or private-reflection fallback.
+The Bridge projects the active Operon-compatible engine's live index through Obsidian Local REST API. Reads work with official Operon `2.4.0` and `2.5.0`, with certified official Operon `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, and `3.2.1`, and provisionally with non-denied `3.3.0` when its Developer API V1 accessor is present. Kairélys legacy support remains bounded to the documented allowlist. Developer API mutations use the official preview/apply/recovery surface; legacy Kairélys mutations use Public API v1. There is no raw Markdown or private-reflection fallback.
 
 Prefix:
 
@@ -24,7 +24,7 @@ All routes inherit Local REST API authentication and TLS behavior.
 - Official Operon `3.2.x`: typed create/update/transition/relationship/recurrence/convert/relocate through Developer API V1, plus saved-filter execution through the additive task-workflow API, when the exact grants are active. The grant state and capability advertisement are both reported in `/status`; an uncertain apply is returned as such and is never retried blindly.
 - Kairélys `2.5.1` through `2.5.3` and `2.6.1` through `2.6.3` with Public API v1: read-write
 
-`GET /status` reports `bridge.mode` as `read-only` or `read-write` and exposes each capability independently. A future Operon version is admitted provisionally only after Developer API V1 negotiation and schema validation; Markdown similarity is irrelevant.
+`GET /status` reports `bridge.mode` as `read-only` or `read-write` and exposes each capability independently. A future non-denied Operon version is admitted provisionally when its Developer API V1 accessor is present; Markdown similarity is irrelevant. Live use remains independently gated by successful negotiation, `developerApi`, top-level `ok`, `index.ready`, and the exact advertised capability.
 
 The adapter certifies official `3.2.1` and provisionally admits `3.3.0`; the complete `3.3.0` live acceptance run is green. The missing Settings renderer is tracked by [#145](https://github.com/hasanyilmaz/operon/issues/145) and [#146](https://github.com/hasanyilmaz/operon/pull/146). Modified-time settlement and multi-window consent fixes from #135 and #137 are already merged. File Task rename safety remains tracked by [#139](https://github.com/hasanyilmaz/operon/pull/139), and the transition investigation by [#99](https://github.com/hasanyilmaz/operon/issues/99) and [#101](https://github.com/hasanyilmaz/operon/pull/101). Those paths stay fail-closed. No Markdown or private-API fallback is introduced.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optimike-obsidian-mcp",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optimike-obsidian-mcp",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optimike-obsidian-mcp",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Unified Obsidian MCP server with shared local cache, Operon and Tasks tools, Bases support, semantic search, runtime observability, and degraded read mode for durable agent workflows.",
   "main": "dist/index.js",
   "files": [

--- a/plugins/obsidian-operon-bridge/README.md
+++ b/plugins/obsidian-operon-bridge/README.md
@@ -28,7 +28,8 @@ official API does not expose the saved-filter catalog. Adoption, unmanaged
 properties, and arbitrary `targetFolder` destinations remain unsupported and
 are rejected explicitly. The complete live pilot used the local 3.2.0 build.
 Operon `3.3.0` is admitted as `compatible-provisional` when Developer API V1
-negotiation and runtime validation succeed. Its complete live pilot passed;
+negotiation succeeds. Its complete live pilot passed as a separate readiness
+proof;
 Bridge `0.7.0` deliberately preserves the contract-first provisional path
 instead of making a product-version allowlist authoritative again.
 The Settings UI fix is tracked in upstream
@@ -42,10 +43,15 @@ and [#101](https://github.com/hasanyilmaz/operon/pull/101).
 Compatibility is reported explicitly:
 
 - `certified`: the product version belongs to the Bridge's explicit certified
-  set and all negotiated runtime checks pass;
-- `compatible-provisional`: the product version is new, but the Developer API
-  V1 negotiation, capabilities, schemas, and live index checks pass;
+  set and its Developer API boundary is admitted;
+- `compatible-provisional`: the product version is outside that set but is not
+  denied and its Developer API V1 boundary is admitted;
 - `incompatible`: the contract boundary is absent, denied, or fails validation.
+
+Compatibility is admission, not live readiness. Check top-level `ok`,
+`index.ready`, and the advertised `capabilities` before using a route; an
+admitted runtime can still be temporarily unready while its index settles or
+recovers.
 
 The product version remains diagnostic metadata and may select a narrowly
 documented denylist entry. It is not the primary admission key for Operon 3.x.

--- a/plugins/obsidian-operon-bridge/README.md
+++ b/plugins/obsidian-operon-bridge/README.md
@@ -27,7 +27,11 @@ Saved-filter execution requires an exact grant and exact `filterSetId`; the
 official API does not expose the saved-filter catalog. Adoption, unmanaged
 properties, and arbitrary `targetFolder` destinations remain unsupported and
 are rejected explicitly. The complete live pilot used the local 3.2.0 build.
-The equivalent Settings UI fix for 3.2.1 is tracked in upstream
+Operon `3.3.0` is admitted as `compatible-provisional` when Developer API V1
+negotiation and runtime validation succeed. Its complete live pilot passed;
+Bridge `0.7.0` deliberately preserves the contract-first provisional path
+instead of making a product-version allowlist authoritative again.
+The Settings UI fix is tracked in upstream
 [#145](https://github.com/hasanyilmaz/operon/issues/145) and
 [#146](https://github.com/hasanyilmaz/operon/pull/146). Uncertain outcomes remain fail-closed;
 the Bridge never retries blindly or falls back to Markdown/private APIs. File

--- a/plugins/obsidian-operon-bridge/README.md
+++ b/plugins/obsidian-operon-bridge/README.md
@@ -41,7 +41,8 @@ and [#101](https://github.com/hasanyilmaz/operon/pull/101).
 
 Compatibility is reported explicitly:
 
-- `certified`: the release completed the Bridge acceptance path;
+- `certified`: the product version belongs to the Bridge's explicit certified
+  set and all negotiated runtime checks pass;
 - `compatible-provisional`: the product version is new, but the Developer API
   V1 negotiation, capabilities, schemas, and live index checks pass;
 - `incompatible`: the contract boundary is absent, denied, or fails validation.

--- a/plugins/obsidian-operon-bridge/README.md
+++ b/plugins/obsidian-operon-bridge/README.md
@@ -27,9 +27,9 @@ Saved-filter execution requires an exact grant and exact `filterSetId`; the
 official API does not expose the saved-filter catalog. Adoption, unmanaged
 properties, and arbitrary `targetFolder` destinations remain unsupported and
 are rejected explicitly. The complete live pilot used the local 3.2.0 build.
-Operon `3.3.0` is admitted as `compatible-provisional` when Developer API V1
-negotiation succeeds. Its complete live pilot passed as a separate readiness
-proof;
+Operon `3.3.0` is admitted as `compatible-provisional` because the non-denied
+version exposes the Developer API V1 accessor. Its complete live pilot passed
+the separate developer-API, schema, index, capability, and readiness gates;
 Bridge `0.7.0` deliberately preserves the contract-first provisional path
 instead of making a product-version allowlist authoritative again.
 The Settings UI fix is tracked in upstream


### PR DESCRIPTION
## Outcome

Prepares Optimike Obsidian MCP `2.5.0` from the already merged PRs #41–#44.

## Included

- Operon saved-filter execution and capability isolation;
- Bridge `0.7.0` contract-first, vacation-safe compatibility;
- bounded retry for transient Developer API startup;
- common governed operation runtime with the first `external_move` adapter;
- terminal compensation replay guard;
- package version and release changelog;
- documentation aligned with the completed Operon `3.3.0` + Bridge `0.7.0` live pilot.

Operon `3.3.0` remains `compatible-provisional` by the contract-first runtime policy even though its complete local live pilot is green. The missing declarative Developer API Settings controls remain tracked upstream in issue #145 / PR #146.

## Verification

- `npm run check:operon`
- `npm run test:docs`
- `npm run build:bridges`
- `npm run test:package`
- `npm run audit:production`

No tag or GitHub release is created by this PR. Publishing remains a separate post-merge action.