### PR TITLE
fix: restore post-merge documentation gate

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -1,7 +1,6 @@
 # Optimike Obsidian MCP
 
 [![Dernière version](https://img.shields.io/github/v/release/optimikelabs/optimike-obsidian-mcp?display_name=tag&sort=semver)](https://github.com/optimikelabs/optimike-obsidian-mcp/releases/latest)
-
 English version: [README.md](README.md) · Hub documentaire : [docs/README.fr.md](docs/README.fr.md)
 Exploitation : [OPERATIONS.fr.md](OPERATIONS.fr.md)
 Sécurité : [SECURITY.fr.md](SECURITY.fr.md)
@@ -107,9 +106,7 @@ OPERON_MUTATIONS_ENABLED=true
 ```
 
 Les snapshots Operon obsolètes restent toujours en lecture seule.
-
 Le remplacement atomique des notes a son propre réglage, désactivé par défaut, et ne requiert pas le grant Developer API d’Operon.
-
 Le MCP expose une surface agentique gouvernée, pas toutes les fonctions de la
 CLI Operon. Les diagnostics natifs, la recherche/résolution, les relations et
 contextes bornés ainsi que l’état du timer sont disponibles en lecture seule.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Optimike Obsidian MCP
 
 [![Latest release](https://img.shields.io/github/v/release/optimikelabs/optimike-obsidian-mcp?display_name=tag&sort=semver)](https://github.com/optimikelabs/optimike-obsidian-mcp/releases/latest)
-
 French version: [README.fr.md](README.fr.md) · Documentation hub: [docs/README.md](docs/README.md)
 Operations: [OPERATIONS.md](OPERATIONS.md)
 Security: [SECURITY.md](SECURITY.md)


### PR DESCRIPTION
## Summary
- restore the README concision contract after PRs #45 and #46 were merged together
- remove four presentation-only blank lines; no product behavior or compatibility wording changes

## Validation
- `npm run test:docs`
- `npm run build:bridges`
- `npm run test:package`
- `npm run audit:production`
- post-merge Atomic Write canary green in the disposable Obsidian pilot vault