### PR TITLE
release: Optimike Obsidian MCP 2.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.8.2] - 2026-08-17
+
 ### Fixed
 
 - Governed Markdown-note and frontmatter reconciliation now accepts the one
@@ -28,6 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   line may advance inside the real apply window (at most five minutes), and
   restoring that line must make the observed note byte-identical to the sealed
   target. Every other drift remains uncertain or conflicting.
+
+### Validation
+
+- The dedicated Operon Bridge pilot vault passed the release canary with
+  Frontmatter Date Manager `1.2.1`: two successful CAS responses and their first
+  reconciliation reads were deliberately lost, timestamp-only settlement
+  reconciled to `committed`, additional body drift remained `outcome_unknown`,
+  and the disposable note was restored to its exact original SHA-256.
 
 ## [2.8.1] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,10 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Validation
 
 - The dedicated Operon Bridge pilot vault passed the release canary with
-  Frontmatter Date Manager `1.2.1`: two successful CAS responses and their first
-  reconciliation reads were deliberately lost, timestamp-only settlement
-  reconciled to `committed`, additional body drift remained `outcome_unknown`,
-  and the disposable note was restored to its exact original SHA-256.
+  Frontmatter Date Manager `1.2.1` at both supported minute and second
+  resolutions: two successful CAS responses and their first reconciliation
+  reads were deliberately lost, timestamp-only settlement reconciled to
+  `committed`, additional body drift remained `outcome_unknown`, and the
+  disposable note was restored to its exact original SHA-256.
 
 ## [2.8.1] - 2026-08-15
 

--- a/OPERATIONS.fr.md
+++ b/OPERATIONS.fr.md
@@ -247,6 +247,27 @@ ne passe que si le reçu est `committed`, conserve le hash de la cible scellée 
 le hash réellement observé après settlement, et si une dérive supplémentaire du
 corps ou du frontmatter reste `outcome_unknown`.
 
+Le dépôt fournit cette gate live discriminante pour les plugins pris en charge :
+
+```powershell
+$env:OBSIDIAN_MODIFIED_TIME_CANARY_PATH = "Canary/modified-time-settlement.md"
+$env:OBSIDIAN_MODIFIED_TIME_CANARY_CONFIRM = "I_UNDERSTAND_THIS_DISPOSABLE_NOTE_WILL_BE_MUTATED_AND_RESTORED"
+$env:OBSIDIAN_MODIFIED_TIME_CANARY_VAULT = "operon-bridge-pilot-vault"
+$env:OBSIDIAN_MODIFIED_TIME_CANARY_PLUGIN_ID = "frontmatter-date-manager"
+$env:OBSIDIAN_MODIFIED_TIME_CANARY_PROPERTY = "modification"
+$env:OBSIDIAN_API_KEY = "<cle-local-rest-api>"
+$env:MCP_WRITE_MODE = "guarded"
+npm run smoke:modified-time-settlement-live
+```
+
+Le script perd volontairement la réponse CAS réussie et la première relecture
+de réconciliation. Il prouve d’abord le settlement du timestamp seul, puis que
+le même comportement accompagné d’une dérive du corps reste
+`outcome_unknown`. Il ne désactive le plugin de date que pour la restauration
+exacte, rétablit son état activé, écrit une preuve JSON expurgée sous la racine
+temporaire du système et ne conserve les éléments privés de récupération que si
+la restauration exacte ne peut pas être vérifiée.
+
 ## Frontmatter gouvernée P1
 
 P1 accepte des intentions top-level `set`/`delete` bornées et les compile sans

--- a/OPERATIONS.fr.md
+++ b/OPERATIONS.fr.md
@@ -263,7 +263,9 @@ npm run smoke:modified-time-settlement-live
 Le script perd volontairement la réponse CAS réussie et la première relecture
 de réconciliation. Il prouve d’abord le settlement du timestamp seul, puis que
 le même comportement accompagné d’une dérive du corps reste
-`outcome_unknown`. Il ne désactive le plugin de date que pour la restauration
+`outcome_unknown`. Avant chaque mutation, il attend le prochain tick que le
+format configuré, à la minute ou à la seconde, peut réellement représenter. Il
+ne désactive le plugin de date que pour la restauration
 exacte, rétablit son état activé, écrit une preuve JSON expurgée sous la racine
 temporaire du système et ne conserve les éléments privés de récupération que si
 la restauration exacte ne peut pas être vérifiée.

--- a/OPERATIONS.fr.md
+++ b/OPERATIONS.fr.md
@@ -264,8 +264,9 @@ Le script perd volontairement la réponse CAS réussie et la première relecture
 de réconciliation. Il prouve d’abord le settlement du timestamp seul, puis que
 le même comportement accompagné d’une dérive du corps reste
 `outcome_unknown`. Avant chaque mutation, il attend le prochain tick que le
-format configuré, à la minute ou à la seconde, peut réellement représenter. Il
-ne désactive le plugin de date que pour la restauration
+format configuré, à la minute ou à la seconde, peut réellement représenter,
+puis franchit la marge de fraîcheur du plugin supporté. Il ne désactive le
+plugin de date que pour la restauration
 exacte, rétablit son état activé, écrit une preuve JSON expurgée sous la racine
 temporaire du système et ne conserve les éléments privés de récupération que si
 la restauration exacte ne peut pas être vérifiée.

--- a/OPERATIONS.fr.md
+++ b/OPERATIONS.fr.md
@@ -274,9 +274,11 @@ la restauration exacte ne peut pas être vérifiée.
 `Ctrl-C` et `SIGTERM` exécutent cette même restauration protégée avant la sortie
 du processus. Les mainteneurs peuvent prouver ce chemin d’interruption de façon
 déterministe avec
-`OBSIDIAN_MODIFIED_TIME_CANARY_SELF_SIGNAL=SIGTERM_AFTER_POSITIVE_APPLY` : le
-code de sortie attendu est `143`, tandis que le hash de la note et l’état activé
-du plugin doivent tous deux être identiques à leurs valeurs initiales.
+`OBSIDIAN_MODIFIED_TIME_CANARY_SELF_SIGNAL=SIGTERM_DURING_POSITIVE_APPLY` : le
+signal est injecté après l’acceptation du CAS par le Bridge mais avant la fin de
+l’apply MCP. Le code de sortie attendu est `143`, tandis que le hash de la note
+et l’état activé du plugin doivent tous deux être identiques à leurs valeurs
+initiales.
 
 ## Frontmatter gouvernée P1
 

--- a/OPERATIONS.fr.md
+++ b/OPERATIONS.fr.md
@@ -271,6 +271,13 @@ exacte, rétablit son état activé, écrit une preuve JSON expurgée sous la ra
 temporaire du système et ne conserve les éléments privés de récupération que si
 la restauration exacte ne peut pas être vérifiée.
 
+`Ctrl-C` et `SIGTERM` exécutent cette même restauration protégée avant la sortie
+du processus. Les mainteneurs peuvent prouver ce chemin d’interruption de façon
+déterministe avec
+`OBSIDIAN_MODIFIED_TIME_CANARY_SELF_SIGNAL=SIGTERM_AFTER_POSITIVE_APPLY` : le
+code de sortie attendu est `143`, tandis que le hash de la note et l’état activé
+du plugin doivent tous deux être identiques à leurs valeurs initiales.
+
 ## Frontmatter gouvernée P1
 
 P1 accepte des intentions top-level `set`/`delete` bornées et les compile sans

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -263,6 +263,12 @@ restores the original enabled state, writes a redacted JSON proof under the
 operating-system temporary root, and retains private recovery material only if
 exact restoration cannot be verified.
 
+`Ctrl-C` and `SIGTERM` run that same guarded restoration before the process
+exits. Maintainers can prove this interruption path deterministically by setting
+`OBSIDIAN_MODIFIED_TIME_CANARY_SELF_SIGNAL=SIGTERM_AFTER_POSITIVE_APPLY`; the
+expected process exit code is `143`, while the note hash and plugin enabled
+state must both match their initial values.
+
 ## Governed frontmatter P1
 
 P1 accepts bounded top-level `set`/`delete` intentions and compiles them without

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -255,7 +255,9 @@ npm run smoke:modified-time-settlement-live
 The script deliberately loses both the successful CAS response and the first
 reconciliation read. It proves timestamp-only settlement, then proves that the
 same timestamp behavior plus an additional body drift remains
-`outcome_unknown`. It disables the date plugin only for exact restoration,
+`outcome_unknown`. Before each mutation it waits for the next timestamp tick
+that the configured minute- or second-resolution format can represent. It
+disables the date plugin only for exact restoration,
 restores the original enabled state, writes a redacted JSON proof under the
 operating-system temporary root, and retains private recovery material only if
 exact restoration cannot be verified.

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -240,6 +240,26 @@ receipt is `committed`, records both the sealed target hash and the actual
 settled hash, and an additional body or frontmatter change still remains
 `outcome_unknown`.
 
+The repository provides that discriminating live gate for supported plugins:
+
+```bash
+OBSIDIAN_MODIFIED_TIME_CANARY_PATH="Canary/modified-time-settlement.md" \
+OBSIDIAN_MODIFIED_TIME_CANARY_CONFIRM=I_UNDERSTAND_THIS_DISPOSABLE_NOTE_WILL_BE_MUTATED_AND_RESTORED \
+OBSIDIAN_MODIFIED_TIME_CANARY_VAULT="operon-bridge-pilot-vault" \
+OBSIDIAN_MODIFIED_TIME_CANARY_PLUGIN_ID="frontmatter-date-manager" \
+OBSIDIAN_MODIFIED_TIME_CANARY_PROPERTY="modification" \
+OBSIDIAN_API_KEY="<local-rest-api-key>" MCP_WRITE_MODE=guarded \
+npm run smoke:modified-time-settlement-live
+```
+
+The script deliberately loses both the successful CAS response and the first
+reconciliation read. It proves timestamp-only settlement, then proves that the
+same timestamp behavior plus an additional body drift remains
+`outcome_unknown`. It disables the date plugin only for exact restoration,
+restores the original enabled state, writes a redacted JSON proof under the
+operating-system temporary root, and retains private recovery material only if
+exact restoration cannot be verified.
+
 ## Governed frontmatter P1
 
 P1 accepts bounded top-level `set`/`delete` intentions and compiles them without

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -256,8 +256,9 @@ The script deliberately loses both the successful CAS response and the first
 reconciliation read. It proves timestamp-only settlement, then proves that the
 same timestamp behavior plus an additional body drift remains
 `outcome_unknown`. Before each mutation it waits for the next timestamp tick
-that the configured minute- or second-resolution format can represent. It
-disables the date plugin only for exact restoration,
+that the configured minute- or second-resolution format can represent, then
+crosses the supported plugin freshness margin. It disables the date plugin only
+for exact restoration,
 restores the original enabled state, writes a redacted JSON proof under the
 operating-system temporary root, and retains private recovery material only if
 exact restoration cannot be verified.

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -265,9 +265,10 @@ exact restoration cannot be verified.
 
 `Ctrl-C` and `SIGTERM` run that same guarded restoration before the process
 exits. Maintainers can prove this interruption path deterministically by setting
-`OBSIDIAN_MODIFIED_TIME_CANARY_SELF_SIGNAL=SIGTERM_AFTER_POSITIVE_APPLY`; the
-expected process exit code is `143`, while the note hash and plugin enabled
-state must both match their initial values.
+`OBSIDIAN_MODIFIED_TIME_CANARY_SELF_SIGNAL=SIGTERM_DURING_POSITIVE_APPLY`; the
+signal is injected after the Bridge accepts the CAS but before the MCP apply
+settles. The expected process exit code is `143`, while the note hash and plugin
+enabled state must both match their initial values.
 
 ## Governed frontmatter P1
 

--- a/docs/governed-note-replacement.fr.md
+++ b/docs/governed-note-replacement.fr.md
@@ -105,8 +105,12 @@ Manager, Update Time ou Update time on edit. Le planning ne scelle cette policy
 que si la propriété figure aussi dans `MCP_PROTECTED_FRONTMATTER_KEYS`. Cette
 configuration étant une liste séparée par des virgules, le Bridge n’annonce
 jamais une propriété de modification dont le nom contient une virgule ; les
-noms avec deux-points, saut de ligne, espaces périphériques ou plus de 128
-caractères sont rejetés à la même frontière.
+noms doivent aussi rester des clés YAML plain source-stable, composées de
+lettres, marques ou chiffres Unicode, de `_`, `.`, `-` et d’espaces internes.
+Elles commencent par une lettre ou `_`. Les booléens/null YAML, débuts
+numériques, formes quotées comme `#modified`, deux-points, sauts de ligne,
+espaces périphériques ou plus de 128 unités de code de chaîne JavaScript sont
+rejetés à la même frontière.
 
 La précondition d’écriture reste un CAS SHA-256 exact sur le fichier complet :
 le settlement n’affaiblit pas le CAS pré-effet. Aucun timestamp n’est ignoré

--- a/docs/governed-note-replacement.fr.md
+++ b/docs/governed-note-replacement.fr.md
@@ -102,7 +102,11 @@ soumis à la politique de rétention bornée existante. Reçus et logs n’expos
 Atomic Write Bridge 0.2.0 annonce la propriété de date de modification
 réellement configurée par une intégration supportée et active : Frontmatter Date
 Manager, Update Time ou Update time on edit. Le planning ne scelle cette policy
-que si la propriété figure aussi dans `MCP_PROTECTED_FRONTMATTER_KEYS`.
+que si la propriété figure aussi dans `MCP_PROTECTED_FRONTMATTER_KEYS`. Cette
+configuration étant une liste séparée par des virgules, le Bridge n’annonce
+jamais une propriété de modification dont le nom contient une virgule ; les
+noms avec deux-points, saut de ligne, espaces périphériques ou plus de 128
+caractères sont rejetés à la même frontière.
 
 La précondition d’écriture reste un CAS SHA-256 exact sur le fichier complet :
 le settlement n’affaiblit pas le CAS pré-effet. Aucun timestamp n’est ignoré

--- a/docs/governed-note-replacement.md
+++ b/docs/governed-note-replacement.md
@@ -95,7 +95,10 @@ Receipts and logs never expose `nextContent` or the physical journal path.
 Atomic Write Bridge 0.2.0 reports the exact modified-time property configured by
 an enabled supported integration: Frontmatter Date Manager, Update Time, or
 Update time on edit. Planning seals that policy only when the property is also
-listed in `MCP_PROTECTED_FRONTMATTER_KEYS`.
+listed in `MCP_PROTECTED_FRONTMATTER_KEYS`. Because that configuration is a
+comma-delimited list, the Bridge never advertises a modified-time property whose
+name contains a comma; colon, newline, surrounding-whitespace and over-128-byte
+names are also rejected at the same boundary.
 
 The write precondition remains an exact whole-file SHA-256 CAS: settlement does
 not weaken pre-effect CAS. No timestamp is ignored before the effect. During

--- a/docs/governed-note-replacement.md
+++ b/docs/governed-note-replacement.md
@@ -97,8 +97,8 @@ an enabled supported integration: Frontmatter Date Manager, Update Time, or
 Update time on edit. Planning seals that policy only when the property is also
 listed in `MCP_PROTECTED_FRONTMATTER_KEYS`. Because that configuration is a
 comma-delimited list, the Bridge never advertises a modified-time property whose
-name contains a comma; colon, newline, surrounding-whitespace and over-128-byte
-names are also rejected at the same boundary.
+name contains a comma; colon, newline, surrounding-whitespace and names longer
+than 128 JavaScript string code units are also rejected at the same boundary.
 
 The write precondition remains an exact whole-file SHA-256 CAS: settlement does
 not weaken pre-effect CAS. No timestamp is ignored before the effect. During

--- a/docs/governed-note-replacement.md
+++ b/docs/governed-note-replacement.md
@@ -97,8 +97,12 @@ an enabled supported integration: Frontmatter Date Manager, Update Time, or
 Update time on edit. Planning seals that policy only when the property is also
 listed in `MCP_PROTECTED_FRONTMATTER_KEYS`. Because that configuration is a
 comma-delimited list, the Bridge never advertises a modified-time property whose
-name contains a comma; colon, newline, surrounding-whitespace and names longer
-than 128 JavaScript string code units are also rejected at the same boundary.
+name contains a comma. It also requires a source-stable plain YAML key made of
+Unicode letters, marks or numbers plus `_`, `.`, `-` and internal spaces, so
+quoted forms such as `#modified` cannot disagree with the runtime's exact
+top-level line proof. It must start with a letter or `_`; YAML boolean/null
+words, numeric starts, colon, newline, surrounding whitespace and names longer
+than 128 JavaScript string code units are rejected at the same boundary.
 
 The write precondition remains an exact whole-file SHA-256 CAS: settlement does
 not weaken pre-effect CAS. No timestamp is ignored before the effect. During

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optimike-obsidian-mcp",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optimike-obsidian-mcp",
-      "version": "2.8.1",
+      "version": "2.8.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optimike-obsidian-mcp",
-  "version": "2.8.1",
+  "version": "2.8.2",
   "description": "Unified Obsidian MCP server with shared local cache, Operon and Tasks tools, Bases support, semantic search, runtime observability, and degraded read mode for durable agent workflows.",
   "main": "dist/index.js",
   "files": [
@@ -156,6 +156,7 @@
     "test:governed-note-replace-mcp": "npm run build && node scripts/test-governed-note-replace-mcp.mjs",
     "test:governed-note-replace-http": "npm run build && node scripts/test-governed-note-replace-http.mjs",
     "smoke:atomic-note-mcp-live": "npm run build && node scripts/smoke-atomic-note-mcp-live.mjs",
+    "smoke:modified-time-settlement-live": "npm run build && node scripts/smoke-modified-time-settlement-live.mjs",
     "test:governed-frontmatter": "npm run build && node scripts/test-governed-frontmatter-model.mjs && node scripts/test-frontmatter-p1-compiler.mjs && node scripts/test-frontmatter-p1-idempotency.mjs && node scripts/test-governed-frontmatter-mcp.mjs && node scripts/test-governed-frontmatter-http.mjs",
     "smoke:governed-frontmatter-live": "npm run build && node scripts/smoke-governed-frontmatter-live.mjs"
   },

--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "test:governed-base": "npm run build && node scripts/test-base-config-p2-compiler.mjs && node scripts/test-governed-base-formula-operation.mjs && node scripts/test-governed-base-formula-mcp.mjs && node scripts/test-governed-base-formula-http.mjs && npm run check:bases-bridge",
     "smoke:governed-base-live": "npm run build && node scripts/smoke-governed-base-formula-live.mjs",
     "check:operon": "npm run build && npm run test:operon-contract && npm run test:operon-service && npm --prefix plugins/obsidian-operon-bridge run check",
-    "check:atomic-write": "npm run build && node scripts/test-modified-time-settlement.mjs && node scripts/test-obsidian-note-replace-operation.mjs && npm --prefix plugins/obsidian-atomic-write-bridge run check",
+    "check:atomic-write": "npm run build && node scripts/test-modified-time-settlement.mjs && node scripts/test-modified-time-canary-helpers.mjs && node scripts/test-obsidian-note-replace-operation.mjs && npm --prefix plugins/obsidian-atomic-write-bridge run check",
     "smoke:operon-mutations": "node scripts/smoke-operon-mutations.mjs",
     "smoke:operon-rich-mutations": "node scripts/smoke-operon-rich-mutations.mjs",
     "test:profiles": "node scripts/test-elysia-task-profile.mjs",

--- a/plugins/obsidian-atomic-write-bridge/README.md
+++ b/plugins/obsidian-atomic-write-bridge/README.md
@@ -36,9 +36,12 @@ The Bridge never relaxes CAS and never decides that a changed note is
 equivalent. Optimike MCP may use this metadata only after an effect, within a
 bounded attempt window, and only when the configured property is protected and
 the rest of the observed note is byte-identical to the sealed result.
-Property names containing a colon, comma, newline, surrounding whitespace, or
-more than 128 characters are not advertised. The comma boundary is required
-because `MCP_PROTECTED_FRONTMATTER_KEYS` is a comma-delimited fail-closed list.
+Only source-stable plain YAML property names are advertised: Unicode
+letters/marks/numbers, `_`, `.`, `-`, and internal spaces, starting with a letter
+or `_`. YAML boolean/null words, purely numeric starts, colon, comma, newline,
+surrounding whitespace, quoting indicators such as `#`, and names longer than
+128 JavaScript string code units are rejected. The comma boundary is also required because
+`MCP_PROTECTED_FRONTMATTER_KEYS` is a comma-delimited fail-closed list.
 
 ## Install from source
 

--- a/plugins/obsidian-atomic-write-bridge/README.md
+++ b/plugins/obsidian-atomic-write-bridge/README.md
@@ -36,6 +36,9 @@ The Bridge never relaxes CAS and never decides that a changed note is
 equivalent. Optimike MCP may use this metadata only after an effect, within a
 bounded attempt window, and only when the configured property is protected and
 the rest of the observed note is byte-identical to the sealed result.
+Property names containing a colon, comma, newline, surrounding whitespace, or
+more than 128 characters are not advertised. The comma boundary is required
+because `MCP_PROTECTED_FRONTMATTER_KEYS` is a comma-delimited fail-closed list.
 
 ## Install from source
 

--- a/plugins/obsidian-atomic-write-bridge/src/modifiedTimeIntegrations.test.ts
+++ b/plugins/obsidian-atomic-write-bridge/src/modifiedTimeIntegrations.test.ts
@@ -64,6 +64,14 @@ test("rejects inactive, numeric, timezone and unsafe configurations", () => {
     ),
     [],
   );
+  assert.deepEqual(
+    getModifiedTimeIntegrations(
+      app({
+        "update-time": { settings: { updatedPropertyName: "modified,time" } },
+      }),
+    ),
+    [],
+  );
 });
 
 test("deduplicates properties exposed by more than one supported plugin", () => {

--- a/plugins/obsidian-atomic-write-bridge/src/modifiedTimeIntegrations.test.ts
+++ b/plugins/obsidian-atomic-write-bridge/src/modifiedTimeIntegrations.test.ts
@@ -67,10 +67,46 @@ test("rejects inactive, numeric, timezone and unsafe configurations", () => {
   assert.deepEqual(
     getModifiedTimeIntegrations(
       app({
+        "update-time": { settings: { updatedPropertyName: "true" } },
+      }),
+    ),
+    [],
+  );
+  assert.deepEqual(
+    getModifiedTimeIntegrations(
+      app({
         "update-time": { settings: { updatedPropertyName: "modified,time" } },
       }),
     ),
     [],
+  );
+  assert.deepEqual(
+    getModifiedTimeIntegrations(
+      app({
+        "update-time": { settings: { updatedPropertyName: "#modified" } },
+      }),
+    ),
+    [],
+  );
+});
+
+test("accepts source-stable plain YAML property names", () => {
+  assert.deepEqual(
+    getModifiedTimeIntegrations(
+      app({
+        "update-time-on-edit": {
+          settings: {
+            dateFormat: "yyyy-MM-dd'T'HH:mm",
+            headerUpdated: "last modified",
+          },
+        },
+        "update-time": { settings: { updatedPropertyName: "modified.at" } },
+      }),
+    ),
+    [
+      { pluginId: "update-time-on-edit", propertyName: "last modified" },
+      { pluginId: "update-time", propertyName: "modified.at" },
+    ],
   );
 });
 

--- a/plugins/obsidian-atomic-write-bridge/src/modifiedTimeIntegrations.ts
+++ b/plugins/obsidian-atomic-write-bridge/src/modifiedTimeIntegrations.ts
@@ -27,7 +27,7 @@ function safePropertyName(value: unknown): string | undefined {
     value.length === 0 ||
     value.length > 128 ||
     value.trim() !== value ||
-    /[\r\n:]/u.test(value)
+    /[,\r\n:]/u.test(value)
   ) {
     return undefined;
   }

--- a/plugins/obsidian-atomic-write-bridge/src/modifiedTimeIntegrations.ts
+++ b/plugins/obsidian-atomic-write-bridge/src/modifiedTimeIntegrations.ts
@@ -27,7 +27,9 @@ function safePropertyName(value: unknown): string | undefined {
     value.length === 0 ||
     value.length > 128 ||
     value.trim() !== value ||
-    /[,\r\n:]/u.test(value)
+    /[,\r\n:]/u.test(value) ||
+    /^(?:null|true|false|yes|no|on|off)$/iu.test(value) ||
+    !/^[\p{L}_](?:[\p{L}\p{M}\p{N}_. -]*[\p{L}\p{M}\p{N}_.-])?$/u.test(value)
   ) {
     return undefined;
   }

--- a/scripts/modified-time-canary-helpers.mjs
+++ b/scripts/modified-time-canary-helpers.mjs
@@ -8,7 +8,9 @@ export function isSafeModifiedTimePropertyName(value) {
     value.length > 0 &&
     value.length <= 128 &&
     value.trim() === value &&
-    !/[,\r\n:]/u.test(value)
+    !/[,\r\n:]/u.test(value) &&
+    !/^(?:null|true|false|yes|no|on|off)$/iu.test(value) &&
+    /^[\p{L}_](?:[\p{L}\p{M}\p{N}_. -]*[\p{L}\p{M}\p{N}_.-])?$/u.test(value)
   );
 }
 

--- a/scripts/modified-time-canary-helpers.mjs
+++ b/scripts/modified-time-canary-helpers.mjs
@@ -54,7 +54,5 @@ export function nextRepresentableTimestampReadyAt(
   }
   const currentEpochMs = localEpochMs - utcOffsetMinutes * 60_000;
   const representableTickMs = second === undefined ? 60_000 : 1_000;
-  return (
-    currentEpochMs + Math.max(representableTickMs, PLUGIN_FRESHNESS_MARGIN_MS)
-  );
+  return currentEpochMs + representableTickMs + PLUGIN_FRESHNESS_MARGIN_MS;
 }

--- a/scripts/modified-time-canary-helpers.mjs
+++ b/scripts/modified-time-canary-helpers.mjs
@@ -8,7 +8,7 @@ export function isSafeModifiedTimePropertyName(value) {
     value.length > 0 &&
     value.length <= 128 &&
     value.trim() === value &&
-    !/[\r\n:]/u.test(value)
+    !/[,\r\n:]/u.test(value)
   );
 }
 

--- a/scripts/modified-time-canary-helpers.mjs
+++ b/scripts/modified-time-canary-helpers.mjs
@@ -14,6 +14,40 @@ export function isSafeModifiedTimePropertyName(value) {
   );
 }
 
+function lineWithoutCarriageReturn(line) {
+  return line.endsWith("\r") ? line.slice(0, -1) : line;
+}
+
+export function modifiedTimeFrontmatterPropertyValue(content, propertyName) {
+  const lines = content.split("\n");
+  if (lineWithoutCarriageReturn(lines[0] ?? "") !== "---") {
+    throw new Error("The canary note must start with standard frontmatter.");
+  }
+  const closingDelimiter = lines.findIndex(
+    (line, index) => index > 0 && lineWithoutCarriageReturn(line) === "---",
+  );
+  if (closingDelimiter < 0) {
+    throw new Error("The canary note frontmatter is not closed.");
+  }
+  const prefix = `${propertyName}:`;
+  const matches = lines
+    .slice(1, closingDelimiter)
+    .map(lineWithoutCarriageReturn)
+    .filter((line) => line.startsWith(prefix));
+  if (matches.length !== 1) {
+    throw new Error(
+      `The canary note must contain exactly one top-level ${propertyName} frontmatter property.`,
+    );
+  }
+  const value = matches[0].slice(prefix.length).trim();
+  if (!value) {
+    throw new Error(
+      `The canary note ${propertyName} property must be non-empty.`,
+    );
+  }
+  return value;
+}
+
 export function nextRepresentableTimestampReadyAt(
   currentValue,
   utcOffsetMinutes,

--- a/scripts/modified-time-canary-helpers.mjs
+++ b/scripts/modified-time-canary-helpers.mjs
@@ -1,0 +1,60 @@
+const LOCAL_DATETIME =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/u;
+const PLUGIN_FRESHNESS_MARGIN_MS = 5_200;
+
+export function isSafeModifiedTimePropertyName(value) {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    value.length <= 128 &&
+    value.trim() === value &&
+    !/[\r\n:]/u.test(value)
+  );
+}
+
+export function nextRepresentableTimestampReadyAt(
+  currentValue,
+  utcOffsetMinutes,
+) {
+  const match = LOCAL_DATETIME.exec(currentValue);
+  if (!match) {
+    throw new Error(
+      "The current modified-time value must use one supported local datetime format.",
+    );
+  }
+  if (
+    !Number.isInteger(utcOffsetMinutes) ||
+    utcOffsetMinutes < -14 * 60 ||
+    utcOffsetMinutes > 14 * 60
+  ) {
+    throw new Error("The Obsidian UTC offset is invalid.");
+  }
+  const [, year, month, day, hour, minute, second] = match;
+  const parts = [year, month, day, hour, minute, second ?? "0"].map(Number);
+  const [yearValue, monthValue, dayValue, hourValue, minuteValue, secondValue] =
+    parts;
+  const localEpochMs = Date.UTC(
+    yearValue,
+    monthValue - 1,
+    dayValue,
+    hourValue,
+    minuteValue,
+    secondValue,
+  );
+  const candidate = new Date(localEpochMs);
+  if (
+    candidate.getUTCFullYear() !== yearValue ||
+    candidate.getUTCMonth() !== monthValue - 1 ||
+    candidate.getUTCDate() !== dayValue ||
+    candidate.getUTCHours() !== hourValue ||
+    candidate.getUTCMinutes() !== minuteValue ||
+    candidate.getUTCSeconds() !== secondValue
+  ) {
+    throw new Error("The current modified-time value is not a real datetime.");
+  }
+  const currentEpochMs = localEpochMs - utcOffsetMinutes * 60_000;
+  const representableTickMs = second === undefined ? 60_000 : 1_000;
+  return (
+    currentEpochMs + Math.max(representableTickMs, PLUGIN_FRESHNESS_MARGIN_MS)
+  );
+}

--- a/scripts/smoke-governed-base-formula-live.mjs
+++ b/scripts/smoke-governed-base-formula-live.mjs
@@ -286,7 +286,7 @@ try {
         originalSha256: original.sha256,
         finalSha256: final.sha256,
         bridgeVersion: status.plugin.version,
-        mcpVersion: process.env.MCP_SERVER_VERSION ?? "2.8.1",
+        mcpVersion: process.env.MCP_SERVER_VERSION ?? "2.8.2",
         checks: [
           "typed_base_binding",
           "plan_without_write",

--- a/scripts/smoke-modified-time-settlement-live.mjs
+++ b/scripts/smoke-modified-time-settlement-live.mjs
@@ -17,6 +17,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import {
   isSafeModifiedTimePropertyName,
+  modifiedTimeFrontmatterPropertyValue,
   nextRepresentableTimestampReadyAt,
 } from "./modified-time-canary-helpers.mjs";
 
@@ -95,16 +96,7 @@ function sha256(content) {
 }
 
 function propertyValue(content) {
-  const prefix = `${propertyName}:`;
-  const matches = content
-    .split(/\r?\n/u)
-    .filter((line) => line.startsWith(prefix));
-  assert.equal(
-    matches.length,
-    1,
-    `The canary note must contain exactly one top-level ${propertyName} property.`,
-  );
-  return matches[0].slice(prefix.length).trim();
+  return modifiedTimeFrontmatterPropertyValue(content, propertyName);
 }
 
 async function waitForNextRepresentableTimestamp(

--- a/scripts/smoke-modified-time-settlement-live.mjs
+++ b/scripts/smoke-modified-time-settlement-live.mjs
@@ -68,9 +68,15 @@ if (!apiKey) throw new Error("OBSIDIAN_API_KEY is required.");
 if (!new Set(["guarded", "full"]).has(writeMode)) {
   throw new Error("The live canary requires MCP_WRITE_MODE=guarded or full.");
 }
-if (!new Set(["", "SIGTERM_AFTER_POSITIVE_APPLY"]).has(selfSignal)) {
+if (
+  !new Set([
+    "",
+    "SIGTERM_AFTER_POSITIVE_APPLY",
+    "SIGTERM_DURING_POSITIVE_APPLY",
+  ]).has(selfSignal)
+) {
   throw new Error(
-    "OBSIDIAN_MODIFIED_TIME_CANARY_SELF_SIGNAL must be empty or SIGTERM_AFTER_POSITIVE_APPLY.",
+    "OBSIDIAN_MODIFIED_TIME_CANARY_SELF_SIGNAL must be empty, SIGTERM_AFTER_POSITIVE_APPLY, or SIGTERM_DURING_POSITIVE_APPLY.",
   );
 }
 
@@ -164,11 +170,23 @@ async function directRequest(route, { method = "GET", payload } = {}) {
   return JSON.parse(text);
 }
 
-async function atomicStatus() {
-  return directRequest("/extensions/obsidian-atomic-write-bridge/status");
+function assertMainFlowActive() {
+  if (shutdownRequested) {
+    throw new Error("The modified-time canary is shutting down.");
+  }
 }
 
-async function atomicRead() {
+async function atomicStatus({ cleanup = false } = {}) {
+  if (!cleanup) assertMainFlowActive();
+  const response = await directRequest(
+    "/extensions/obsidian-atomic-write-bridge/status",
+  );
+  if (!cleanup) assertMainFlowActive();
+  return response;
+}
+
+async function atomicRead({ cleanup = false } = {}) {
+  if (!cleanup) assertMainFlowActive();
   const response = await directRequest(
     "/extensions/obsidian-atomic-write-bridge/notes/read",
     {
@@ -176,6 +194,7 @@ async function atomicRead() {
       payload: { contractVersion: 1, path: canaryPath },
     },
   );
+  if (!cleanup) assertMainFlowActive();
   if (
     originalBindingFingerprint !== undefined &&
     response.bindingFingerprint !== originalBindingFingerprint
@@ -187,10 +206,15 @@ async function atomicRead() {
   return response;
 }
 
-async function atomicReplace(expectedSha256, nextContent, bindingFingerprint) {
-  const response = await directRequest(
-    "/extensions/obsidian-atomic-write-bridge/notes/cas",
-    {
+async function atomicReplace(
+  expectedSha256,
+  nextContent,
+  bindingFingerprint,
+  { cleanup = false } = {},
+) {
+  if (!cleanup) assertMainFlowActive();
+  const response = await trackMutation(
+    directRequest("/extensions/obsidian-atomic-write-bridge/notes/cas", {
       method: "POST",
       payload: {
         contractVersion: 1,
@@ -199,8 +223,10 @@ async function atomicReplace(expectedSha256, nextContent, bindingFingerprint) {
         expectedSha256,
         nextContent,
       },
-    },
+    }),
+    { cleanup },
   );
+  if (!cleanup) assertMainFlowActive();
   if (response.bindingFingerprint !== bindingFingerprint) {
     throw new Error(
       "The Atomic Write backend binding changed while applying a CAS.",
@@ -256,10 +282,17 @@ const proxy = createServer(async (request, response) => {
       dropNextCasResponse &&
       target.pathname === "/extensions/obsidian-atomic-write-bridge/notes/cas"
     ) {
+      const signalDuringPositiveApply =
+        selfSignal === "SIGTERM_DURING_POSITIVE_APPLY" &&
+        droppedCasResponses === 0;
       dropNextCasResponse = false;
       dropNextReconciliationRead = true;
       droppedCasResponses += 1;
       request.socket.destroy();
+      if (signalDuringPositiveApply) {
+        process.emit("SIGTERM", "SIGTERM");
+        process.emit("SIGTERM", "SIGTERM");
+      }
       return;
     }
     response.statusCode = upstream.status;
@@ -333,7 +366,10 @@ function parse(result) {
 }
 
 async function call(name, args) {
-  return parse(await client.callTool({ name, arguments: args }));
+  assertMainFlowActive();
+  const result = parse(await client.callTool({ name, arguments: args }));
+  assertMainFlowActive();
+  return result;
 }
 
 async function plan(nextContent, idempotencyKey) {
@@ -348,10 +384,12 @@ async function plan(nextContent, idempotencyKey) {
 
 async function applyWithLostResponse(receipt, idempotencyKey) {
   dropNextCasResponse = true;
-  const result = await call("obsidian_note_replace_apply", {
-    planRef: receipt.planRef,
-    idempotencyKey,
-  });
+  const result = await trackMutation(
+    call("obsidian_note_replace_apply", {
+      planRef: receipt.planRef,
+      idempotencyKey,
+    }),
+  );
   assert.equal(result.outcome, "outcome_unknown");
   assert.equal(dropNextCasResponse, false);
   assert.equal(dropNextReconciliationRead, false);
@@ -371,11 +409,40 @@ let retainedLogsPath;
 let backupMetadata;
 let cleanupPromise;
 let signalExitInProgress = false;
+let shutdownRequested = false;
+let activeMutationPromise;
+let mutationQuiesced = true;
+
+async function trackMutation(promise, { cleanup = false } = {}) {
+  activeMutationPromise = promise;
+  try {
+    const result = await promise;
+    if (!cleanup) assertMainFlowActive();
+    return result;
+  } finally {
+    if (activeMutationPromise === promise) activeMutationPromise = undefined;
+  }
+}
+
+async function quiesceActiveMutation(timeoutMs = 20_000) {
+  const pending = activeMutationPromise;
+  if (!pending) return true;
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => resolve(false), timeoutMs);
+    const settled = () => {
+      clearTimeout(timer);
+      resolve(true);
+    };
+    pending.then(settled, settled);
+  });
+}
 
 async function cleanup() {
+  mutationQuiesced = await quiesceActiveMutation();
   await client.close().catch(() => undefined);
   await new Promise((resolve) => proxy.close(resolve));
   if (
+    mutationQuiesced &&
     originalContent !== undefined &&
     originalBindingFingerprint !== undefined &&
     !restored
@@ -385,8 +452,8 @@ async function cleanup() {
         setPluginEnabled(false);
         pluginStateRestored = false;
       }
-      const current = await atomicRead();
-      const status = await atomicStatus();
+      const current = await atomicRead({ cleanup: true });
+      const status = await atomicStatus({ cleanup: true });
       if (status.backend.bindingFingerprint !== originalBindingFingerprint) {
         throw new Error(
           "The Atomic Write backend binding changed during cleanup; refusing cross-vault recovery.",
@@ -397,9 +464,10 @@ async function cleanup() {
           current.sha256,
           originalContent,
           originalBindingFingerprint,
+          { cleanup: true },
         );
       }
-      const finalRead = await atomicRead();
+      const finalRead = await atomicRead({ cleanup: true });
       restored =
         finalRead.sha256 === originalSha256 &&
         finalRead.content === originalContent;
@@ -431,7 +499,7 @@ async function cleanup() {
       pluginStateRestored = true;
       if (restored && originalContent !== undefined) {
         await new Promise((resolve) => setTimeout(resolve, 1_500));
-        const finalRead = await atomicRead();
+        const finalRead = await atomicRead({ cleanup: true });
         restored =
           finalRead.sha256 === originalSha256 &&
           finalRead.content === originalContent;
@@ -460,6 +528,7 @@ async function cleanup() {
       retainedLogsPath = logsPath;
     }
     backupMetadata.runtimeLogsPath = retainedLogsPath;
+    backupMetadata.mutationQuiesced = mutationQuiesced;
     writeFileSync(
       backupMetadataPath,
       `${JSON.stringify(backupMetadata, null, 2)}\n`,
@@ -485,6 +554,7 @@ function cleanupOnce() {
 function handleSignal(signal) {
   if (signalExitInProgress) return;
   signalExitInProgress = true;
+  shutdownRequested = true;
   const exitCode = signal === "SIGINT" ? 130 : 143;
   void cleanupOnce()
     .then(() => {
@@ -494,6 +564,7 @@ function handleSignal(signal) {
           interruptedBy: signal,
           restored,
           pluginStateRestored,
+          mutationQuiesced,
         }),
       );
     })

--- a/scripts/smoke-modified-time-settlement-live.mjs
+++ b/scripts/smoke-modified-time-settlement-live.mjs
@@ -169,23 +169,44 @@ async function atomicStatus() {
 }
 
 async function atomicRead() {
-  return directRequest("/extensions/obsidian-atomic-write-bridge/notes/read", {
-    method: "POST",
-    payload: { contractVersion: 1, path: canaryPath },
-  });
+  const response = await directRequest(
+    "/extensions/obsidian-atomic-write-bridge/notes/read",
+    {
+      method: "POST",
+      payload: { contractVersion: 1, path: canaryPath },
+    },
+  );
+  if (
+    originalBindingFingerprint !== undefined &&
+    response.bindingFingerprint !== originalBindingFingerprint
+  ) {
+    throw new Error(
+      "The Atomic Write backend binding changed during the canary; refusing cross-vault recovery.",
+    );
+  }
+  return response;
 }
 
 async function atomicReplace(expectedSha256, nextContent, bindingFingerprint) {
-  return directRequest("/extensions/obsidian-atomic-write-bridge/notes/cas", {
-    method: "POST",
-    payload: {
-      contractVersion: 1,
-      path: canaryPath,
-      bindingFingerprint,
-      expectedSha256,
-      nextContent,
+  const response = await directRequest(
+    "/extensions/obsidian-atomic-write-bridge/notes/cas",
+    {
+      method: "POST",
+      payload: {
+        contractVersion: 1,
+        path: canaryPath,
+        bindingFingerprint,
+        expectedSha256,
+        nextContent,
+      },
     },
-  });
+  );
+  if (response.bindingFingerprint !== bindingFingerprint) {
+    throw new Error(
+      "The Atomic Write backend binding changed while applying a CAS.",
+    );
+  }
+  return response;
 }
 
 async function waitForRead(predicate, label, timeoutMs = 15_000) {
@@ -339,6 +360,7 @@ async function applyWithLostResponse(receipt, idempotencyKey) {
 
 let originalContent;
 let originalSha256;
+let originalBindingFingerprint;
 let restored = false;
 let backupWritten = false;
 let originalPluginEnabled = false;
@@ -353,7 +375,11 @@ let signalExitInProgress = false;
 async function cleanup() {
   await client.close().catch(() => undefined);
   await new Promise((resolve) => proxy.close(resolve));
-  if (originalContent !== undefined && !restored) {
+  if (
+    originalContent !== undefined &&
+    originalBindingFingerprint !== undefined &&
+    !restored
+  ) {
     try {
       if (pluginEnabled()) {
         setPluginEnabled(false);
@@ -361,11 +387,16 @@ async function cleanup() {
       }
       const current = await atomicRead();
       const status = await atomicStatus();
+      if (status.backend.bindingFingerprint !== originalBindingFingerprint) {
+        throw new Error(
+          "The Atomic Write backend binding changed during cleanup; refusing cross-vault recovery.",
+        );
+      }
       if (current.sha256 !== originalSha256) {
         await atomicReplace(
           current.sha256,
           originalContent,
-          status.backend.bindingFingerprint,
+          originalBindingFingerprint,
         );
       }
       const finalRead = await atomicRead();
@@ -494,6 +525,8 @@ try {
   assert.equal(status.plugin.id, "obsidian-atomic-write-bridge");
   assert.equal(status.plugin.version, "0.2.0");
   assert.equal(status.backend.writeEnabled, true);
+  assert.match(status.backend.bindingFingerprint, /^[a-f0-9]{64}$/u);
+  originalBindingFingerprint = status.backend.bindingFingerprint;
   const integrations =
     status.settlement?.modifiedTimeFrontmatter?.integrations ?? [];
   assert.equal(
@@ -521,8 +554,9 @@ try {
     backupPath,
     runtimeLogsPath: logsPath,
     modifiedTimePluginId: pluginId,
+    backendBindingFingerprint: originalBindingFingerprint,
     recoveryInstruction:
-      "Disable the configured modified-time plugin, then restore original-content.md only to the explicit canary note and verify SHA-256.",
+      "Verify the recorded backend binding, disable the configured modified-time plugin, then restore original-content.md only to the explicit canary note and verify SHA-256.",
   };
   writeFileSync(
     backupMetadataPath,
@@ -612,7 +646,7 @@ try {
   await atomicReplace(
     negativeSettled.sha256,
     driftedContent,
-    status.backend.bindingFingerprint,
+    originalBindingFingerprint,
   );
   const drifted = await waitForRead(
     (read) => read.content.includes(driftMarker),
@@ -630,7 +664,7 @@ try {
   await atomicReplace(
     beforeRestore.sha256,
     originalContent,
-    status.backend.bindingFingerprint,
+    originalBindingFingerprint,
   );
   const restoredRead = await atomicRead();
   assert.equal(restoredRead.sha256, originalSha256);
@@ -649,6 +683,7 @@ try {
     completedAt: new Date().toISOString(),
     canaryPath,
     bridgeVersion: status.plugin.version,
+    backendBindingFingerprint: originalBindingFingerprint,
     modifiedTimePluginId: pluginId,
     modifiedTimeProperty: propertyName,
     utcOffsetMinutes:

--- a/scripts/smoke-modified-time-settlement-live.mjs
+++ b/scripts/smoke-modified-time-settlement-live.mjs
@@ -15,12 +15,16 @@ import os from "node:os";
 import path from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import {
+  isSafeModifiedTimePropertyName,
+  nextRepresentableTimestampReadyAt,
+} from "./modified-time-canary-helpers.mjs";
 
 const canaryPath = process.env.OBSIDIAN_MODIFIED_TIME_CANARY_PATH?.trim();
 const confirmation = process.env.OBSIDIAN_MODIFIED_TIME_CANARY_CONFIRM?.trim();
 const vaultName = process.env.OBSIDIAN_MODIFIED_TIME_CANARY_VAULT?.trim();
 const propertyName =
-  process.env.OBSIDIAN_MODIFIED_TIME_CANARY_PROPERTY?.trim() ?? "modification";
+  process.env.OBSIDIAN_MODIFIED_TIME_CANARY_PROPERTY ?? "modification";
 const pluginId =
   process.env.OBSIDIAN_MODIFIED_TIME_CANARY_PLUGIN_ID?.trim() ??
   "frontmatter-date-manager";
@@ -51,7 +55,7 @@ if (!vaultName || /[&|<>\r\n]/u.test(vaultName)) {
     "OBSIDIAN_MODIFIED_TIME_CANARY_VAULT must name the open disposable vault.",
   );
 }
-if (!/^[\p{L}\p{N}_-]+$/u.test(propertyName)) {
+if (!isSafeModifiedTimePropertyName(propertyName)) {
   throw new Error("The modified-time property name is unsafe.");
 }
 if (!SUPPORTED_PLUGINS.has(pluginId)) {
@@ -94,6 +98,25 @@ function propertyValue(content) {
     `The canary note must contain exactly one top-level ${propertyName} property.`,
   );
   return matches[0].slice(prefix.length).trim();
+}
+
+async function waitForNextRepresentableTimestamp(
+  currentValue,
+  utcOffsetMinutes,
+  timeoutMs = 75_000,
+) {
+  const deadline = Date.now() + timeoutMs;
+  const readyAt = nextRepresentableTimestampReadyAt(
+    currentValue,
+    utcOffsetMinutes,
+  );
+  while (Date.now() < deadline) {
+    if (Date.now() > readyAt) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(
+    `Timed out waiting for the next representable ${propertyName} timestamp tick.`,
+  );
 }
 
 function runCli(command, ...args) {
@@ -385,6 +408,11 @@ try {
     assert.equal(toolNames.has(name), true, `${name} is not registered`);
   }
 
+  await waitForNextRepresentableTimestamp(
+    originalPropertyValue,
+    status.settlement.modifiedTimeFrontmatter.utcOffsetMinutes,
+  );
+
   const positiveMarker = `<!-- modified-time-positive:${runId} -->`;
   const positiveTarget = `${originalContent}${
     originalContent.endsWith("\n") ? "" : "\n"
@@ -420,6 +448,10 @@ try {
   // timestamp for five seconds. Cross that real runtime window before the
   // negative case so it exercises another automatic timestamp update.
   await new Promise((resolve) => setTimeout(resolve, 6_200));
+  await waitForNextRepresentableTimestamp(
+    propertyValue(positiveObserved.content),
+    status.settlement.modifiedTimeFrontmatter.utcOffsetMinutes,
+  );
   const negativeMarker = `<!-- modified-time-negative:${runId} -->`;
   const negativeTarget = `${positiveObserved.content}${
     positiveObserved.content.endsWith("\n") ? "" : "\n"

--- a/scripts/smoke-modified-time-settlement-live.mjs
+++ b/scripts/smoke-modified-time-settlement-live.mjs
@@ -33,6 +33,8 @@ const upstreamBaseUrl = (
   process.env.OBSIDIAN_BASE_URL?.trim() ?? "http://127.0.0.1:27123"
 ).replace(/\/+$/u, "");
 const writeMode = process.env.MCP_WRITE_MODE?.trim() ?? "readonly";
+const selfSignal =
+  process.env.OBSIDIAN_MODIFIED_TIME_CANARY_SELF_SIGNAL?.trim() ?? "";
 const cliCommand = process.env.OBSIDIAN_CLI_COMMAND?.trim() ?? "obsidian";
 const CONFIRMATION =
   "I_UNDERSTAND_THIS_DISPOSABLE_NOTE_WILL_BE_MUTATED_AND_RESTORED";
@@ -64,6 +66,11 @@ if (!SUPPORTED_PLUGINS.has(pluginId)) {
 if (!apiKey) throw new Error("OBSIDIAN_API_KEY is required.");
 if (!new Set(["guarded", "full"]).has(writeMode)) {
   throw new Error("The live canary requires MCP_WRITE_MODE=guarded or full.");
+}
+if (!new Set(["", "SIGTERM_AFTER_POSITIVE_APPLY"]).has(selfSignal)) {
+  throw new Error(
+    "OBSIDIAN_MODIFIED_TIME_CANARY_SELF_SIGNAL must be empty or SIGTERM_AFTER_POSITIVE_APPLY.",
+  );
 }
 
 const tempParent = os.tmpdir();
@@ -348,6 +355,142 @@ let runId;
 let evidenceFile;
 let retainedLogsPath;
 let backupMetadata;
+let cleanupPromise;
+let signalExitInProgress = false;
+
+async function cleanup() {
+  await client.close().catch(() => undefined);
+  await new Promise((resolve) => proxy.close(resolve));
+  if (originalContent !== undefined && !restored) {
+    try {
+      if (pluginEnabled()) {
+        setPluginEnabled(false);
+        pluginStateRestored = false;
+      }
+      const current = await atomicRead();
+      const status = await atomicStatus();
+      if (current.sha256 !== originalSha256) {
+        await atomicReplace(
+          current.sha256,
+          originalContent,
+          status.backend.bindingFingerprint,
+        );
+      }
+      const finalRead = await atomicRead();
+      restored =
+        finalRead.sha256 === originalSha256 &&
+        finalRead.content === originalContent;
+    } catch (restoreError) {
+      console.error(
+        JSON.stringify(
+          {
+            ok: false,
+            canaryPath,
+            restored: false,
+            evidenceDirectory: tempRoot,
+            backupPath,
+            backupMetadataPath,
+            recoveryRequired: true,
+            error:
+              restoreError instanceof Error
+                ? restoreError.message
+                : String(restoreError),
+          },
+          null,
+          2,
+        ),
+      );
+    }
+  }
+  if (originalPluginEnabled && !pluginStateRestored) {
+    try {
+      if (!pluginEnabled()) setPluginEnabled(true);
+      pluginStateRestored = true;
+      if (restored && originalContent !== undefined) {
+        await new Promise((resolve) => setTimeout(resolve, 1_500));
+        const finalRead = await atomicRead();
+        restored =
+          finalRead.sha256 === originalSha256 &&
+          finalRead.content === originalContent;
+      }
+    } catch (pluginRestoreError) {
+      console.error(
+        `Failed to restore ${pluginId}: ${
+          pluginRestoreError instanceof Error
+            ? pluginRestoreError.message
+            : String(pluginRestoreError)
+        }`,
+      );
+    }
+  }
+  if (restored && pluginStateRestored) {
+    rmSync(logsPath, { recursive: true, force: true });
+    rmSync(tempRoot, { recursive: true, force: true });
+    if (evidenceFile) {
+      console.error(`Modified-time canary evidence written to ${evidenceFile}`);
+    }
+  } else if (backupWritten) {
+    retainedLogsPath = path.join(tempRoot, "runtime-logs");
+    try {
+      renameSync(logsPath, retainedLogsPath);
+    } catch {
+      retainedLogsPath = logsPath;
+    }
+    backupMetadata.runtimeLogsPath = retainedLogsPath;
+    writeFileSync(
+      backupMetadataPath,
+      `${JSON.stringify(backupMetadata, null, 2)}\n`,
+      { encoding: "utf8", mode: 0o600 },
+    );
+    console.error(
+      `Modified-time canary recovery evidence retained at ${tempRoot}; restore only the explicit canary note from ${backupPath}.`,
+    );
+  } else {
+    rmSync(logsPath, { recursive: true, force: true });
+    rmSync(tempRoot, { recursive: true, force: true });
+    console.error(
+      "Modified-time canary failed before backup; no note recovery is required.",
+    );
+  }
+}
+
+function cleanupOnce() {
+  cleanupPromise ??= cleanup();
+  return cleanupPromise;
+}
+
+function handleSignal(signal) {
+  if (signalExitInProgress) return;
+  signalExitInProgress = true;
+  const exitCode = signal === "SIGINT" ? 130 : 143;
+  void cleanupOnce()
+    .then(() => {
+      console.error(
+        JSON.stringify({
+          ok: restored && pluginStateRestored,
+          interruptedBy: signal,
+          restored,
+          pluginStateRestored,
+        }),
+      );
+    })
+    .catch((error) => {
+      console.error(
+        `Modified-time canary cleanup failed after ${signal}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    })
+    .finally(() => process.exit(exitCode));
+}
+
+const handleSigint = () => handleSignal("SIGINT");
+const handleSigterm = () => handleSignal("SIGTERM");
+// Keep both listeners installed until cleanup completes so a repeated signal
+// cannot fall through to Node's default termination and interrupt restoration.
+process.on("SIGINT", handleSigint);
+process.on("SIGTERM", handleSigterm);
+
 try {
   originalPluginEnabled = pluginEnabled();
   assert.equal(
@@ -420,6 +563,11 @@ try {
   const positiveKey = `modified-time-live:${runId}:positive`;
   const positivePlan = await plan(positiveTarget, positiveKey);
   const positiveApply = await applyWithLostResponse(positivePlan, positiveKey);
+  if (selfSignal === "SIGTERM_AFTER_POSITIVE_APPLY") {
+    process.emit("SIGTERM", "SIGTERM");
+    process.emit("SIGTERM", "SIGTERM");
+    await new Promise(() => undefined);
+  }
   const positiveObserved = await waitForRead(
     (read) =>
       read.content.includes(positiveMarker) &&
@@ -537,97 +685,7 @@ try {
   });
   console.log(JSON.stringify({ ...evidence, evidenceFile }, null, 2));
 } finally {
-  await client.close().catch(() => undefined);
-  await new Promise((resolve) => proxy.close(resolve));
-  if (originalContent !== undefined && !restored) {
-    try {
-      if (pluginEnabled()) {
-        setPluginEnabled(false);
-        pluginStateRestored = false;
-      }
-      const current = await atomicRead();
-      const status = await atomicStatus();
-      if (current.sha256 !== originalSha256) {
-        await atomicReplace(
-          current.sha256,
-          originalContent,
-          status.backend.bindingFingerprint,
-        );
-      }
-      const finalRead = await atomicRead();
-      restored =
-        finalRead.sha256 === originalSha256 &&
-        finalRead.content === originalContent;
-    } catch (restoreError) {
-      console.error(
-        JSON.stringify(
-          {
-            ok: false,
-            canaryPath,
-            restored: false,
-            evidenceDirectory: tempRoot,
-            backupPath,
-            backupMetadataPath,
-            recoveryRequired: true,
-            error:
-              restoreError instanceof Error
-                ? restoreError.message
-                : String(restoreError),
-          },
-          null,
-          2,
-        ),
-      );
-    }
-  }
-  if (originalPluginEnabled && !pluginStateRestored) {
-    try {
-      if (!pluginEnabled()) setPluginEnabled(true);
-      pluginStateRestored = true;
-      if (restored && originalContent !== undefined) {
-        await new Promise((resolve) => setTimeout(resolve, 1_500));
-        const finalRead = await atomicRead();
-        restored =
-          finalRead.sha256 === originalSha256 &&
-          finalRead.content === originalContent;
-      }
-    } catch (pluginRestoreError) {
-      console.error(
-        `Failed to restore ${pluginId}: ${
-          pluginRestoreError instanceof Error
-            ? pluginRestoreError.message
-            : String(pluginRestoreError)
-        }`,
-      );
-    }
-  }
-  if (restored && pluginStateRestored) {
-    rmSync(logsPath, { recursive: true, force: true });
-    rmSync(tempRoot, { recursive: true, force: true });
-    if (evidenceFile) {
-      console.error(`Modified-time canary evidence written to ${evidenceFile}`);
-    }
-  } else if (backupWritten) {
-    retainedLogsPath = path.join(tempRoot, "runtime-logs");
-    try {
-      renameSync(logsPath, retainedLogsPath);
-    } catch {
-      retainedLogsPath = logsPath;
-    }
-    backupMetadata.runtimeLogsPath = retainedLogsPath;
-    writeFileSync(
-      backupMetadataPath,
-      `${JSON.stringify(backupMetadata, null, 2)}\n`,
-      { encoding: "utf8", mode: 0o600 },
-    );
-    console.error(
-      `Modified-time canary recovery evidence retained at ${tempRoot}; restore only the explicit canary note from ${backupPath}.`,
-    );
-  } else {
-    rmSync(logsPath, { recursive: true, force: true });
-    rmSync(tempRoot, { recursive: true, force: true });
-    console.error(
-      "Modified-time canary failed before backup; no note recovery is required.",
-    );
-  }
+  await cleanupOnce();
+  process.off("SIGINT", handleSigint);
+  process.off("SIGTERM", handleSigterm);
 }

--- a/scripts/smoke-modified-time-settlement-live.mjs
+++ b/scripts/smoke-modified-time-settlement-live.mjs
@@ -1,0 +1,601 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  mkdirSync,
+  mkdtempSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { createServer } from "node:http";
+import os from "node:os";
+import path from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const canaryPath = process.env.OBSIDIAN_MODIFIED_TIME_CANARY_PATH?.trim();
+const confirmation = process.env.OBSIDIAN_MODIFIED_TIME_CANARY_CONFIRM?.trim();
+const vaultName = process.env.OBSIDIAN_MODIFIED_TIME_CANARY_VAULT?.trim();
+const propertyName =
+  process.env.OBSIDIAN_MODIFIED_TIME_CANARY_PROPERTY?.trim() ?? "modification";
+const pluginId =
+  process.env.OBSIDIAN_MODIFIED_TIME_CANARY_PLUGIN_ID?.trim() ??
+  "frontmatter-date-manager";
+const apiKey = process.env.OBSIDIAN_API_KEY?.trim();
+const upstreamBaseUrl = (
+  process.env.OBSIDIAN_BASE_URL?.trim() ?? "http://127.0.0.1:27123"
+).replace(/\/+$/u, "");
+const writeMode = process.env.MCP_WRITE_MODE?.trim() ?? "readonly";
+const cliCommand = process.env.OBSIDIAN_CLI_COMMAND?.trim() ?? "obsidian";
+const CONFIRMATION =
+  "I_UNDERSTAND_THIS_DISPOSABLE_NOTE_WILL_BE_MUTATED_AND_RESTORED";
+const SUPPORTED_PLUGINS = new Set([
+  "frontmatter-date-manager",
+  "update-time",
+  "update-time-on-edit",
+]);
+
+if (!canaryPath?.toLowerCase().endsWith(".md")) {
+  throw new Error(
+    "OBSIDIAN_MODIFIED_TIME_CANARY_PATH must name one existing disposable Markdown note.",
+  );
+}
+if (confirmation !== CONFIRMATION) {
+  throw new Error(`Set OBSIDIAN_MODIFIED_TIME_CANARY_CONFIRM=${CONFIRMATION}.`);
+}
+if (!vaultName || /[&|<>\r\n]/u.test(vaultName)) {
+  throw new Error(
+    "OBSIDIAN_MODIFIED_TIME_CANARY_VAULT must name the open disposable vault.",
+  );
+}
+if (!/^[\p{L}\p{N}_-]+$/u.test(propertyName)) {
+  throw new Error("The modified-time property name is unsafe.");
+}
+if (!SUPPORTED_PLUGINS.has(pluginId)) {
+  throw new Error("The modified-time plugin is not supported by this canary.");
+}
+if (!apiKey) throw new Error("OBSIDIAN_API_KEY is required.");
+if (!new Set(["guarded", "full"]).has(writeMode)) {
+  throw new Error("The live canary requires MCP_WRITE_MODE=guarded or full.");
+}
+
+const tempParent = os.tmpdir();
+const tempRoot = mkdtempSync(
+  path.join(tempParent, "optimike-modified-time-live-"),
+);
+const journalPath = path.join(tempRoot, "note-replace.sqlite");
+const backupPath = path.join(tempRoot, "original-content.md");
+const backupMetadataPath = path.join(tempRoot, "original-content.json");
+const transientLogsParent = path.join(
+  process.cwd(),
+  "logs",
+  "modified-time-live",
+);
+mkdirSync(transientLogsParent, { recursive: true });
+const logsPath = mkdtempSync(path.join(transientLogsParent, "run-"));
+console.error(`Modified-time canary recovery directory: ${tempRoot}`);
+console.error(`Modified-time canary transient runtime logs: ${logsPath}`);
+
+function sha256(content) {
+  return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+function propertyValue(content) {
+  const prefix = `${propertyName}:`;
+  const matches = content
+    .split(/\r?\n/u)
+    .filter((line) => line.startsWith(prefix));
+  assert.equal(
+    matches.length,
+    1,
+    `The canary note must contain exactly one top-level ${propertyName} property.`,
+  );
+  return matches[0].slice(prefix.length).trim();
+}
+
+function runCli(command, ...args) {
+  const result = spawnSync(
+    cliCommand,
+    [`vault=${vaultName}`, command, ...args],
+    {
+      encoding: "utf8",
+      windowsHide: true,
+    },
+  );
+  if (result.error || result.status !== 0) {
+    throw new Error(
+      `Obsidian CLI ${command} failed: ${
+        result.error?.message || result.stderr || result.stdout || result.status
+      }`,
+    );
+  }
+  return `${result.stdout ?? ""}${result.stderr ?? ""}`;
+}
+
+function pluginEnabled() {
+  return /enabled\s+true/iu.test(runCli("plugin", `id=${pluginId}`));
+}
+
+function setPluginEnabled(enabled) {
+  runCli(enabled ? "plugin:enable" : "plugin:disable", `id=${pluginId}`);
+  assert.equal(pluginEnabled(), enabled);
+}
+
+async function directRequest(route, { method = "GET", payload } = {}) {
+  const response = await fetch(`${upstreamBaseUrl}${route}`, {
+    method,
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      ...(payload ? { "Content-Type": "application/json" } : {}),
+    },
+    ...(payload ? { body: JSON.stringify(payload) } : {}),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(
+      `Live Bridge request failed with HTTP ${response.status}: ${text.slice(0, 500)}`,
+    );
+  }
+  return JSON.parse(text);
+}
+
+async function atomicStatus() {
+  return directRequest("/extensions/obsidian-atomic-write-bridge/status");
+}
+
+async function atomicRead() {
+  return directRequest("/extensions/obsidian-atomic-write-bridge/notes/read", {
+    method: "POST",
+    payload: { contractVersion: 1, path: canaryPath },
+  });
+}
+
+async function atomicReplace(expectedSha256, nextContent, bindingFingerprint) {
+  return directRequest("/extensions/obsidian-atomic-write-bridge/notes/cas", {
+    method: "POST",
+    payload: {
+      contractVersion: 1,
+      path: canaryPath,
+      bindingFingerprint,
+      expectedSha256,
+      nextContent,
+    },
+  });
+}
+
+async function waitForRead(predicate, label, timeoutMs = 15_000) {
+  const deadline = Date.now() + timeoutMs;
+  let last;
+  while (Date.now() < deadline) {
+    last = await atomicRead();
+    if (predicate(last)) return last;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(
+    `Timed out waiting for ${label}; last SHA-256 was ${last?.sha256 ?? "unavailable"}.`,
+  );
+}
+
+let dropNextCasResponse = false;
+let dropNextReconciliationRead = false;
+let droppedCasResponses = 0;
+let droppedReconciliationReads = 0;
+const proxy = createServer(async (request, response) => {
+  try {
+    const chunks = [];
+    for await (const chunk of request) chunks.push(chunk);
+    const body = Buffer.concat(chunks);
+    const target = new URL(request.url ?? "/", `${upstreamBaseUrl}/`);
+    if (
+      dropNextReconciliationRead &&
+      target.pathname === "/extensions/obsidian-atomic-write-bridge/notes/read"
+    ) {
+      dropNextReconciliationRead = false;
+      droppedReconciliationReads += 1;
+      request.socket.destroy();
+      return;
+    }
+    const headers = { ...request.headers };
+    delete headers.host;
+    delete headers["content-length"];
+    const upstream = await fetch(target, {
+      method: request.method,
+      headers,
+      ...(!new Set(["GET", "HEAD"]).has(request.method ?? "GET")
+        ? { body }
+        : {}),
+    });
+    const upstreamBody = Buffer.from(await upstream.arrayBuffer());
+    if (
+      dropNextCasResponse &&
+      target.pathname === "/extensions/obsidian-atomic-write-bridge/notes/cas"
+    ) {
+      dropNextCasResponse = false;
+      dropNextReconciliationRead = true;
+      droppedCasResponses += 1;
+      request.socket.destroy();
+      return;
+    }
+    response.statusCode = upstream.status;
+    const contentType = upstream.headers.get("content-type");
+    if (contentType) response.setHeader("content-type", contentType);
+    response.end(upstreamBody);
+  } catch (error) {
+    if (!response.headersSent) {
+      response.statusCode = 502;
+      response.setHeader("content-type", "application/json");
+    }
+    response.end(
+      JSON.stringify({
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
+  }
+});
+
+await new Promise((resolve, reject) => {
+  proxy.once("error", reject);
+  proxy.listen(0, "127.0.0.1", resolve);
+});
+const proxyAddress = proxy.address();
+assert.equal(typeof proxyAddress, "object");
+const proxyBaseUrl = `http://127.0.0.1:${proxyAddress.port}`;
+
+const protectedKeys = new Set(
+  (process.env.MCP_PROTECTED_FRONTMATTER_KEYS ?? "création,modification")
+    .split(",")
+    .map((key) => key.trim())
+    .filter(Boolean),
+);
+protectedKeys.add(propertyName);
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: ["dist/index.js"],
+  cwd: process.cwd(),
+  env: {
+    ...process.env,
+    NODE_ENV: "production",
+    MCP_TRANSPORT_TYPE: "stdio",
+    MCP_WRITE_MODE: writeMode,
+    MCP_PROTECTED_FRONTMATTER_KEYS: [...protectedKeys].join(","),
+    MCP_OBSIDIAN_NOTE_REPLACE_JOURNAL_PATH: journalPath,
+    LOGS_DIR: logsPath,
+    OBSIDIAN_RUNTIME_MODE: "live",
+    OBSIDIAN_API_KEY: apiKey,
+    OBSIDIAN_BASE_URL: proxyBaseUrl,
+    SEMANTIC_SEARCH_PREWARM: "false",
+  },
+  stderr: "inherit",
+});
+const client = new Client(
+  { name: "optimike-modified-time-live-canary", version: "1.0.0" },
+  { capabilities: {} },
+);
+
+function parse(result) {
+  const text = result.content
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("\n");
+  const payload = JSON.parse(text || "null");
+  if (result.isError) {
+    throw new Error(
+      payload?.error?.message ?? `MCP tool failed: ${JSON.stringify(payload)}`,
+    );
+  }
+  return payload;
+}
+
+async function call(name, args) {
+  return parse(await client.callTool({ name, arguments: args }));
+}
+
+async function plan(nextContent, idempotencyKey) {
+  const receipt = await call("obsidian_note_replace_plan", {
+    path: canaryPath,
+    nextContent,
+    idempotencyKey,
+  });
+  assert.equal(receipt.phase, "planned");
+  return receipt;
+}
+
+async function applyWithLostResponse(receipt, idempotencyKey) {
+  dropNextCasResponse = true;
+  const result = await call("obsidian_note_replace_apply", {
+    planRef: receipt.planRef,
+    idempotencyKey,
+  });
+  assert.equal(result.outcome, "outcome_unknown");
+  assert.equal(dropNextCasResponse, false);
+  assert.equal(dropNextReconciliationRead, false);
+  return result;
+}
+
+let originalContent;
+let originalSha256;
+let restored = false;
+let backupWritten = false;
+let originalPluginEnabled = false;
+let pluginStateRestored = false;
+let runId;
+let evidenceFile;
+let retainedLogsPath;
+let backupMetadata;
+try {
+  originalPluginEnabled = pluginEnabled();
+  assert.equal(
+    originalPluginEnabled,
+    true,
+    `${pluginId} must be enabled before the canary starts.`,
+  );
+  const status = await atomicStatus();
+  assert.equal(status.plugin.id, "obsidian-atomic-write-bridge");
+  assert.equal(status.plugin.version, "0.2.0");
+  assert.equal(status.backend.writeEnabled, true);
+  const integrations =
+    status.settlement?.modifiedTimeFrontmatter?.integrations ?? [];
+  assert.equal(
+    integrations.some(
+      (integration) =>
+        integration.pluginId === pluginId &&
+        integration.propertyName === propertyName,
+    ),
+    true,
+    "The Bridge did not advertise the expected modified-time integration.",
+  );
+
+  const original = await atomicRead();
+  originalContent = original.content;
+  originalSha256 = original.sha256;
+  assert.equal(originalSha256, sha256(originalContent));
+  const originalPropertyValue = propertyValue(originalContent);
+  runId = randomUUID();
+  writeFileSync(backupPath, originalContent, { encoding: "utf8", mode: 0o600 });
+  backupMetadata = {
+    canaryPath,
+    vaultName,
+    createdAt: new Date().toISOString(),
+    sha256: originalSha256,
+    backupPath,
+    runtimeLogsPath: logsPath,
+    modifiedTimePluginId: pluginId,
+    recoveryInstruction:
+      "Disable the configured modified-time plugin, then restore original-content.md only to the explicit canary note and verify SHA-256.",
+  };
+  writeFileSync(
+    backupMetadataPath,
+    `${JSON.stringify(backupMetadata, null, 2)}\n`,
+    { encoding: "utf8", mode: 0o600 },
+  );
+  backupWritten = true;
+
+  await client.connect(transport);
+  const { tools } = await client.listTools();
+  const toolNames = new Set(tools.map((tool) => tool.name));
+  for (const name of [
+    "obsidian_note_replace_plan",
+    "obsidian_note_replace_apply",
+    "obsidian_note_replace_status",
+    "obsidian_note_replace_recover",
+  ]) {
+    assert.equal(toolNames.has(name), true, `${name} is not registered`);
+  }
+
+  const positiveMarker = `<!-- modified-time-positive:${runId} -->`;
+  const positiveTarget = `${originalContent}${
+    originalContent.endsWith("\n") ? "" : "\n"
+  }\n${positiveMarker}\n`;
+  const positiveKey = `modified-time-live:${runId}:positive`;
+  const positivePlan = await plan(positiveTarget, positiveKey);
+  const positiveApply = await applyWithLostResponse(positivePlan, positiveKey);
+  const positiveObserved = await waitForRead(
+    (read) =>
+      read.content.includes(positiveMarker) &&
+      propertyValue(read.content) !== originalPropertyValue,
+    "the supported plugin to advance the modified-time property",
+  );
+  const positiveStatus = await call("obsidian_note_replace_status", {
+    planRef: positivePlan.planRef,
+  });
+  assert.equal(positiveStatus.outcome, "committed");
+  assert.equal(
+    positiveStatus.afterProof.details.sealedSha256,
+    sha256(positiveTarget),
+  );
+  assert.equal(
+    positiveStatus.afterProof.details.sha256,
+    positiveObserved.sha256,
+  );
+  assert.equal(
+    positiveStatus.afterProof.details.settlementPropertyName,
+    propertyName,
+  );
+  assert.equal(positiveStatus.afterProof.details.settlementPluginId, pluginId);
+
+  // Frontmatter Date Manager deliberately ignores its own freshly written
+  // timestamp for five seconds. Cross that real runtime window before the
+  // negative case so it exercises another automatic timestamp update.
+  await new Promise((resolve) => setTimeout(resolve, 6_200));
+  const negativeMarker = `<!-- modified-time-negative:${runId} -->`;
+  const negativeTarget = `${positiveObserved.content}${
+    positiveObserved.content.endsWith("\n") ? "" : "\n"
+  }\n${negativeMarker}\n`;
+  const negativeKey = `modified-time-live:${runId}:negative`;
+  const negativePlan = await plan(negativeTarget, negativeKey);
+  const negativeApply = await applyWithLostResponse(negativePlan, negativeKey);
+  const negativeSettled = await waitForRead(
+    (read) =>
+      read.content.includes(negativeMarker) &&
+      propertyValue(read.content) !== propertyValue(positiveObserved.content),
+    "the negative case modified-time settlement",
+  );
+  const driftMarker = `<!-- unauthorized-body-drift:${runId} -->`;
+  const driftedContent = `${negativeSettled.content}${
+    negativeSettled.content.endsWith("\n") ? "" : "\n"
+  }\n${driftMarker}\n`;
+  await atomicReplace(
+    negativeSettled.sha256,
+    driftedContent,
+    status.backend.bindingFingerprint,
+  );
+  const drifted = await waitForRead(
+    (read) => read.content.includes(driftMarker),
+    "the deliberate body drift",
+  );
+  const negativeStatus = await call("obsidian_note_replace_status", {
+    planRef: negativePlan.planRef,
+  });
+  assert.equal(negativeStatus.outcome, "outcome_unknown");
+  assert.equal(negativeStatus.afterProof, undefined);
+  assert.equal(negativeStatus.recoveryAllowed, true);
+
+  setPluginEnabled(false);
+  const beforeRestore = await atomicRead();
+  await atomicReplace(
+    beforeRestore.sha256,
+    originalContent,
+    status.backend.bindingFingerprint,
+  );
+  const restoredRead = await atomicRead();
+  assert.equal(restoredRead.sha256, originalSha256);
+  assert.equal(restoredRead.content, originalContent);
+  setPluginEnabled(true);
+  pluginStateRestored = true;
+  await new Promise((resolve) => setTimeout(resolve, 1_500));
+  const finalRead = await atomicRead();
+  assert.equal(finalRead.sha256, originalSha256);
+  assert.equal(finalRead.content, originalContent);
+  restored = true;
+
+  const evidence = {
+    ok: true,
+    runId,
+    completedAt: new Date().toISOString(),
+    canaryPath,
+    bridgeVersion: status.plugin.version,
+    modifiedTimePluginId: pluginId,
+    modifiedTimeProperty: propertyName,
+    utcOffsetMinutes:
+      status.settlement.modifiedTimeFrontmatter.utcOffsetMinutes,
+    droppedCasResponses,
+    droppedReconciliationReads,
+    positiveApplyOutcome: positiveApply.outcome,
+    positiveStatusOutcome: positiveStatus.outcome,
+    positiveSealedSha256: sha256(positiveTarget),
+    positiveObservedSha256: positiveObserved.sha256,
+    negativeApplyOutcome: negativeApply.outcome,
+    negativeStatusOutcome: negativeStatus.outcome,
+    negativeObservedSha256: drifted.sha256,
+    originalSha256,
+    finalSha256: finalRead.sha256,
+    restored,
+    pluginStateRestored,
+  };
+  evidenceFile = path.join(
+    tempParent,
+    `modified-time-live-evidence-${runId}.json`,
+  );
+  writeFileSync(evidenceFile, `${JSON.stringify(evidence, null, 2)}\n`, {
+    encoding: "utf8",
+    mode: 0o600,
+  });
+  console.log(JSON.stringify({ ...evidence, evidenceFile }, null, 2));
+} finally {
+  await client.close().catch(() => undefined);
+  await new Promise((resolve) => proxy.close(resolve));
+  if (originalContent !== undefined && !restored) {
+    try {
+      if (pluginEnabled()) {
+        setPluginEnabled(false);
+        pluginStateRestored = false;
+      }
+      const current = await atomicRead();
+      const status = await atomicStatus();
+      if (current.sha256 !== originalSha256) {
+        await atomicReplace(
+          current.sha256,
+          originalContent,
+          status.backend.bindingFingerprint,
+        );
+      }
+      const finalRead = await atomicRead();
+      restored =
+        finalRead.sha256 === originalSha256 &&
+        finalRead.content === originalContent;
+    } catch (restoreError) {
+      console.error(
+        JSON.stringify(
+          {
+            ok: false,
+            canaryPath,
+            restored: false,
+            evidenceDirectory: tempRoot,
+            backupPath,
+            backupMetadataPath,
+            recoveryRequired: true,
+            error:
+              restoreError instanceof Error
+                ? restoreError.message
+                : String(restoreError),
+          },
+          null,
+          2,
+        ),
+      );
+    }
+  }
+  if (originalPluginEnabled && !pluginStateRestored) {
+    try {
+      if (!pluginEnabled()) setPluginEnabled(true);
+      pluginStateRestored = true;
+      if (restored && originalContent !== undefined) {
+        await new Promise((resolve) => setTimeout(resolve, 1_500));
+        const finalRead = await atomicRead();
+        restored =
+          finalRead.sha256 === originalSha256 &&
+          finalRead.content === originalContent;
+      }
+    } catch (pluginRestoreError) {
+      console.error(
+        `Failed to restore ${pluginId}: ${
+          pluginRestoreError instanceof Error
+            ? pluginRestoreError.message
+            : String(pluginRestoreError)
+        }`,
+      );
+    }
+  }
+  if (restored && pluginStateRestored) {
+    rmSync(logsPath, { recursive: true, force: true });
+    rmSync(tempRoot, { recursive: true, force: true });
+    if (evidenceFile) {
+      console.error(`Modified-time canary evidence written to ${evidenceFile}`);
+    }
+  } else if (backupWritten) {
+    retainedLogsPath = path.join(tempRoot, "runtime-logs");
+    try {
+      renameSync(logsPath, retainedLogsPath);
+    } catch {
+      retainedLogsPath = logsPath;
+    }
+    backupMetadata.runtimeLogsPath = retainedLogsPath;
+    writeFileSync(
+      backupMetadataPath,
+      `${JSON.stringify(backupMetadata, null, 2)}\n`,
+      { encoding: "utf8", mode: 0o600 },
+    );
+    console.error(
+      `Modified-time canary recovery evidence retained at ${tempRoot}; restore only the explicit canary note from ${backupPath}.`,
+    );
+  } else {
+    rmSync(logsPath, { recursive: true, force: true });
+    rmSync(tempRoot, { recursive: true, force: true });
+    console.error(
+      "Modified-time canary failed before backup; no note recovery is required.",
+    );
+  }
+}

--- a/scripts/test-doc-contract.mjs
+++ b/scripts/test-doc-contract.mjs
@@ -106,8 +106,8 @@ assert.match(matrixFr, /\| Admin filesystem\s+\| Non\s+\| Non/);
 const packageJson = JSON.parse(await text("package.json"));
 assert.equal(
   packageJson.version,
-  "2.8.1",
-  "released package metadata must match the 2.8.1 canary-boundary patch",
+  "2.8.2",
+  "released package metadata must match the 2.8.2 modified-time settlement patch",
 );
 assert.equal(packageJson.scripts["start:http"], "node scripts/run-http.mjs");
 assert.equal(packageJson.scripts["start:daemon"], "node scripts/run-http.mjs");

--- a/scripts/test-governed-note-doc-contract.mjs
+++ b/scripts/test-governed-note-doc-contract.mjs
@@ -202,6 +202,8 @@ assert.match(bridgeReadme, /Update Time/i);
 assert.match(bridgeReadme, /comma-delimited fail-closed list/i);
 assert.match(contract, /never advertises[\s\S]*contains a comma/i);
 assert.match(contractFr, /n.annonce[\s\S]*contient une virgule/i);
+assert.match(contract, /128 JavaScript string code units/i);
+assert.doesNotMatch(contract, /128-byte/i);
 assert.match(
   security,
   /Supported modified-time plugins do not weaken that CAS/i,

--- a/scripts/test-governed-note-doc-contract.mjs
+++ b/scripts/test-governed-note-doc-contract.mjs
@@ -32,6 +32,9 @@ const bridgeReadme = await text(
   "plugins/obsidian-atomic-write-bridge/README.md",
 );
 const liveCanary = await text("scripts/smoke-atomic-note-mcp-live.mjs");
+const modifiedTimeLiveCanary = await text(
+  "scripts/smoke-modified-time-settlement-live.mjs",
+);
 const operations = await text("OPERATIONS.md");
 const operationsFr = await text("OPERATIONS.fr.md");
 const security = await text("SECURITY.md");
@@ -73,6 +76,10 @@ assert.equal(
 assert.equal(
   pkg.scripts["smoke:atomic-note-mcp-live"],
   "npm run build && node scripts/smoke-atomic-note-mcp-live.mjs",
+);
+assert.equal(
+  pkg.scripts["smoke:modified-time-settlement-live"],
+  "npm run build && node scripts/smoke-modified-time-settlement-live.mjs",
 );
 assert.equal(
   pkg.scripts["test:governed-note-replace-http"],
@@ -204,10 +211,31 @@ assert.match(
   operationsFr,
   /dérive supplémentaire du[\s\S]*corps ou du frontmatter/i,
 );
+assert.match(operations, /smoke:modified-time-settlement-live/);
+assert.match(operationsFr, /smoke:modified-time-settlement-live/);
+assert.match(modifiedTimeLiveCanary, /os\.tmpdir\(\)/);
+assert.match(modifiedTimeLiveCanary, /dropNextCasResponse/);
+assert.match(modifiedTimeLiveCanary, /dropNextReconciliationRead/);
+assert.match(modifiedTimeLiveCanary, /positiveStatus\.outcome, "committed"/);
+assert.match(
+  modifiedTimeLiveCanary,
+  /negativeStatus\.outcome, "outcome_unknown"/,
+);
+assert.match(modifiedTimeLiveCanary, /finalRead\.sha256, originalSha256/);
+assert.ok(
+  modifiedTimeLiveCanary.indexOf("const finalRead = await atomicRead();") <
+    modifiedTimeLiveCanary.indexOf("restored = true;"),
+  "restoration authority must follow the final post-plugin hash read",
+);
+assert.doesNotMatch(
+  modifiedTimeLiveCanary,
+  /path\.join\(process\.cwd\(\), ["']\.tmp["']\)/,
+);
 
 await access("scripts/test-governed-note-replace-mcp.mjs");
 await access("scripts/test-governed-note-replace-http.mjs");
 await access("scripts/smoke-atomic-note-mcp-live.mjs");
+await access("scripts/smoke-modified-time-settlement-live.mjs");
 assert.match(
   liveCanary,
   /transientLogsParent[\s\S]*process\.cwd\(\)[\s\S]*["']logs["'][\s\S]*mkdtempSync/,

--- a/scripts/test-governed-note-doc-contract.mjs
+++ b/scripts/test-governed-note-doc-contract.mjs
@@ -35,6 +35,9 @@ const liveCanary = await text("scripts/smoke-atomic-note-mcp-live.mjs");
 const modifiedTimeLiveCanary = await text(
   "scripts/smoke-modified-time-settlement-live.mjs",
 );
+const modifiedTimeCanaryHelpers = await text(
+  "scripts/modified-time-canary-helpers.mjs",
+);
 const operations = await text("OPERATIONS.md");
 const operationsFr = await text("OPERATIONS.fr.md");
 const security = await text("SECURITY.md");
@@ -216,6 +219,15 @@ assert.match(operationsFr, /smoke:modified-time-settlement-live/);
 assert.match(modifiedTimeLiveCanary, /os\.tmpdir\(\)/);
 assert.match(modifiedTimeLiveCanary, /dropNextCasResponse/);
 assert.match(modifiedTimeLiveCanary, /dropNextReconciliationRead/);
+assert.match(modifiedTimeLiveCanary, /waitForNextRepresentableTimestamp/);
+assert.match(modifiedTimeCanaryHelpers, /\[\\r\\n:\]/);
+assert.doesNotMatch(modifiedTimeCanaryHelpers, /\\p\{L\}.*\\p\{N\}/);
+assert.match(modifiedTimeCanaryHelpers, /representableTickMs/);
+assert.match(modifiedTimeCanaryHelpers, /60_000/);
+assert.match(
+  pkg.scripts["check:atomic-write"],
+  /test-modified-time-canary-helpers/,
+);
 assert.match(modifiedTimeLiveCanary, /positiveStatus\.outcome, "committed"/);
 assert.match(
   modifiedTimeLiveCanary,
@@ -236,6 +248,8 @@ await access("scripts/test-governed-note-replace-mcp.mjs");
 await access("scripts/test-governed-note-replace-http.mjs");
 await access("scripts/smoke-atomic-note-mcp-live.mjs");
 await access("scripts/smoke-modified-time-settlement-live.mjs");
+await access("scripts/modified-time-canary-helpers.mjs");
+await access("scripts/test-modified-time-canary-helpers.mjs");
 assert.match(
   liveCanary,
   /transientLogsParent[\s\S]*process\.cwd\(\)[\s\S]*["']logs["'][\s\S]*mkdtempSync/,

--- a/scripts/test-governed-note-doc-contract.mjs
+++ b/scripts/test-governed-note-doc-contract.mjs
@@ -253,6 +253,15 @@ assert.doesNotMatch(
   modifiedTimeLiveCanary,
   /path\.join\(process\.cwd\(\), ["']\.tmp["']\)/,
 );
+assert.match(modifiedTimeLiveCanary, /process\.on\("SIGINT", handleSigint\)/);
+assert.match(modifiedTimeLiveCanary, /process\.on\("SIGTERM", handleSigterm\)/);
+assert.match(modifiedTimeLiveCanary, /function cleanupOnce\(\)/);
+assert.match(
+  modifiedTimeLiveCanary,
+  /finally \{[\s\S]*await cleanupOnce\(\);[\s\S]*process\.off\("SIGINT"/,
+);
+assert.match(operations, /SELF_SIGNAL=SIGTERM_AFTER_POSITIVE_APPLY/);
+assert.match(operationsFr, /SELF_SIGNAL=SIGTERM_AFTER_POSITIVE_APPLY/);
 
 await access("scripts/test-governed-note-replace-mcp.mjs");
 await access("scripts/test-governed-note-replace-http.mjs");

--- a/scripts/test-governed-note-doc-contract.mjs
+++ b/scripts/test-governed-note-doc-contract.mjs
@@ -199,6 +199,9 @@ assert.match(adr, /never\s+ignores a field\s+globally/i);
 assert.match(bridgeReadme, /Version 0\.2\.0/i);
 assert.match(bridgeReadme, /Frontmatter Date Manager/i);
 assert.match(bridgeReadme, /Update Time/i);
+assert.match(bridgeReadme, /comma-delimited fail-closed list/i);
+assert.match(contract, /never advertises[\s\S]*contains a comma/i);
+assert.match(contractFr, /n.annonce[\s\S]*contient une virgule/i);
 assert.match(
   security,
   /Supported modified-time plugins do not weaken that CAS/i,
@@ -220,7 +223,7 @@ assert.match(modifiedTimeLiveCanary, /os\.tmpdir\(\)/);
 assert.match(modifiedTimeLiveCanary, /dropNextCasResponse/);
 assert.match(modifiedTimeLiveCanary, /dropNextReconciliationRead/);
 assert.match(modifiedTimeLiveCanary, /waitForNextRepresentableTimestamp/);
-assert.match(modifiedTimeCanaryHelpers, /\[\\r\\n:\]/);
+assert.match(modifiedTimeCanaryHelpers, /\[,\\r\\n:\]/);
 assert.doesNotMatch(modifiedTimeCanaryHelpers, /\\p\{L\}.*\\p\{N\}/);
 assert.match(modifiedTimeCanaryHelpers, /representableTickMs/);
 assert.match(modifiedTimeCanaryHelpers, /60_000/);

--- a/scripts/test-governed-note-doc-contract.mjs
+++ b/scripts/test-governed-note-doc-contract.mjs
@@ -258,6 +258,14 @@ assert.match(modifiedTimeLiveCanary, /process\.on\("SIGTERM", handleSigterm\)/);
 assert.match(modifiedTimeLiveCanary, /function cleanupOnce\(\)/);
 assert.match(
   modifiedTimeLiveCanary,
+  /status\.backend\.bindingFingerprint !== originalBindingFingerprint/,
+);
+assert.match(
+  modifiedTimeLiveCanary,
+  /current\.sha256,[\s\S]*originalContent,[\s\S]*originalBindingFingerprint/,
+);
+assert.match(
+  modifiedTimeLiveCanary,
   /finally \{[\s\S]*await cleanupOnce\(\);[\s\S]*process\.off\("SIGINT"/,
 );
 assert.match(operations, /SELF_SIGNAL=SIGTERM_AFTER_POSITIVE_APPLY/);

--- a/scripts/test-governed-note-doc-contract.mjs
+++ b/scripts/test-governed-note-doc-contract.mjs
@@ -200,10 +200,15 @@ assert.match(bridgeReadme, /Version 0\.2\.0/i);
 assert.match(bridgeReadme, /Frontmatter Date Manager/i);
 assert.match(bridgeReadme, /Update Time/i);
 assert.match(bridgeReadme, /comma-delimited fail-closed list/i);
+assert.match(bridgeReadme, /128 JavaScript string code units/i);
+assert.match(bridgeReadme, /source-stable plain YAML property names/i);
 assert.match(contract, /never advertises[\s\S]*contains a comma/i);
 assert.match(contractFr, /n.annonce[\s\S]*contient une virgule/i);
 assert.match(contract, /128 JavaScript string code units/i);
 assert.doesNotMatch(contract, /128-byte/i);
+assert.match(contract, /quoted forms such as `#modified`/i);
+assert.match(contractFr, /128 unités de code de chaîne JavaScript/i);
+assert.match(contractFr, /formes quotées comme `#modified`/i);
 assert.match(
   security,
   /Supported modified-time plugins do not weaken that CAS/i,
@@ -226,7 +231,7 @@ assert.match(modifiedTimeLiveCanary, /dropNextCasResponse/);
 assert.match(modifiedTimeLiveCanary, /dropNextReconciliationRead/);
 assert.match(modifiedTimeLiveCanary, /waitForNextRepresentableTimestamp/);
 assert.match(modifiedTimeCanaryHelpers, /\[,\\r\\n:\]/);
-assert.doesNotMatch(modifiedTimeCanaryHelpers, /\\p\{L\}.*\\p\{N\}/);
+assert.match(modifiedTimeCanaryHelpers, /\\p\{L\}.*\\p\{M\}.*\\p\{N\}/);
 assert.match(modifiedTimeCanaryHelpers, /representableTickMs/);
 assert.match(modifiedTimeCanaryHelpers, /60_000/);
 assert.match(

--- a/scripts/test-governed-note-doc-contract.mjs
+++ b/scripts/test-governed-note-doc-contract.mjs
@@ -256,6 +256,16 @@ assert.doesNotMatch(
 assert.match(modifiedTimeLiveCanary, /process\.on\("SIGINT", handleSigint\)/);
 assert.match(modifiedTimeLiveCanary, /process\.on\("SIGTERM", handleSigterm\)/);
 assert.match(modifiedTimeLiveCanary, /function cleanupOnce\(\)/);
+assert.match(modifiedTimeLiveCanary, /function trackMutation\(promise/);
+assert.match(modifiedTimeLiveCanary, /quiesceActiveMutation/);
+assert.match(
+  modifiedTimeLiveCanary,
+  /mutationQuiesced = await quiesceActiveMutation\(\);[\s\S]*await client\.close/,
+);
+assert.match(
+  modifiedTimeLiveCanary,
+  /mutationQuiesced &&[\s\S]*originalContent !== undefined/,
+);
 assert.match(
   modifiedTimeLiveCanary,
   /status\.backend\.bindingFingerprint !== originalBindingFingerprint/,
@@ -268,8 +278,12 @@ assert.match(
   modifiedTimeLiveCanary,
   /finally \{[\s\S]*await cleanupOnce\(\);[\s\S]*process\.off\("SIGINT"/,
 );
-assert.match(operations, /SELF_SIGNAL=SIGTERM_AFTER_POSITIVE_APPLY/);
-assert.match(operationsFr, /SELF_SIGNAL=SIGTERM_AFTER_POSITIVE_APPLY/);
+assert.match(operations, /SELF_SIGNAL=SIGTERM_DURING_POSITIVE_APPLY/);
+assert.match(operationsFr, /SELF_SIGNAL=SIGTERM_DURING_POSITIVE_APPLY/);
+assert.match(
+  modifiedTimeLiveCanary,
+  /signalDuringPositiveApply[\s\S]*request\.socket\.destroy\(\);[\s\S]*process\.emit\("SIGTERM"/,
+);
 
 await access("scripts/test-governed-note-replace-mcp.mjs");
 await access("scripts/test-governed-note-replace-http.mjs");

--- a/scripts/test-modified-time-canary-helpers.mjs
+++ b/scripts/test-modified-time-canary-helpers.mjs
@@ -10,6 +10,7 @@ assert.equal(isSafeModifiedTimePropertyName("modified.at"), true);
 assert.equal(isSafeModifiedTimePropertyName(" modified"), false);
 assert.equal(isSafeModifiedTimePropertyName("modified "), false);
 assert.equal(isSafeModifiedTimePropertyName("modified:at"), false);
+assert.equal(isSafeModifiedTimePropertyName("modified,time"), false);
 assert.equal(isSafeModifiedTimePropertyName("modified\nat"), false);
 assert.equal(isSafeModifiedTimePropertyName("x".repeat(129)), false);
 

--- a/scripts/test-modified-time-canary-helpers.mjs
+++ b/scripts/test-modified-time-canary-helpers.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {
   isSafeModifiedTimePropertyName,
+  modifiedTimeFrontmatterPropertyValue,
   nextRepresentableTimestampReadyAt,
 } from "./modified-time-canary-helpers.mjs";
 
@@ -19,6 +20,31 @@ assert.equal(isSafeModifiedTimePropertyName("123"), false);
 assert.equal(isSafeModifiedTimePropertyName("true"), false);
 assert.equal(isSafeModifiedTimePropertyName("modified\nat"), false);
 assert.equal(isSafeModifiedTimePropertyName("x".repeat(129)), false);
+
+assert.equal(
+  modifiedTimeFrontmatterPropertyValue(
+    "---\r\nmodification: 2026-08-17T12:34:20\r\ntitle: Canary\r\n---\r\n\r\nmodification: ordinary body text\r\n",
+    "modification",
+  ),
+  "2026-08-17T12:34:20",
+  "a body line that resembles the property must not affect frontmatter scope",
+);
+assert.throws(
+  () =>
+    modifiedTimeFrontmatterPropertyValue(
+      "---\nmodification: first\nmodification: second\n---\n",
+      "modification",
+    ),
+  /exactly one top-level modification frontmatter property/u,
+);
+assert.throws(
+  () =>
+    modifiedTimeFrontmatterPropertyValue(
+      "---\ntitle: missing\n---\nmodification: body only\n",
+      "modification",
+    ),
+  /exactly one top-level modification frontmatter property/u,
+);
 
 const offsetMinutes = 120;
 const minuteValue = "2026-08-17T12:34";

--- a/scripts/test-modified-time-canary-helpers.mjs
+++ b/scripts/test-modified-time-canary-helpers.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import {
+  isSafeModifiedTimePropertyName,
+  nextRepresentableTimestampReadyAt,
+} from "./modified-time-canary-helpers.mjs";
+
+assert.equal(isSafeModifiedTimePropertyName("modification"), true);
+assert.equal(isSafeModifiedTimePropertyName("last modified"), true);
+assert.equal(isSafeModifiedTimePropertyName("modified.at"), true);
+assert.equal(isSafeModifiedTimePropertyName(" modified"), false);
+assert.equal(isSafeModifiedTimePropertyName("modified "), false);
+assert.equal(isSafeModifiedTimePropertyName("modified:at"), false);
+assert.equal(isSafeModifiedTimePropertyName("modified\nat"), false);
+assert.equal(isSafeModifiedTimePropertyName("x".repeat(129)), false);
+
+const offsetMinutes = 120;
+const minuteValue = "2026-08-17T12:34";
+const minuteEpoch = Date.UTC(2026, 7, 17, 10, 34, 0);
+assert.equal(
+  nextRepresentableTimestampReadyAt(minuteValue, offsetMinutes),
+  minuteEpoch + 60_000,
+  "minute precision must wait for the next minute boundary",
+);
+
+const secondValue = "2026-08-17T12:34:20";
+const secondEpoch = Date.UTC(2026, 7, 17, 10, 34, 20);
+assert.equal(
+  nextRepresentableTimestampReadyAt(secondValue, offsetMinutes),
+  secondEpoch + 5_200,
+  "second precision must still cross the supported plugin freshness window",
+);
+
+assert.throws(
+  () => nextRepresentableTimestampReadyAt("2026-02-30T12:00", 0),
+  /real datetime/u,
+);
+assert.throws(
+  () => nextRepresentableTimestampReadyAt(minuteValue, 15 * 60),
+  /UTC offset/u,
+);
+
+console.log(
+  "PASS: modified-time live canary accepts the Bridge property-name contract and waits for minute/second timestamp ticks.",
+);

--- a/scripts/test-modified-time-canary-helpers.mjs
+++ b/scripts/test-modified-time-canary-helpers.mjs
@@ -19,16 +19,16 @@ const minuteValue = "2026-08-17T12:34";
 const minuteEpoch = Date.UTC(2026, 7, 17, 10, 34, 0);
 assert.equal(
   nextRepresentableTimestampReadyAt(minuteValue, offsetMinutes),
-  minuteEpoch + 60_000,
-  "minute precision must wait for the next minute boundary",
+  minuteEpoch + 60_000 + 5_200,
+  "minute precision must cross the next minute boundary and freshness margin",
 );
 
 const secondValue = "2026-08-17T12:34:20";
 const secondEpoch = Date.UTC(2026, 7, 17, 10, 34, 20);
 assert.equal(
   nextRepresentableTimestampReadyAt(secondValue, offsetMinutes),
-  secondEpoch + 5_200,
-  "second precision must still cross the supported plugin freshness window",
+  secondEpoch + 1_000 + 5_200,
+  "second precision must cross its next tick and the plugin freshness margin",
 );
 
 assert.throws(

--- a/scripts/test-modified-time-canary-helpers.mjs
+++ b/scripts/test-modified-time-canary-helpers.mjs
@@ -7,10 +7,16 @@ import {
 assert.equal(isSafeModifiedTimePropertyName("modification"), true);
 assert.equal(isSafeModifiedTimePropertyName("last modified"), true);
 assert.equal(isSafeModifiedTimePropertyName("modified.at"), true);
+assert.equal(isSafeModifiedTimePropertyName("création date"), true);
+assert.equal(isSafeModifiedTimePropertyName("version2"), true);
 assert.equal(isSafeModifiedTimePropertyName(" modified"), false);
 assert.equal(isSafeModifiedTimePropertyName("modified "), false);
 assert.equal(isSafeModifiedTimePropertyName("modified:at"), false);
 assert.equal(isSafeModifiedTimePropertyName("modified,time"), false);
+assert.equal(isSafeModifiedTimePropertyName("#modified"), false);
+assert.equal(isSafeModifiedTimePropertyName("modified/key"), false);
+assert.equal(isSafeModifiedTimePropertyName("123"), false);
+assert.equal(isSafeModifiedTimePropertyName("true"), false);
 assert.equal(isSafeModifiedTimePropertyName("modified\nat"), false);
 assert.equal(isSafeModifiedTimePropertyName("x".repeat(129)), false);
 


### PR DESCRIPTION
## Summary

- release Optimike Obsidian MCP 2.8.2 with bounded modified-time settlement
- add a reproducible lost-response live canary for supported Obsidian date plugins
- document and contract-test the exact recovery, evidence, and restoration boundaries

## Local gates

- `check:atomic-write`
- `test:governed-frontmatter`
- `test:governed-base`
- `test:operation-runtime`
- `test:runtime` (48/45/68/51/60 tools across supported modes)
- `check:operon` (33 Bridge tests)
- `test:docs`
- `test:package`
- `build:bridges`
- `audit:production` (0 vulnerabilities)
- `npm audit signatures` (411 signatures, 31 attestations)

## Live pilot evidence

Dedicated Operon Bridge pilot vault only; all disposable fixtures restored to their original SHA-256.

- P0 Atomic Note: PASS
- P1 governed Frontmatter: PASS
- P2 governed Base formula: PASS
- modified-time settlement with Frontmatter Date Manager 1.2.1: PASS
  - two successful CAS responses deliberately lost
  - two first reconciliation reads deliberately lost
  - timestamp-only drift reconciled to `committed`
  - timestamp plus body drift remained `outcome_unknown`
  - final note SHA-256 exactly matched the original

## Review focus

- failure and interruption paths of `smoke-modified-time-settlement-live.mjs`
- plugin disable/restore fencing and final hash authority
- absence of note bodies or credentials from redacted evidence
- Windows/Linux temporary-path and Obsidian CLI assumptions
