### PR TITLE
fix: align live canary logs with runtime boundary

### DIFF
--- a/scripts/smoke-atomic-note-mcp-live.mjs
+++ b/scripts/smoke-atomic-note-mcp-live.mjs
@@ -2,7 +2,13 @@
 
 import assert from "node:assert/strict";
 import { createHash, randomUUID } from "node:crypto";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -40,10 +46,19 @@ const tempRoot = mkdtempSync(
   path.join(tempParent, "optimike-atomic-note-mcp-live-"),
 );
 const journalPath = path.join(tempRoot, "note-replace.sqlite");
-const logsPath = path.join(tempRoot, "logs");
+// Runtime logging is intentionally constrained to the project boundary. Keep
+// the private backup and journal in the OS temporary directory, while staging
+// transient logs under the gitignored logs/ tree. If manual recovery is ever
+// required, move those logs beside the private recovery artifacts.
+const transientLogsParent = path.join(
+  process.cwd(),
+  "logs",
+  "atomic-note-live",
+);
+mkdirSync(transientLogsParent, { recursive: true });
+const logsPath = mkdtempSync(path.join(transientLogsParent, "run-"));
 const backupPath = path.join(tempRoot, "original-content.md");
 const backupMetadataPath = path.join(tempRoot, "original-content.json");
-mkdirSync(logsPath, { recursive: true });
 console.error(`Canary recovery directory: ${tempRoot}`);
 
 const transport = new StdioClientTransport({
@@ -177,6 +192,7 @@ let restored = false;
 let runId;
 let evidenceFile;
 let backupWritten = false;
+let retainedLogsPath;
 try {
   await client.connect(transport);
   const { tools } = await client.listTools();
@@ -316,14 +332,22 @@ try {
   }
   await client.close().catch(() => undefined);
   if (restored) {
+    rmSync(logsPath, { recursive: true, force: true });
     rmSync(tempRoot, { recursive: true, force: true });
     if (evidenceFile)
       console.error(`Canary evidence written to ${evidenceFile}`);
   } else if (backupWritten) {
+    retainedLogsPath = path.join(tempRoot, "runtime-logs");
+    try {
+      renameSync(logsPath, retainedLogsPath);
+    } catch {
+      retainedLogsPath = logsPath;
+    }
     console.error(
-      `Canary recovery evidence retained at ${tempRoot}; restore only the explicit canary note from ${backupPath}.`,
+      `Canary recovery evidence retained at ${tempRoot}; runtime logs retained at ${retainedLogsPath}; restore only the explicit canary note from ${backupPath}.`,
     );
   } else {
+    rmSync(logsPath, { recursive: true, force: true });
     rmSync(tempRoot, { recursive: true, force: true });
     console.error(
       "Canary failed before the first mutation; no note recovery is required.",

--- a/scripts/smoke-atomic-note-mcp-live.mjs
+++ b/scripts/smoke-atomic-note-mcp-live.mjs
@@ -60,6 +60,7 @@ const logsPath = mkdtempSync(path.join(transientLogsParent, "run-"));
 const backupPath = path.join(tempRoot, "original-content.md");
 const backupMetadataPath = path.join(tempRoot, "original-content.json");
 console.error(`Canary recovery directory: ${tempRoot}`);
+console.error(`Canary transient runtime logs: ${logsPath}`);
 
 const transport = new StdioClientTransport({
   command: process.execPath,
@@ -217,6 +218,7 @@ try {
         createdAt: new Date().toISOString(),
         sha256: sha256(originalContent),
         backupPath,
+        runtimeLogsPath: logsPath,
         recoveryInstruction:
           "If the canary process terminates before restoration, restore original-content.md only to the explicit canary note.",
       },

--- a/scripts/smoke-atomic-note-mcp-live.mjs
+++ b/scripts/smoke-atomic-note-mcp-live.mjs
@@ -194,6 +194,7 @@ let runId;
 let evidenceFile;
 let backupWritten = false;
 let retainedLogsPath;
+let backupMetadata;
 try {
   await client.connect(transport);
   const { tools } = await client.listTools();
@@ -210,21 +211,18 @@ try {
   originalContent = await readNote();
   runId = randomUUID();
   writeFileSync(backupPath, originalContent, { encoding: "utf8", mode: 0o600 });
+  backupMetadata = {
+    canaryPath,
+    createdAt: new Date().toISOString(),
+    sha256: sha256(originalContent),
+    backupPath,
+    runtimeLogsPath: logsPath,
+    recoveryInstruction:
+      "If the canary process terminates before restoration, restore original-content.md only to the explicit canary note.",
+  };
   writeFileSync(
     backupMetadataPath,
-    `${JSON.stringify(
-      {
-        canaryPath,
-        createdAt: new Date().toISOString(),
-        sha256: sha256(originalContent),
-        backupPath,
-        runtimeLogsPath: logsPath,
-        recoveryInstruction:
-          "If the canary process terminates before restoration, restore original-content.md only to the explicit canary note.",
-      },
-      null,
-      2,
-    )}\n`,
+    `${JSON.stringify(backupMetadata, null, 2)}\n`,
     { encoding: "utf8", mode: 0o600 },
   );
   backupWritten = true;
@@ -345,6 +343,12 @@ try {
     } catch {
       retainedLogsPath = logsPath;
     }
+    backupMetadata.runtimeLogsPath = retainedLogsPath;
+    writeFileSync(
+      backupMetadataPath,
+      `${JSON.stringify(backupMetadata, null, 2)}\n`,
+      { encoding: "utf8", mode: 0o600 },
+    );
     console.error(
       `Canary recovery evidence retained at ${tempRoot}; runtime logs retained at ${retainedLogsPath}; restore only the explicit canary note from ${backupPath}.`,
     );

--- a/scripts/test-governed-note-doc-contract.mjs
+++ b/scripts/test-governed-note-doc-contract.mjs
@@ -172,6 +172,13 @@ assert.match(
   /transientLogsParent[\s\S]*process\.cwd\(\)[\s\S]*["']logs["'][\s\S]*mkdtempSync/,
 );
 assert.match(liveCanary, /renameSync\(logsPath, retainedLogsPath\)/);
+assert.match(liveCanary, /Canary transient runtime logs:/);
+assert.match(liveCanary, /runtimeLogsPath: logsPath/);
+assert.ok(
+  liveCanary.indexOf("Canary transient runtime logs:") <
+    liveCanary.indexOf("new StdioClientTransport"),
+  "the transient log path must be observable before the canary connects",
+);
 assert.doesNotMatch(
   liveCanary,
   /const logsPath = path\.join\(tempRoot, ["']logs["']\)/,

--- a/scripts/test-governed-note-doc-contract.mjs
+++ b/scripts/test-governed-note-doc-contract.mjs
@@ -174,6 +174,10 @@ assert.match(
 assert.match(liveCanary, /renameSync\(logsPath, retainedLogsPath\)/);
 assert.match(liveCanary, /Canary transient runtime logs:/);
 assert.match(liveCanary, /runtimeLogsPath: logsPath/);
+assert.match(
+  liveCanary,
+  /backupMetadata\.runtimeLogsPath = retainedLogsPath[\s\S]*writeFileSync\([\s\S]*backupMetadataPath/,
+);
 assert.ok(
   liveCanary.indexOf("Canary transient runtime logs:") <
     liveCanary.indexOf("new StdioClientTransport"),

--- a/scripts/test-governed-note-doc-contract.mjs
+++ b/scripts/test-governed-note-doc-contract.mjs
@@ -167,5 +167,14 @@ assert.match(contractFr, /conflit CAS suivant reste `outcome_unknown`/i);
 await access("scripts/test-governed-note-replace-mcp.mjs");
 await access("scripts/test-governed-note-replace-http.mjs");
 await access("scripts/smoke-atomic-note-mcp-live.mjs");
+assert.match(
+  liveCanary,
+  /transientLogsParent[\s\S]*process\.cwd\(\)[\s\S]*["']logs["'][\s\S]*mkdtempSync/,
+);
+assert.match(liveCanary, /renameSync\(logsPath, retainedLogsPath\)/);
+assert.doesNotMatch(
+  liveCanary,
+  /const logsPath = path\.join\(tempRoot, ["']logs["']\)/,
+);
 
 console.log("PASS: governed atomic note replacement documentation is coherent");


### PR DESCRIPTION
## What changed

- stage Atomic Note live-canary runtime logs inside the repository's gitignored `logs/` boundary;
- keep the private backup and journal in the OS temporary directory;
- delete transient logs after a restored run, or move them beside retained recovery evidence when manual recovery is required;
- add a contract test that prevents the invalid OS-temp `LOGS_DIR` topology from returning.

## Why

The v2.8.0 Atomic Note live canary created `LOGS_DIR` under the OS temporary directory. The runtime deliberately rejects log directories outside the project boundary, so the canary stopped before its first mutation. The security boundary was correct; the harness violated it.

## Validation

- `node scripts/test-governed-note-doc-contract.mjs`
- `npm run test:docs`
- `npm run test:runtime`
- `npm run test:package`
- live Atomic Note canary in the dedicated Operon Bridge pilot vault: PASS, conflict/replay/restore verified
- live governed frontmatter canary in the same vault: PASS, restored
- live governed Base formula canary in the same vault: PASS, restored
