### PR TITLE
chore: release Optimike Obsidian MCP v2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.1] - 2026-08-15
+
+### Fixed
+
+- The Atomic Note live canary now respects the runtime log-directory boundary,
+  announces its transient log path before connecting, and keeps retained
+  recovery metadata aligned if those logs are moved after a failed restore.
+
 ## [2.8.0] - 2026-08-15
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optimike-obsidian-mcp",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optimike-obsidian-mcp",
-      "version": "2.8.0",
+      "version": "2.8.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optimike-obsidian-mcp",
-  "version": "2.8.0",
+  "version": "2.8.1",
   "description": "Unified Obsidian MCP server with shared local cache, Operon and Tasks tools, Bases support, semantic search, runtime observability, and degraded read mode for durable agent workflows.",
   "main": "dist/index.js",
   "files": [

--- a/scripts/smoke-governed-base-formula-live.mjs
+++ b/scripts/smoke-governed-base-formula-live.mjs
@@ -286,7 +286,7 @@ try {
         originalSha256: original.sha256,
         finalSha256: final.sha256,
         bridgeVersion: status.plugin.version,
-        mcpVersion: process.env.MCP_SERVER_VERSION ?? "2.8.0",
+        mcpVersion: process.env.MCP_SERVER_VERSION ?? "2.8.1",
         checks: [
           "typed_base_binding",
           "plan_without_write",

--- a/scripts/test-doc-contract.mjs
+++ b/scripts/test-doc-contract.mjs
@@ -106,8 +106,8 @@ assert.match(matrixFr, /\| Admin filesystem\s+\| Non\s+\| Non/);
 const packageJson = JSON.parse(await text("package.json"));
 assert.equal(
   packageJson.version,
-  "2.8.0",
-  "released package metadata must match the bounded 2.8.0 P2 authority",
+  "2.8.1",
+  "released package metadata must match the 2.8.1 canary-boundary patch",
 );
 assert.equal(packageJson.scripts["start:http"], "node scripts/run-http.mjs");
 assert.equal(packageJson.scripts["start:daemon"], "node scripts/run-http.mjs");


### PR DESCRIPTION
## Release

Prepare Optimike Obsidian MCP `2.8.1` as a patch release over the already released P0/P1/P2 governed-operation stack.

## Included fix

- align the Atomic Note live-canary log directory with the runtime boundary;
- announce and persist the transient log location before the canary connects;
- keep recovery metadata synchronized if logs are retained after a failed restore.

## Exact release validation

- package/docs/build/audit checks: PASS;
- full PR #55 CI on Windows and Linux: PASS;
- Codex Review on the merged fix: no remaining issue;
- live Atomic Note canary in the dedicated Operon Bridge pilot vault: PASS and exact restoration;
- live governed frontmatter canary: PASS and exact restoration;
- live governed Base formula canary: PASS and exact restoration.
