### PR TITLE
chore: prepare Optimike Obsidian MCP v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [2.8.0] - 2026-08-14
+## [2.8.0] - 2026-08-15
 
 ### Added
 
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Named formula set/delete preserves every byte outside authorized source
   ranges and fails closed on ambiguous YAML, aliases, tags, merge keys,
   duplicate/case-colliding names, mixed line endings and final-formula delete.
+- Parsed YAML node ranges fence formula ownership, including block-scalar
+  content that resembles comments or blank trivia. Governed state-changing
+  HTTP calls use mutation backpressure by default.
 - The live pilot proved no-write planning, apply/status, replay, stale-plan
   conflict and exact final SHA restoration in the dedicated Operon Bridge test
   vault.

--- a/docs/adr/ADR-Governed-Base-Formula-P2.md
+++ b/docs/adr/ADR-Governed-Base-Formula-P2.md
@@ -2,10 +2,10 @@
 
 ## Status
 
-Accepted and implemented as the `2.8.0` release candidate. Compiler, typed
-Bridge CAS, durable runtime, stdio MCP, documentation and pilot-vault canary
-gates pass. Merge, exact-head external review, post-merge CI and publication
-remain repository-authority decisions.
+Accepted, implemented and released in `2.8.0`. Compiler, typed Bridge CAS,
+durable runtime, stdio/HTTP MCP, documentation and pilot-vault canary gates
+passed. PR #53 merged at `cd43c53f`; its exact-head external review and the
+post-merge Windows/Linux Runtime workflow passed before publication.
 
 ## Authority and fixture
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -3,15 +3,15 @@
 ADRs record decisions and their boundaries. Operational commands belong in
 setup or operations guides, not in this index.
 
-| ADR                                                                                                                | Current status                                                                          | Relationship                                                             |
-| ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ |
-| [External document roots](ADR-External-Document-Roots.md)                                                          | Accepted and implemented; handoff and local move contracts later amended                | Base authorization, confinement and read/handoff contract                |
-| [Governed HTTP delivery](ADR-HTTP-External-Artifact-Delivery.md)                                                   | Accepted and implemented on `main` for authenticated loopback; remote remains pilot     | Adds `http_ticket`; HTTP mutation remains denied                         |
-| [External reference integrity](ADR-External-Reference-Integrity.md) / [FR](ADR-External-Reference-Integrity.fr.md) | Accepted and implemented for a local stdio pilot                                        | Same-root file move, exact ÉLYSIA reference repair, journal and rollback |
-| [Operon Bridge](ADR-Operon-Bridge.md)                                                                              | Accepted for bounded pilot                                                              | Versioned task-domain bridge and guarded mutation contract               |
-| [Common governed operation runtime](ADR-Common-Operation-Runtime.md)                                               | Accepted and released in 2.6.0; public atomic-note projection and live canary complete | Shared plan, apply, status, receipt and exact-plan recovery vocabulary   |
-| [P1 governed frontmatter projection](ADR-Governed-Frontmatter-P1.md)                                               | Accepted, implemented and released in 2.7.0                                             | Source-preserving domain compiler projected over the released P0 runtime |
-| [P2 governed Base formula operation](ADR-Governed-Base-Formula-P2.md)                                              | Accepted and implemented as a 2.8.0 release candidate; live pilot passed                | Second typed backend, source-preserving formula intent and legacy migration |
+| ADR                                                                                                                | Current status                                                                         | Relationship                                                                |
+| ------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| [External document roots](ADR-External-Document-Roots.md)                                                          | Accepted and implemented; handoff and local move contracts later amended               | Base authorization, confinement and read/handoff contract                   |
+| [Governed HTTP delivery](ADR-HTTP-External-Artifact-Delivery.md)                                                   | Accepted and implemented on `main` for authenticated loopback; remote remains pilot    | Adds `http_ticket`; HTTP mutation remains denied                            |
+| [External reference integrity](ADR-External-Reference-Integrity.md) / [FR](ADR-External-Reference-Integrity.fr.md) | Accepted and implemented for a local stdio pilot                                       | Same-root file move, exact ÉLYSIA reference repair, journal and rollback    |
+| [Operon Bridge](ADR-Operon-Bridge.md)                                                                              | Accepted for bounded pilot                                                             | Versioned task-domain bridge and guarded mutation contract                  |
+| [Common governed operation runtime](ADR-Common-Operation-Runtime.md)                                               | Accepted and released in 2.6.0; public atomic-note projection and live canary complete | Shared plan, apply, status, receipt and exact-plan recovery vocabulary      |
+| [P1 governed frontmatter projection](ADR-Governed-Frontmatter-P1.md)                                               | Accepted, implemented and released in 2.7.0                                            | Source-preserving domain compiler projected over the released P0 runtime    |
+| [P2 governed Base formula operation](ADR-Governed-Base-Formula-P2.md)                                              | Accepted, implemented and released in 2.8.0; live pilot passed                         | Second typed backend, source-preserving formula intent and legacy migration |
 
 ## Status vocabulary
 
@@ -30,3 +30,7 @@ mutation. The P1 ADR is accepted and implemented after its
 source-preservation proof, projected concurrency tests, Linux/Windows CI,
 exact-head Codex Review, live Obsidian canary, merge, and post-merge `main`
 workflow all passed.
+The P2 ADR is accepted and implemented after its parsed-node
+source-preservation proof, second typed Bridge CAS, HTTP mutation backpressure,
+Linux/Windows CI, exact-head Codex Review, live Base canary, merge, and
+post-merge `main` workflow all passed. It is released in `2.8.0`.

--- a/scripts/test-doc-contract.mjs
+++ b/scripts/test-doc-contract.mjs
@@ -107,7 +107,7 @@ const packageJson = JSON.parse(await text("package.json"));
 assert.equal(
   packageJson.version,
   "2.8.0",
-  "release-candidate package metadata must match the bounded 2.8.0 P2 authority",
+  "released package metadata must match the bounded 2.8.0 P2 authority",
 );
 assert.equal(packageJson.scripts["start:http"], "node scripts/run-http.mjs");
 assert.equal(packageJson.scripts["start:daemon"], "node scripts/run-http.mjs");

--- a/scripts/test-governed-base-doc-contract.mjs
+++ b/scripts/test-governed-base-doc-contract.mjs
@@ -12,6 +12,11 @@ const files = [
   "plugins/obsidian-bases-bridge/README.md",
 ].map((path) => [path, readFileSync(path, "utf8")]);
 const joined = files.map(([path, content]) => `${path}\n${content}`).join("\n");
+const releaseAdr = readFileSync(
+  "docs/adr/ADR-Governed-Base-Formula-P2.md",
+  "utf8",
+);
+const changelog = readFileSync("CHANGELOG.md", "utf8");
 
 for (const tool of [
   "bases_formula_patch_plan",
@@ -54,6 +59,13 @@ assert.doesNotMatch(
   joined,
   /generic public operation API is (?:available|exposed)/iu,
   "P2 must not claim a generic public operation surface",
+);
+assert.match(releaseAdr, /Accepted, implemented and released in `2\.8\.0`/u);
+assert.match(releaseAdr, /post-merge Windows\/Linux Runtime workflow passed/u);
+assert.match(changelog, /## \[2\.8\.0\] - 2026-08-15/u);
+assert.match(
+  changelog,
+  /Governed state-changing\s+HTTP calls use mutation backpressure/u,
 );
 
 console.log(


### PR DESCRIPTION
## Release authority

P2 merged through #53 and is canonical on `main` at merge commit `cd43c53f237a3ecf9f4a348d0706fe4bf79679b9`. The exact-head Codex Review, dedicated Operon Bridge pilot-vault canary with exact SHA restoration, and post-merge Runtime workflow on Linux and Windows are green.

This PR is intentionally limited to publishing P2 as `v2.8.0`:

- date the existing `2.8.0` changelog entry on the actual release day;
- mark the P2 ADR accepted, implemented, merged and post-merge validated;
- record the parsed-node ownership and governed HTTP mutation-backpressure hardening added during exact-head review;
- update documentation contracts so candidate/released status cannot drift.

## Explicit exclusions

This PR adds no Base, Canvas, batch, Bridge, journal, state-machine, write-policy, tool-schema, or runtime behavior change. It does not publish a generic `operation_*` surface. The legacy whole-file Base writer remains disabled by default.

## P2 public surface

- `bases_formula_patch_plan`
- `bases_formula_patch_apply`
- `bases_formula_patch_status`
- `bases_formula_patch_recover`

## Gates completed before opening

- post-merge Runtime on `main`: 13/13 jobs green on `cd43c53f`
- `npm run test:docs`
- `npm run test:governed-base`
- `npm run test:package`
- `npm run test:runtime`
- `npm run test:operation-runtime`
- `npm run build:bridges`
- `npm run check:operon`
- production audit: zero vulnerabilities
- `git diff --check`
- live canary on exact release commit `69efdf5`: restored `Canary/PROJETS-P2.base` to SHA-256 `00985cc85da6d44b11535790dd2a5c4a7a03dee59aaf39fccc20d83e619e29d9`; private recovery and journal artifacts removed

The normal PR matrix and Codex Review must pass on the exact release commit before merge. After merge, tag and publish `v2.8.0` only from the resulting `main` authority.