### PR TITLE
chore: prepare Optimike Obsidian MCP v2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.0] - 2026-08-14
+
 ### Added
 
 - Governed source-preserving Frontmatter P1 surface:

--- a/docs/adr/ADR-Governed-Frontmatter-P1.md
+++ b/docs/adr/ADR-Governed-Frontmatter-P1.md
@@ -2,11 +2,12 @@
 
 ## Status
 
-Candidate admitted for merge — the pure model, compiler, multi-process
-identity, stdio/HTTP MCP, runtime, Operon, documentation, package, and
-production-audit gates pass. Live admission passed in the disposable Obsidian
-pilot vault on 2026-08-14. Merge remains repository-authority work and requires
-the exact post-canary head to remain green and externally reviewed.
+Accepted, implemented, and prepared for release in `2.7.0`. The pure model,
+compiler, multi-process identity, stdio/HTTP MCP, runtime, Operon,
+documentation, package, and production-audit gates pass. Live admission passed
+in the disposable Obsidian pilot vault on 2026-08-14. PR #51 merged the exact
+post-canary reviewed head, and the post-merge `main` Runtime workflow passed on
+Linux and Windows.
 
 ## Authority
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -10,7 +10,7 @@ setup or operations guides, not in this index.
 | [External reference integrity](ADR-External-Reference-Integrity.md) / [FR](ADR-External-Reference-Integrity.fr.md) | Accepted and implemented for a local stdio pilot                                        | Same-root file move, exact ÉLYSIA reference repair, journal and rollback |
 | [Operon Bridge](ADR-Operon-Bridge.md)                                                                              | Accepted for bounded pilot                                                              | Versioned task-domain bridge and guarded mutation contract               |
 | [Common governed operation runtime](ADR-Common-Operation-Runtime.md)                                               | Accepted and released in 2.6.0; public atomic-note projection and live canary complete | Shared plan, apply, status, receipt and exact-plan recovery vocabulary   |
-| [P1 governed frontmatter projection](ADR-Governed-Frontmatter-P1.md)                                               | Proposed; model and executable failure-contract gate                                    | Source-preserving domain compiler projected over the released P0 runtime |
+| [P1 governed frontmatter projection](ADR-Governed-Frontmatter-P1.md)                                               | Accepted and implemented; prepared for release in 2.7.0                                 | Source-preserving domain compiler projected over the released P0 runtime |
 
 ## Status vocabulary
 
@@ -25,6 +25,7 @@ The external-roots ADR remains authoritative for root authorization,
 confinement, provenance, reads and handoff. The HTTP ADR amends its stdio-only
 delivery restriction. The external-reference-integrity ADR adds one opt-in
 local stdio mutation without opening upload, replace, delete, sync or HTTP
-mutation. The P1 ADR remains proposed until its source-preservation proof,
-projected concurrency tests, Linux/Windows CI, Codex Review, and live Obsidian
-canary all pass.
+mutation. The P1 ADR is accepted and implemented after its
+source-preservation proof, projected concurrency tests, Linux/Windows CI,
+exact-head Codex Review, live Obsidian canary, merge, and post-merge `main`
+workflow all passed.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optimike-obsidian-mcp",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optimike-obsidian-mcp",
-      "version": "2.6.0",
+      "version": "2.7.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optimike-obsidian-mcp",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Unified Obsidian MCP server with shared local cache, Operon and Tasks tools, Bases support, semantic search, runtime observability, and degraded read mode for durable agent workflows.",
   "main": "dist/index.js",
   "files": [

--- a/scripts/test-doc-contract.mjs
+++ b/scripts/test-doc-contract.mjs
@@ -102,8 +102,8 @@ assert.match(matrixFr, /\| Admin filesystem\s+\| Non\s+\| Non/);
 const packageJson = JSON.parse(await text("package.json"));
 assert.equal(
   packageJson.version,
-  "2.6.0",
-  "released package metadata must match the stabilized 2.6.0 authority",
+  "2.7.0",
+  "release-candidate package metadata must match the bounded 2.7.0 P1 authority",
 );
 assert.equal(packageJson.scripts["start:http"], "node scripts/run-http.mjs");
 assert.equal(packageJson.scripts["start:daemon"], "node scripts/run-http.mjs");

--- a/scripts/test-governed-frontmatter-doc-contract.mjs
+++ b/scripts/test-governed-frontmatter-doc-contract.mjs
@@ -41,6 +41,7 @@ const [
   read("scripts/smoke-governed-frontmatter-live.mjs"),
 ]);
 const pkg = JSON.parse(await read("package.json"));
+assert.equal(pkg.version, "2.7.0");
 
 for (const tool of tools) {
   for (const [name, content] of [
@@ -78,7 +79,7 @@ assert.match(adr, /Observer/);
 assert.match(adr, /Failure matrix/);
 assert.match(adr, /Linearization points/);
 assert.match(adr, /actualDiff\(before, after\)/);
-assert.match(adr, /Candidate admitted for merge/);
+assert.match(adr, /Accepted, implemented, and prepared for release in `2\.7\.0`/);
 assert.match(adr, /Live admission passed[\s\S]*2026-08-14/i);
 assert.match(
   adr,
@@ -179,9 +180,17 @@ assert.doesNotMatch(
   liveCanary,
   /path\.join\(process\.cwd\(\), ["']\.tmp["']\)/,
 );
-assert.match(
-  changelog,
-  /## \[Unreleased\][\s\S]*obsidian_frontmatter_patch_plan/,
+const releaseHeading = "## [2.7.0] - 2026-08-14";
+const previousReleaseHeading = "## [2.6.0] - 2026-08-14";
+const releaseStart = changelog.indexOf(releaseHeading);
+const previousReleaseStart = changelog.indexOf(previousReleaseHeading);
+assert.ok(releaseStart > changelog.indexOf("## [Unreleased]"));
+assert.ok(previousReleaseStart > releaseStart);
+const releaseSection = changelog.slice(releaseStart, previousReleaseStart);
+assert.match(releaseSection, /obsidian_frontmatter_patch_plan/);
+assert.doesNotMatch(
+  changelog.slice(changelog.indexOf("## [Unreleased]"), releaseStart),
+  /obsidian_frontmatter_patch_plan/,
 );
 
 console.log(

--- a/scripts/test-governed-frontmatter-doc-contract.mjs
+++ b/scripts/test-governed-frontmatter-doc-contract.mjs
@@ -180,17 +180,22 @@ assert.doesNotMatch(
   liveCanary,
   /path\.join\(process\.cwd\(\), ["']\.tmp["']\)/,
 );
-const releaseHeading = "## [2.7.0] - 2026-08-14";
-const previousReleaseHeading = "## [2.6.0] - 2026-08-14";
-const releaseStart = changelog.indexOf(releaseHeading);
-const previousReleaseStart = changelog.indexOf(previousReleaseHeading);
-assert.ok(releaseStart > changelog.indexOf("## [Unreleased]"));
-assert.ok(previousReleaseStart > releaseStart);
-const releaseSection = changelog.slice(releaseStart, previousReleaseStart);
-const unreleasedSection = changelog.slice(
-  changelog.indexOf("## [Unreleased]"),
-  releaseStart,
-);
+const changelogHeadings = [
+  ...changelog.matchAll(/^## \[([^\]]+)\](?: - .*?)?$/gm),
+];
+function changelogSection(version) {
+  const headingIndex = changelogHeadings.findIndex(
+    (heading) => heading[1] === version,
+  );
+  assert.notEqual(headingIndex, -1, `missing changelog section ${version}`);
+  const start = changelogHeadings[headingIndex].index;
+  const end = changelogHeadings[headingIndex + 1]?.index ?? changelog.length;
+  return changelog.slice(start, end);
+}
+
+assert.match(changelog, /^## \[2\.7\.0\] - 2026-08-14$/m);
+const releaseSection = changelogSection("2.7.0");
+const unreleasedSection = changelogSection("Unreleased");
 for (const tool of tools) {
   assert.ok(
     releaseSection.includes(`\`${tool}\``),

--- a/scripts/test-governed-frontmatter-doc-contract.mjs
+++ b/scripts/test-governed-frontmatter-doc-contract.mjs
@@ -187,11 +187,20 @@ const previousReleaseStart = changelog.indexOf(previousReleaseHeading);
 assert.ok(releaseStart > changelog.indexOf("## [Unreleased]"));
 assert.ok(previousReleaseStart > releaseStart);
 const releaseSection = changelog.slice(releaseStart, previousReleaseStart);
-assert.match(releaseSection, /obsidian_frontmatter_patch_plan/);
-assert.doesNotMatch(
-  changelog.slice(changelog.indexOf("## [Unreleased]"), releaseStart),
-  /obsidian_frontmatter_patch_plan/,
+const unreleasedSection = changelog.slice(
+  changelog.indexOf("## [Unreleased]"),
+  releaseStart,
 );
+for (const tool of tools) {
+  assert.ok(
+    releaseSection.includes(`\`${tool}\``),
+    `2.7.0 changelog section omits ${tool}`,
+  );
+  assert.ok(
+    !unreleasedSection.includes(`\`${tool}\``),
+    `${tool} must belong to 2.7.0, not Unreleased`,
+  );
+}
 
 console.log(
   "PASS: governed frontmatter P1 docs, package surface, authority model, live-canary boundary, and bilingual contracts are coherent",


### PR DESCRIPTION
## Release authority

P1 merged through #51 and is canonical on `main` at merge commit `681599f68a74e6e68527f29980431fedf2fead96`. The exact-head Codex Review, disposable Obsidian canary with exact restoration, and post-merge Runtime workflow on Linux and Windows are green.

This PR is intentionally limited to publishing P1 alone as `v2.7.0`:

- bump `package.json` and the lockfile from `2.6.0` to `2.7.0`;
- move the governed Frontmatter P1 changes from `Unreleased` to `2.7.0` dated 2026-08-14;
- mark the P1 ADR accepted and implemented after merge and post-merge verification;
- update documentation contracts so the release version and changelog ownership cannot drift again.

## Explicit exclusions

This PR adds no Base, Canvas, batch, Bridge, journal, state machine, write-policy, tool-schema, or runtime behavior change. No P2 branch is open. It does not publish a generic `operation_*` surface.

## P1 public surface

- `obsidian_frontmatter_patch_plan`
- `obsidian_frontmatter_patch_apply`
- `obsidian_frontmatter_patch_status`
- `obsidian_frontmatter_patch_recover`

P1 remains a source-preserving domain compiler projected onto the released P0 journal, leases, attempt fencing, Atomic Write Bridge CAS, receipts, status, and exact-plan recovery.

## Local release gates completed

- `npm run test:docs`
- `npm run test:governed-frontmatter`
- `npm run test:package`
- `npm run audit:production` — zero vulnerabilities
- `npm run test:runtime`
- `npm run test:operation-runtime`
- `npm run build:bridges`
- `npm run check:bases-bridge`
- `npm run check:operon`
- `git diff --check`

The normal PR matrix and Codex Review must pass on the exact release commit before merge. After merge, tag and publish `v2.7.0` only from the resulting `main` authority.