### PR TITLE
docs: align Operon baseline with 3.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,20 +126,20 @@ set report `certified`; unknown non-denied versions exposing the accessor report
 `index.ready`, and the exact capability. Missing capabilities fail closed only
 for affected tools; known regressions remain denied.
 Operon `3.2.0` remains the earlier certified pilot baseline. Modified-time frontmatter settlement and
-multi-window consent were merged upstream before these releases. Saved-filter execution is available
+multi-window consent were merged upstream before the current release. Saved-filter execution is available
 through the additive task-workflow Developer API after an exact grant, but the
 official API does not expose the saved-filter catalog: callers must supply an
 exact `filterSetId` obtained from Operon's UI/configuration or an operator
 workflow. Adoption remains unavailable on the official Developer API. Operon
-`3.3.0` passed the complete live pilot and remains admitted as
-`compatible-provisional` by the contract-first policy rather than a product-version allowlist. Operon still omits the declarative Settings renderer for Developer API grant
-controls; the fix is tracked in [#145](https://github.com/hasanyilmaz/operon/issues/145)
-and [#146](https://github.com/hasanyilmaz/operon/pull/146).
-No MCP route falls back to Markdown or private APIs. Implicit File Task renames
-remain tracked in [#139](https://github.com/hasanyilmaz/operon/pull/139), and the
-unscoped transition edge case remains tracked in
-[#99](https://github.com/hasanyilmaz/operon/issues/99) and
-[#101](https://github.com/hasanyilmaz/operon/pull/101).
+`3.3.2` with Operon CLI `1.1.2` is the current complete live-pilot baseline and
+remains admitted as `compatible-provisional` by the contract-first policy
+rather than a product-version allowlist. Operon `3.3.2` restores the Developer
+API Settings controls, rejects implicit File Task renames, and fixes unscoped
+Project Serial transition settlement. The production acceptance proved a
+non-terminal transition and exact restoration with 30 tasks, no pending
+recovery, and `P0/P1/P2 = 0/0/0`. Adoption is the only tracked official API gap
+([Operon #140](https://github.com/hasanyilmaz/operon/issues/140)). No MCP route
+falls back to Markdown or private APIs.
 
 ## External document roots
 

--- a/docs/operon-cli-audit.fr.md
+++ b/docs/operon-cli-audit.fr.md
@@ -2,21 +2,21 @@
 
 English version: [operon-cli-audit.md](operon-cli-audit.md)
 
-Date : 2026-08-13
+Date : 2026-08-17
 
-Référence : Operon officiel `3.3.0` admis provisoirement par contrat, Operon
-`3.2.1` certifié, Operon CLI `1.1.0`, Developer API V1 et
+Référence : Operon officiel `3.3.2` admis provisoirement par contrat, Operon
+`3.2.1` certifié, Operon CLI `1.1.2`, Developer API V1 et
 `cli-manifest-v1.json`.
 
 Les observations CLI initiales du 1er août 2026 utilisaient Operon `3.0.1` et
 restent des preuves historiques. L’adaptateur MCP certifie `3.2.1` et admet
-`3.3.0` provisoirement après négociation du contrat. Le pilote live complet
-`3.3.0` est vert ; le renderer manquant est suivi dans
-[#145](https://github.com/hasanyilmaz/operon/issues/145) et
-[#146](https://github.com/hasanyilmaz/operon/pull/146). Les correctifs #135 et #137 sont déjà fusionnés. La sécurité
-de renommage File Task reste suivie dans #139 et le cas de transition incertain
-dans #99/#101. Le MCP échoue fermé et ne bascule jamais vers Markdown ou une API
-privée.
+`3.3.2` provisoirement après négociation du contrat. Le pilote live complet
+`3.3.2` avec CLI `1.1.2` est vert : les contrôles de grant dans les réglages,
+le refus des renommages implicites de File Tasks et le règlement des
+transitions sans portée Project Serial sont corrigés upstream. L’adoption reste
+indisponible dans l’API développeur officielle et est suivie dans
+[#140](https://github.com/hasanyilmaz/operon/issues/140). Le MCP échoue fermé et
+ne bascule jamais vers Markdown ou une API privée.
 
 ## Décision
 
@@ -87,9 +87,11 @@ transition terminale, restauration exacte, ajout/changement de portée/retrait d
 récurrence, redémarrage stable, exécution d’un filtre avec pagination opaque,
 source live, 25 tâches après nettoyage, aucun résidu et `P0/P1/P2 = 0/0/0`.
 
-Le chemin #99/#101 peut encore produire un résultat borné `outcome-unknown`.
-La limite File Task reste suivie dans #139. Le Bridge expose l’incertitude et ne
-rejoue pas la mutation.
+L’acceptation live `3.3.2` a aussi prouvé une transition non terminale de
+Planifié vers En cours, puis sa restauration exacte vers Planifié via l’API
+officielle. Les deux applies ont rendu un résultat terminal ; la fixture a été
+supprimée par la CLI opérateur après sauvegarde. Le coffre est revenu à 30
+tâches, sans recovery, avec `P0/P1/P2 = 0/0/0`.
 
 Les autres écritures avancées restent hors MCP jusqu’à disposer chacune d’un
 contrat preview/apply, révision, postflight, récupération et confirmation
@@ -104,8 +106,9 @@ setup, profil, doctor offline, `health`, `task.get`, `tasks.query` et
 Sur cette version, plusieurs handlers pourtant annoncés par `health` échouaient
 avant leur exécution avec `obsidian-cli-exit-failed` ou
 `persistent-write-failed`. Cette preuve reste historique et ne doit pas être
-présentée comme l’état de la CLI `1.1.0`, dont la version installable a seulement
-été vérifiée dans cette mise à jour.
+présentée comme l’état de la CLI `1.1.2`. Son bootstrap/health Windows et la
+suppression opérateur exacte ont été validés pendant l’acceptation `3.3.2`, sans
+requalifier pour autant chaque observation historique de la `1.0.0`.
 
 La conclusion d’architecture ne change pas : la CLI est la surface opérateur
 large. Le MCP/Bridge reste le contrat agentique indépendant, borné et vérifiable.

--- a/docs/operon-cli-audit.md
+++ b/docs/operon-cli-audit.md
@@ -2,18 +2,16 @@
 
 French version: [operon-cli-audit.fr.md](operon-cli-audit.fr.md)
 
-Date: 2026-08-13
-Reference: official Operon `3.3.0` provisionally admitted by contract, certified Operon `3.2.1`, Operon CLI `1.1.0`, Developer API V1 and `cli-manifest-v1.json`.
+Date: 2026-08-17
+Reference: official Operon `3.3.2` provisionally admitted by contract, certified Operon `3.2.1`, Operon CLI `1.1.2`, Developer API V1 and `cli-manifest-v1.json`.
 
 The original 2026-08-01 CLI observations were made against Operon `3.0.1` and
 remain historical evidence. The current MCP adapter certifies `3.2.1` and
-admits `3.3.0` provisionally after contract negotiation. The complete `3.3.0`
-live acceptance run is green; the missing settings renderer is tracked in
-[#145](https://github.com/hasanyilmaz/operon/issues/145) and
-[#146](https://github.com/hasanyilmaz/operon/pull/146). Fixes #135 and #137 are already merged. File Task rename safety
-remains tracked in [#139](https://github.com/hasanyilmaz/operon/pull/139), and
-uncertain transition settlement in [#99](https://github.com/hasanyilmaz/operon/issues/99)
-and [#101](https://github.com/hasanyilmaz/operon/pull/101). The MCP remains
+admits `3.3.2` provisionally after contract negotiation. The complete `3.3.2`
+live acceptance run is green with CLI `1.1.2`: Settings grant controls, File
+Task rename refusal, and unscoped transition settlement are fixed upstream.
+Adoption remains unavailable through the official Developer API and is tracked
+in [#140](https://github.com/hasanyilmaz/operon/issues/140). The MCP remains
 fail-closed and does not fall back to Markdown or private APIs.
 
 ## Decision
@@ -90,11 +88,11 @@ recurrence add/scope-change/clear, restart/recovery stability, saved-filter
 execution with opaque pagination, live source, 25 tasks after fixture cleanup,
 no residual relationship/recurrence state, and `P0/P1/P2 = 0/0/0`.
 
-The remaining official transition edge may still return the bounded `outcome-unknown` result
-tracked by [Operon #99](https://github.com/hasanyilmaz/operon/issues/99) and
-[#101](https://github.com/hasanyilmaz/operon/pull/101). When the runtime cannot
-prove its result, the Bridge reports the uncertainty and does not retry or fall
-back to Markdown/private APIs. This remains a capability gate, not a hidden bypass.
+Operon `3.3.2` live acceptance additionally proved a non-terminal transition
+from planned to in-progress and exact restoration to planned through the
+official Developer API. Both applies returned terminal results; the fixture was
+removed through the operator CLI after backup. The vault returned to 30 tasks,
+no recovery remained, and validation returned `P0/P1/P2 = 0/0/0`.
 
 The read audit, implementation and live acceptance of the two useful advanced
 writes are complete. Other advanced writes remain outside MCP until each has a
@@ -122,7 +120,8 @@ datetime metadata, omitting those fields rather than failing the whole query.
 
 Conclusion: the CLI is a broader operator surface, but it was not a dependable
 transport layer for MCP on that historical Windows installation. The current
-package version is `1.1.0`, but this update does not claim every former handler
-failure was requalified through the CLI. Keep the MCP/Bridge contract independent
-and bounded; keep the CLI for operator diagnostics, native acceptance and
-recovery investigation. No real mutation was applied during the historical audit.
+paired package is `1.1.2`; its Windows bootstrap/health path and exact operator
+deletion were validated during the `3.3.2` acceptance. This does not reclassify
+every historical `1.0.0` handler observation. Keep the MCP/Bridge contract
+independent and bounded; keep the CLI for operator diagnostics, native
+acceptance and recovery investigation.

--- a/docs/operon-decision-report.md
+++ b/docs/operon-decision-report.md
@@ -1,24 +1,21 @@
 # Operon integration decision report
 
-## Current status — 2026-08-13
+## Current status — 2026-08-17
 
 Optimike Obsidian MCP Bridge `0.7.0` certifies Operon through `3.2.1` and admits
-the non-denied Operon `3.3.0` version with its Developer API V1 accessor as
+the non-denied Operon `3.3.2` version with its Developer API V1 accessor as
 `compatible-provisional`. Developer API status, schema, index readiness, and
 capabilities remain separate live-use gates. The canonical server registers
 twenty-three governed Operon tools. Kairélys remains disabled and retained only
 for bounded rollback compatibility.
 
-The complete local acceptance run is green on Operon `3.3.0` with Bridge
-`0.7.0`: persisted grants, governed apply/replay/conflict/postflight, thirty
-tasks, zero validation violations and zero recovery. The Settings fix remains
-tracked in upstream #145/#146. Remaining fail-closed
-limitations are tracked in:
-
-- transition settlement: [#99](https://github.com/hasanyilmaz/operon/issues/99)
-  and [#101](https://github.com/hasanyilmaz/operon/pull/101);
-- implicit File Task description/rename behavior:
-  [#139](https://github.com/hasanyilmaz/operon/pull/139).
+The complete local acceptance run is green on Operon `3.3.2`, Operon CLI
+`1.1.2`, and Bridge `0.7.0`: persisted grants, governed
+apply/replay/conflict/postflight, saved-filter execution, a non-terminal
+transition and exact restoration, thirty tasks, zero validation violations and
+zero recovery. Settings grant controls, implicit File Task rename refusal, and
+unscoped transition settlement are fixed upstream. Adoption remains the only
+tracked official API gap ([#140](https://github.com/hasanyilmaz/operon/issues/140)).
 
 No MCP or Bridge route falls back to raw Markdown, private Operon methods or UI
 commands when a capability is missing or an outcome is uncertain.
@@ -81,11 +78,12 @@ properties, hierarchy/dependencies, blocked/released transitions, conversion,
 idempotency, stale-revision conflict, reindex/restart, stale cache and duplicate
 ID refusal. It is not presented as Developer API V1 evidence.
 
-## Operon 3.3.0 acceptance evidence
+## Operon 3.3.2 acceptance evidence
 
-The 2026-08-13 production-shaped ÉLYSIA run used official Operon `3.3.0`,
-Bridge `0.7.0`, both mutation opt-ins, and Developer API V1. A pre-cutover
-backup and rollback path were verified before installation.
+The production-shaped ÉLYSIA baseline was upgraded through official Operon
+`3.3.2` with Operon CLI `1.1.2`, Bridge `0.7.0`, both mutation opt-ins, and
+Developer API V1. Pre-cutover backups and paired rollback paths were verified
+before installation.
 
 Observed results:
 
@@ -98,14 +96,18 @@ Observed results:
 - smoke task `1dbefy1` passed sealed preview/apply, idempotent replay,
   stale-revision conflict, semantic restoration, and postflight re-read;
 - final pending recovery inventory was empty after restoration.
+- a temporary task passed `Planifié → En cours → Planifié` with two terminal
+  applies and fresh host consent; it was then removed through the operator CLI
+  after backup;
+- the final live snapshot returned to 30 tasks and `P0/P1/P2 = 0/0/0`.
 
 The lost-response path was not forced against the live vault. Its exact-plan
 reconciliation remains fixture evidence, not part of this live acceptance
 claim.
 
 The 2026-08-01 Operon `3.0.1` cutover and CLI `1.0.0` Windows observations also
-remain historical. The current runtime target is Operon `3.3.0` with Bridge
-`0.7.0`; CLI `1.1.0` remains the documented operator-reference target.
+remain historical. The current runtime target is Operon `3.3.2` with Bridge
+`0.7.0`; CLI `1.1.2` is the paired operator-reference target.
 
 ## Deliberately excluded or unavailable
 
@@ -124,6 +126,5 @@ Keep the current Operon integration active. Use MCP/Bridge for governed agent
 workflows and CLI for broad operator work. Keep Kairélys disabled but available
 for rollback until a separate non-dependency proof authorizes removal.
 
-The code and local acceptance work are complete. Remaining work is reviewing
-and publishing the prepared MCP and Operon settings patches under separate
-authorization, plus the separate real Sync/non-dependency decision.
+The code, publication, and local acceptance work are complete. The separate
+real Sync/non-dependency decision remains outside this integration scope.

--- a/docs/operon-local-validation.md
+++ b/docs/operon-local-validation.md
@@ -7,19 +7,19 @@ This recipe is the Desktop proof. Run destructive fixtures only in a disposable 
 - Node.js `>=22.7.5`
 - Obsidian Desktop
 - Local REST API enabled
-- Operon `3.3.0` for the completed contract-first live pilot; `3.2.1` remains in the explicit certified set, and `2.4.0` / `2.5.0` remain legacy-read fixtures
+- Operon `3.3.2` with Operon CLI `1.1.2` for the completed contract-first live pilot; `3.2.1` remains in the explicit certified set, and `2.4.0` / `2.5.0` remain legacy-read fixtures
 - Optimike Operon Bridge built from this branch
 - Optimike Obsidian MCP built from this branch
 - a backup or disposable vault
 
-The adapter certifies through Operon `3.2.1` and gives `3.3.0` provisional
-version/accessor admission. The `3.3.0` live acceptance run separately proves
+The adapter certifies through Operon `3.2.1` and gives `3.3.2` provisional
+version/accessor admission. The `3.3.2` live acceptance run separately proves
 the Developer API, schema, index, capability, and readiness gates and is
 complete and green; keeping its runtime state provisional preserves the
-contract-first policy. The missing grant-control
-renderer is tracked in upstream #145/#146. Fixes #135 and #137 are already merged. File Task rename safety remains
-tracked by [#139](https://github.com/hasanyilmaz/operon/pull/139), and transition
-settlement by #99/#101. Unsupported or uncertain paths stay fail-closed; this
+contract-first policy. Settings grant controls, implicit File Task rename
+refusal, and unscoped transition settlement are fixed in `3.3.2`. Adoption
+remains unavailable through the official Developer API and is tracked in
+[#140](https://github.com/hasanyilmaz/operon/issues/140). Unsupported or uncertain paths stay fail-closed; this
 recipe never authorizes a Markdown/private-API fallback or a blind retry.
 
 ## 1. Automated checks
@@ -406,12 +406,12 @@ PASS:
 - Obsidian and MCP backend restart, no pending recovery, no residual relation or
   recurrence, and final `P0/P1/P2 = 0/0/0`.
 
-OPEN BOUNDARIES:
+BOUNDARIES AT THE TIME OF THIS 3.2.0 PILOT:
 
 - adoption is not exposed by the official Developer API;
 - saved-filter IDs must come from Operon's UI/configuration or an operator
   workflow because the official API does not list the catalog;
-- #99/#101 and #139 remain fail-closed paths;
+- #99/#101 and #139 were fail-closed paths; Operon `3.3.2` later fixed them;
 - no deletion tool, generic CLI passthrough, raw Markdown or private API exists
   in the MCP.
 
@@ -449,6 +449,39 @@ NOT RUN LIVE:
 The `compatible-provisional` label records version/accessor admission only.
 The successful Developer API status, schema, index, capability, and readiness
 checks above are the independent evidence that authorized this pilot.
+
+## 20. Official Operon 3.3.2 / CLI 1.1.2 paired acceptance — 2026-08-17
+
+Inputs:
+
+- official Operon `3.3.2` and Operon CLI `1.1.2`;
+- Optimike Operon Bridge `0.7.0` and the 23-tool MCP surface;
+- Local REST API, exact Developer API grants, and both mutation opt-ins;
+- paired pre-cutover backup and rollback to Operon `3.3.1` / CLI `1.1.1`.
+
+PASS:
+
+- Windows bootstrap progressed through `starting`, `cache-ready`, and `ready`;
+- the live source exposed 30 tasks, saved filter `fs_elysia_now`, and no pending
+  recovery;
+- a temporary task passed a sealed `Planifié → En cours` apply and exact
+  `En cours → Planifié` restoration with fresh host consent;
+- both transition applies returned terminal `applied` results with matching
+  postflight state;
+- the fixture was backed up, deleted through the official operator CLI, and
+  confirmed absent from the live index;
+- the final snapshot returned to 30 tasks, two historical Operon Pilot tasks,
+  zero recovery, and `P0/P1/P2 = 0/0/0`.
+
+CURRENT BOUNDARIES:
+
+- adoption remains unavailable through the official Developer API (#140);
+- saved-filter execution requires an exact known ID because catalog discovery
+  is not exposed;
+- delete, reminders, pin state, and timer control/session remain CLI operator
+  actions rather than MCP tools;
+- no generic CLI passthrough, raw Markdown mutation, or private API fallback is
+  permitted.
 
 ## Executed pilot result — 2026-07-21
 

--- a/docs/operon-rest-contract.md
+++ b/docs/operon-rest-contract.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-The Bridge projects the active Operon-compatible engine's live index through Obsidian Local REST API. Reads work with official Operon `2.4.0` and `2.5.0`, with certified official Operon `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, and `3.2.1`, and provisionally with non-denied `3.3.0` when its Developer API V1 accessor is present. Kairélys legacy support remains bounded to the documented allowlist. Developer API mutations use the official preview/apply/recovery surface; legacy Kairélys mutations use Public API v1. There is no raw Markdown or private-reflection fallback.
+The Bridge projects the active Operon-compatible engine's live index through Obsidian Local REST API. Reads work with official Operon `2.4.0` and `2.5.0`, with certified official Operon `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, and `3.2.1`, and provisionally with non-denied `3.3.2` when its Developer API V1 accessor is present. Kairélys legacy support remains bounded to the documented allowlist. Developer API mutations use the official preview/apply/recovery surface; legacy Kairélys mutations use Public API v1. There is no raw Markdown or private-reflection fallback.
 
 Prefix:
 
@@ -15,18 +15,18 @@ All routes inherit Local REST API authentication and TLS behavior.
 ## Compatibility and capabilities
 
 - Bridge contract: `1`
-- Certified compatibility through official Operon `3.2.1`; provisional contract admission and complete live read/write pilot: `3.3.0`
+- Certified compatibility through official Operon `3.2.1`; provisional contract admission and complete live read/write pilot: `3.3.2` with Operon CLI `1.1.2`
 - Official Operon legacy read allowlist: `2.4.0`, `2.5.0`
 - Official Operon Developer API V1 allowlist: `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, `3.2.1`
 - Kairélys read allowlist: `2.5.1`, `2.5.2`, `2.5.3`, `2.6.1`, `2.6.2`, `2.6.3`
 - Legacy mutation contract: Operon Public API `1`
 - Official Operon `2.5.0`: read-only
-- Official Operon `3.2.x`: typed create/update/transition/relationship/recurrence/convert/relocate through Developer API V1, plus saved-filter execution through the additive task-workflow API, when the exact grants are active. The grant state and capability advertisement are both reported in `/status`; an uncertain apply is returned as such and is never retried blindly.
+- Official Operon `3.x` with the negotiated V1 boundary: typed create/update/transition/relationship/recurrence/convert/relocate through Developer API V1, plus saved-filter execution through the additive task-workflow API, when the exact grants are active. The grant state and capability advertisement are both reported in `/status`; an uncertain apply is returned as such and is never retried blindly.
 - Kairélys `2.5.1` through `2.5.3` and `2.6.1` through `2.6.3` with Public API v1: read-write
 
 `GET /status` reports `bridge.mode` as `read-only` or `read-write` and exposes each capability independently. A future non-denied Operon version is admitted provisionally when its Developer API V1 accessor is present; Markdown similarity is irrelevant. Live use remains independently gated by successful negotiation, `developerApi`, top-level `ok`, `index.ready`, and the exact advertised capability.
 
-The adapter certifies official `3.2.1` and provisionally admits `3.3.0`; the complete `3.3.0` live acceptance run is green. The missing Settings renderer is tracked by [#145](https://github.com/hasanyilmaz/operon/issues/145) and [#146](https://github.com/hasanyilmaz/operon/pull/146). Modified-time settlement and multi-window consent fixes from #135 and #137 are already merged. File Task rename safety remains tracked by [#139](https://github.com/hasanyilmaz/operon/pull/139), and the transition investigation by [#99](https://github.com/hasanyilmaz/operon/issues/99) and [#101](https://github.com/hasanyilmaz/operon/pull/101). Those paths stay fail-closed. No Markdown or private-API fallback is introduced.
+The adapter certifies official `3.2.1` and provisionally admits `3.3.2`; the complete `3.3.2` live acceptance run is green with Bridge `0.7.0` and CLI `1.1.2`. The release restores the Settings grant controls, rejects implicit File Task renames, and fixes transition settlement without Project Serial scopes. The live acceptance applied and restored a non-terminal transition, returned to 30 tasks, left no pending recovery, and validated `P0/P1/P2 = 0/0/0`. Adoption remains unavailable through the official Developer API and is tracked in [#140](https://github.com/hasanyilmaz/operon/issues/140). No Markdown or private-API fallback is introduced.
 
 Readiness requires a compatible plugin, positive generation, healthy idle V8 index, zero dirty sources, and a task count matching diagnostics. A duplicate-ID conflict is reported separately and causes MCP snapshot refresh refusal.
 

--- a/plugins/obsidian-operon-bridge/README.md
+++ b/plugins/obsidian-operon-bridge/README.md
@@ -16,7 +16,7 @@ If both plugins are enabled, the Bridge refuses to choose an owner. Disable one 
 - Obsidian Desktop
 - Operon `2.4.0` or `2.5.0` for legacy reads
 - Operon exposing the negotiated Developer API V1 contract (`contractVersion: 1`, `runtimeApi: 1`)
-- certified Developer API releases: `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, and `3.2.1`; later compatible releases are admitted provisionally by contract rather than product-version allowlist
+- certified Developer API releases: `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, and `3.2.1`; Operon `3.3.2` is the current validated baseline and remains admitted provisionally by contract rather than product-version allowlist
 - Kairélys `2.5.1` through `2.5.3` (based on Operon `2.5.0`) and Kairélys `2.6.1` through `2.6.3`
   (based on Operon `2.6.0`) with Public API v1 for mutations
 - Obsidian Local REST API
@@ -27,18 +27,17 @@ Saved-filter execution requires an exact grant and exact `filterSetId`; the
 official API does not expose the saved-filter catalog. Adoption, unmanaged
 properties, and arbitrary `targetFolder` destinations remain unsupported and
 are rejected explicitly. The complete live pilot used the local 3.2.0 build.
-Operon `3.3.0` is admitted as `compatible-provisional` because the non-denied
-version exposes the Developer API V1 accessor. Its complete live pilot passed
-the separate developer-API, schema, index, capability, and readiness gates;
-Bridge `0.7.0` deliberately preserves the contract-first provisional path
-instead of making a product-version allowlist authoritative again.
-The Settings UI fix is tracked in upstream
-[#145](https://github.com/hasanyilmaz/operon/issues/145) and
-[#146](https://github.com/hasanyilmaz/operon/pull/146). Uncertain outcomes remain fail-closed;
-the Bridge never retries blindly or falls back to Markdown/private APIs. File
-Task rename safety remains tracked in [#139](https://github.com/hasanyilmaz/operon/pull/139),
-and the transition edge in [#99](https://github.com/hasanyilmaz/operon/issues/99)
-and [#101](https://github.com/hasanyilmaz/operon/pull/101).
+Operon `3.3.2` with Operon CLI `1.1.2` is admitted as
+`compatible-provisional` because the non-denied version exposes the Developer
+API V1 accessor. Its complete live pilot passed the separate Developer API,
+schema, index, capability, readiness, saved-filter, transition, restoration,
+and recovery gates with Bridge `0.7.0`. Operon `3.3.2` restores the Settings
+grant controls, rejects implicit File Task renames, and fixes the unscoped
+Project Serial transition edge. Adoption remains unavailable through the
+official Developer API and is tracked in
+[#140](https://github.com/hasanyilmaz/operon/issues/140). Uncertain outcomes
+remain fail-closed; the Bridge never retries blindly or falls back to
+Markdown/private APIs.
 
 Compatibility is reported explicitly:
 
@@ -79,11 +78,11 @@ Prefix: `/extensions/optimike-operon-bridge/v1`
 - `GET /mutations/pending-recoveries`
 - `POST /mutations/recover`
 
-All routes inherit Local REST API authentication and local TLS settings. Saved filters run through Operon's native filter evaluator with an exact caller-supplied `filterSetId`; the official 3.2 API does not list saved filters. Mutations require idempotency; an idempotency key is bound to one canonical request and conflicting reuse is rejected before later payload validation. Existing-task mutations require the live revision; in-place adoption instead requires an exact one-based line plus `expectedLine` on engines that advertise it. Dry-run is the default.
+All routes inherit Local REST API authentication and local TLS settings. Saved filters run through Operon's native filter evaluator with an exact caller-supplied `filterSetId`; the official task-workflow API does not list saved filters. Mutations require idempotency; an idempotency key is bound to one canonical request and conflicting reuse is rejected before later payload validation. Existing-task mutations require the live revision; in-place adoption instead requires an exact one-based line plus `expectedLine` on engines that advertise it. Dry-run is the default.
 
 Mutation paths are strict, exact vault-relative paths. The MCP and Bridge reject leading or trailing whitespace, backslashes, absolute paths, empty segments, traversal, and non-Markdown `targetPath` values; they never trim or rewrite an invalid destination into a valid one.
 
-Mutation apply is disabled by default. Operon 3.2.x mutation routes are advertised only when the Bridge setting is enabled, the official grant exposes the matching preview/apply capabilities, and the MCP runtime has the separate `OPERON_MUTATIONS_ENABLED` opt-in. Relationship apply rereads the source and inverse dependency edges; recurrence uses the official scoped recurrence plan and never passes through the generic update route.
+Mutation apply is disabled by default. Operon 3.x mutation routes are advertised only when the Bridge setting is enabled, the official grant exposes the matching preview/apply capabilities, and the MCP runtime has the separate `OPERON_MUTATIONS_ENABLED` opt-in. Relationship apply rereads the source and inverse dependency edges; recurrence uses the official scoped recurrence plan and never passes through the generic update route.
 
 ## Build
 


### PR DESCRIPTION
## Summary

- align the public Operon documentation with the validated `3.3.2` / CLI `1.1.2` baseline
- record the live non-terminal transition, exact restoration, fixture cleanup, 30-task postflight, zero recovery, and `P0/P1/P2 = 0/0/0`
- remove stale current-state references to resolved Settings, File Task rename, and Project Serial transition issues
- keep the contract distinction explicit: `3.3.2` is live-validated but remains `compatible-provisional`; adoption remains unavailable through the official Developer API and tracked in Operon #140
- preserve the curated MCP/CLI boundary in both English and French documentation

## Validation

- `npm run test:docs`
- `npm run test:operon-contract`
- `npm run test:package`
- `git diff --check`
- stale current-state assertion scan