### PR TITLE
feat: clarify MCP tool routing

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -28,6 +28,7 @@ jobs:
       - run: node scripts/test-governed-note-replace-http.mjs
       - run: npm run test:profiles
       - run: npm run test:tool-annotations
+      - run: npm run test:tool-routing
       - run: npm run test:docs
       - run: node scripts/test-governed-note-doc-contract.mjs
       - run: npm run test:launchers

--- a/docs/mcp-routing-guide.fr.md
+++ b/docs/mcp-routing-guide.fr.md
@@ -26,6 +26,29 @@ Ce guide aide les agents à choisir la bonne couche pour travailler avec Obsidia
 | Actions ou diagnostics app-native Obsidian                                 | Obsidian CLI                                                    | Utile comme plan de contrôle Desktop/app, pas comme headless strict.              |
 | Savoir écrire la syntaxe Markdown, Bases ou Canvas Obsidian                | Skills ou docs de format Obsidian                               | Les skills enseignent les conventions ; elles n'exécutent pas les opérations MCP. |
 
+## Outils directs, legacy et gouvernés
+
+Quand plusieurs outils touchent le même domaine, ils ne sont pas
+interchangeables. Appliquer cette priorité :
+
+| Intention                                          | Outil préféré                                                                     | Limite de la voie directe ou legacy                                                                                            |
+| -------------------------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Similarité sémantique                              | `smart_semantic_search`                                                           | `smart_search` et `smart-search` sont des alias de compatibilité de la même implémentation.                                    |
+| Lecture de tâches gérées par Operon                | `operon_list_tasks`, `operon_query_tasks`                                         | `list_all_tasks` et `query_tasks` inspectent le Markdown compatible Obsidian Tasks.                                            |
+| Remplacement complet d'une note Markdown existante | `obsidian_note_replace_plan`, puis les outils apply/status/recover correspondants | L'overwrite de `obsidian_update_note` ne fournit ni reçu durable ni récupération du plan exact.                                |
+| Set/delete du frontmatter de premier niveau        | `obsidian_frontmatter_patch_plan`, puis son cycle associé                         | `obsidian_manage_frontmatter` reste utile pour la lecture, la compatibilité ou quand la projection gouvernée live est absente. |
+| Set/delete d'une formule Base nommée               | `bases_formula_patch_plan`, puis son cycle associé                                | `bases_upsert_config` est une voie de compatibilité whole-config désactivée par défaut.                                        |
+
+Les mutations directes append, prepend, search/replace et tags restent exposées
+quand le runtime actif les autorise. Elles ne produisent pas de reçu durable
+plan/status/recovery. Les mutations filesystem headless sont des fallbacks
+bornés pour une copie ou un coffre dédié ; elles ne garantissent pas la
+sémantique Desktop/plugins.
+
+Le serveur expose la même priorité concise via la ressource MCP
+`optimike://guides/tool-routing`. Un client peut la lister et la lire sans
+ajouter un nouvel outil de mutation appelable.
+
 ## Nouveau en V2.2
 
 Utiliser `obsidian_validate_format` avant les écritures risquées ou le contenu généré :

--- a/docs/mcp-routing-guide.md
+++ b/docs/mcp-routing-guide.md
@@ -39,6 +39,29 @@ explicit vault-relative path first, then use the ordinary note tools. The
 optional upstream Periodic Notes API extension is a separate integration and is
 not assumed by Optimike MCP.
 
+## Direct, legacy and governed tools
+
+When multiple tools touch the same domain, they are not interchangeable. Use
+this precedence:
+
+| Intent                                            | Preferred tool                                                            | Direct or legacy boundary                                                                                              |
+| ------------------------------------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Semantic similarity                               | `smart_semantic_search`                                                   | `smart_search` and `smart-search` are compatibility aliases of the same implementation.                                |
+| Operon-managed task reads                         | `operon_list_tasks`, `operon_query_tasks`                                 | `list_all_tasks` and `query_tasks` inspect legacy Obsidian Tasks-compatible Markdown.                                  |
+| Complete replacement of an existing Markdown note | `obsidian_note_replace_plan` then its matching apply/status/recover tools | `obsidian_update_note` overwrite has no durable receipt or exact-plan recovery.                                        |
+| Top-level frontmatter set/delete                  | `obsidian_frontmatter_patch_plan` then its matching lifecycle             | `obsidian_manage_frontmatter` remains useful for reads, compatibility, or when the governed live projection is absent. |
+| Named Base formula set/delete                     | `bases_formula_patch_plan` then its matching lifecycle                    | `bases_upsert_config` is a default-off whole-config compatibility path.                                                |
+
+Direct append, prepend, search/replace and tag mutations remain intentionally
+available where the active runtime permits them. They do not produce a durable
+plan/status/recovery receipt. Headless filesystem mutations are bounded fallback
+operations for copied or dedicated vaults and do not claim Desktop/plugin
+semantics.
+
+The server exposes the same concise precedence as the MCP resource
+`optimike://guides/tool-routing`. Clients can list and read that resource without
+adding another callable mutation tool.
+
 ## New In V2.2
 
 Use `obsidian_validate_format` before risky writes or generated content:

--- a/docs/obsidian_mcp_tools_spec.md
+++ b/docs/obsidian_mcp_tools_spec.md
@@ -14,6 +14,13 @@ Related docs:
 - External roots: [external-roots-setup.md](external-roots-setup.md)
 - Operon contract: [operon-mcp-contract.md](operon-mcp-contract.md)
 
+## MCP Resources
+
+- `optimike://guides/tool-routing`: concise Markdown precedence for canonical,
+  governed, direct and legacy-compatible tool families. Clients can read it
+  when choosing between overlapping domains; it adds no callable mutation
+  capability.
+
 ## Runtime Rules
 
 - `live`: Obsidian Desktop + Local REST API. Full REST-backed note and Bases

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "smoke:operon-rich-mutations": "node scripts/smoke-operon-rich-mutations.mjs",
     "test:profiles": "node scripts/test-elysia-task-profile.mjs",
     "test:tool-annotations": "node scripts/test-tool-annotations.mjs",
+    "test:tool-routing": "npm run build && node scripts/test-tool-routing-contract.mjs && node scripts/smoke-headless-readonly.mjs",
     "test:local-rest-api-compat": "node scripts/test-local-rest-api-compat.mjs",
     "test:external-roots": "npm run build && node scripts/test-external-reference-parser.mjs && node scripts/test-external-move-integrity.mjs && node scripts/test-backend-vault-adapter-cas.mjs && node scripts/test-obsidian-cas.mjs && node scripts/test-obsidian-search-replace-cas.mjs && node scripts/test-external-roots.mjs && node scripts/test-stdio-proxy-external-roots.mjs && node scripts/test-http-external-handoff.mjs",
     "test:external-roots:proxy": "npm run build && node scripts/test-stdio-proxy-external-roots.mjs",

--- a/scripts/smoke-headless-readonly.mjs
+++ b/scripts/smoke-headless-readonly.mjs
@@ -339,6 +339,7 @@ async function main() {
 
     const tools = await withTimeout(client.listTools(), "listTools");
     const toolNames = tools.tools.map((tool) => tool.name).sort();
+    const toolsByName = new Map(tools.tools.map((tool) => [tool.name, tool]));
     const unannotatedTools = tools.tools.filter((tool) => {
       const annotations = tool.annotations;
       return (
@@ -398,6 +399,69 @@ async function main() {
           .map((tool) => tool.name)
           .join(", ")}`,
       );
+    }
+    for (const alias of ["smart_search", "smart-search"]) {
+      const description = toolsByName.get(alias)?.description ?? "";
+      if (
+        !description.includes("Legacy compatibility alias") ||
+        !description.includes("Prefer smart_semantic_search")
+      ) {
+        throw new Error(
+          `${alias} must identify itself as a legacy alias and route new calls to smart_semantic_search.`,
+        );
+      }
+    }
+
+    const routingDescriptionContracts = [
+      ["obsidian_update_note", "obsidian_note_replace_plan"],
+      ["obsidian_search_replace", "obsidian_note_replace_plan"],
+      ["obsidian_manage_frontmatter", "obsidian_frontmatter_patch_plan"],
+      ["bases_upsert_config", "bases_formula_patch_plan"],
+      ["list_all_tasks", "operon_list_tasks"],
+      ["query_tasks", "operon_query_tasks"],
+    ];
+    for (const [directName, preferredName] of routingDescriptionContracts) {
+      const direct = toolsByName.get(directName);
+      const preferred = toolsByName.get(preferredName);
+      if (direct && preferred && !direct.description?.includes(preferredName)) {
+        throw new Error(
+          `${directName} overlaps ${preferredName} but its exposed description does not route callers to the governed/canonical tool.`,
+        );
+      }
+    }
+
+    const resources = await withTimeout(
+      client.listResources(),
+      "listResources",
+    );
+    const routingResource = resources.resources.find(
+      (resource) => resource.uri === "optimike://guides/tool-routing",
+    );
+    if (!routingResource || routingResource.mimeType !== "text/markdown") {
+      throw new Error(
+        "Missing canonical optimike://guides/tool-routing MCP resource.",
+      );
+    }
+    const routingGuide = await withTimeout(
+      client.readResource({ uri: routingResource.uri }),
+      "readRoutingResource",
+    );
+    const routingText = routingGuide.contents
+      .map((content) => ("text" in content ? content.text : ""))
+      .join("\n");
+    for (const requiredText of [
+      "smart_semantic_search",
+      "operon_query_tasks",
+      "obsidian_note_replace_plan",
+      "obsidian_frontmatter_patch_plan",
+      "bases_formula_patch_plan",
+      "There is intentionally no generic public `operation_*` surface.",
+    ]) {
+      if (!routingText.includes(requiredText)) {
+        throw new Error(
+          `Tool-routing resource is missing required contract text: ${requiredText}`,
+        );
+      }
     }
     const expected = [
       "obsidian_list_notes",

--- a/scripts/smoke-headless-readonly.mjs
+++ b/scripts/smoke-headless-readonly.mjs
@@ -430,6 +430,39 @@ async function main() {
       }
     }
 
+    const taskDescriptionContracts = [
+      [
+        "list_all_tasks",
+        [
+          "vault-relative",
+          "defaults to the vault root",
+          "traversal components (`..`)",
+          "operon_list_tasks",
+        ],
+      ],
+      [
+        "query_tasks",
+        [
+          "newline-separated query line",
+          "combined with AND logic",
+          "`not done`",
+          "`tag include #foo/bar`",
+          "vault-relative",
+          "operon_query_tasks",
+        ],
+      ],
+    ];
+    for (const [toolName, requiredFragments] of taskDescriptionContracts) {
+      const description = toolsByName.get(toolName)?.description ?? "";
+      for (const fragment of requiredFragments) {
+        if (!description.includes(fragment)) {
+          throw new Error(
+            `${toolName} description lost its client-visible contract fragment: ${fragment}`,
+          );
+        }
+      }
+    }
+
     const resources = await withTimeout(
       client.listResources(),
       "listResources",

--- a/scripts/test-http-headless-multiclient.mjs
+++ b/scripts/test-http-headless-multiclient.mjs
@@ -481,6 +481,27 @@ try {
   for (const name of expectedReadTools) {
     assert.ok(toolNames.includes(name), `missing read tool ${name}`);
   }
+  const listedResources = await call(
+    clientA,
+    backend.baseUrl,
+    "resources/list",
+  );
+  const routingResource = (listedResources.result?.resources ?? []).find(
+    (resource) => resource.uri === "optimike://guides/tool-routing",
+  );
+  assert.equal(routingResource?.mimeType, "text/markdown");
+  const readRoutingResource = await call(
+    clientB,
+    backend.baseUrl,
+    "resources/read",
+    { uri: "optimike://guides/tool-routing" },
+  );
+  const routingText = (readRoutingResource.result?.contents ?? [])
+    .map((content) => content.text ?? "")
+    .join("\n");
+  assert.match(routingText, /obsidian_note_replace_plan/u);
+  assert.match(routingText, /obsidian_frontmatter_patch_plan/u);
+  assert.match(routingText, /bases_formula_patch_plan/u);
   const forbiddenWriteTools = [
     "obsidian_update_note",
     "obsidian_search_replace",
@@ -627,7 +648,7 @@ try {
   );
 
   console.log(
-    "PASS: a disposable headless-readonly filesystem vault served two distinct authenticated HTTP clients concurrently; readiness and status reported filesystem provenance without live Obsidian or mutations; notes, search, tasks and Bases reads succeeded; the vault hash stayed unchanged, structured logs disclosed no secrets or content, vault/Bases write tools were absent, and the stable Operon registry denied mutation without its live Desktop Bridge",
+    "PASS: a disposable headless-readonly filesystem vault served two distinct authenticated HTTP clients concurrently; the canonical routing resource was listable/readable across sessions; readiness and status reported filesystem provenance without live Obsidian or mutations; notes, search, tasks and Bases reads succeeded; the vault hash stayed unchanged, structured logs disclosed no secrets or content, vault/Bases write tools were absent, and the stable Operon registry denied mutation without its live Desktop Bridge",
   );
 } finally {
   if (backend) await stopBackend(backend);

--- a/scripts/test-tool-routing-contract.mjs
+++ b/scripts/test-tool-routing-contract.mjs
@@ -1,0 +1,83 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  registerToolRoutingResource,
+  TOOL_ROUTING_RESOURCE_TEXT,
+  TOOL_ROUTING_RESOURCE_URI,
+} from "../dist/mcp-server/resources/toolRoutingResource.js";
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+
+let registeredResource;
+registerToolRoutingResource({
+  registerResource(name, uri, metadata, callback) {
+    assert.equal(
+      registeredResource,
+      undefined,
+      "routing resource must be unique",
+    );
+    registeredResource = { name, uri, metadata, callback };
+  },
+});
+
+assert.ok(registeredResource, "routing resource was not registered");
+assert.equal(registeredResource.name, "optimike-tool-routing");
+assert.equal(registeredResource.uri, TOOL_ROUTING_RESOURCE_URI);
+assert.equal(registeredResource.metadata.mimeType, "text/markdown");
+const readResult = await registeredResource.callback();
+assert.deepEqual(readResult, {
+  contents: [
+    {
+      uri: TOOL_ROUTING_RESOURCE_URI,
+      mimeType: "text/markdown",
+      text: TOOL_ROUTING_RESOURCE_TEXT,
+    },
+  ],
+});
+
+const routingPairs = [
+  ["smart_search", "smart_semantic_search"],
+  ["smart-search", "smart_semantic_search"],
+  ["list_all_tasks", "operon_list_tasks"],
+  ["query_tasks", "operon_query_tasks"],
+  ["obsidian_update_note", "obsidian_note_replace_plan"],
+  ["obsidian_search_replace", "obsidian_note_replace_plan"],
+  ["obsidian_manage_frontmatter", "obsidian_frontmatter_patch_plan"],
+  ["bases_upsert_config", "bases_formula_patch_plan"],
+];
+for (const [overlappingTool, preferredTool] of routingPairs) {
+  assert.ok(
+    TOOL_ROUTING_RESOURCE_TEXT.includes(overlappingTool),
+    `routing resource omits ${overlappingTool}`,
+  );
+  assert.ok(
+    TOOL_ROUTING_RESOURCE_TEXT.includes(preferredTool),
+    `routing resource omits preferred tool ${preferredTool}`,
+  );
+}
+
+for (const relativePath of [
+  "docs/mcp-routing-guide.md",
+  "docs/mcp-routing-guide.fr.md",
+]) {
+  const content = fs.readFileSync(path.join(repoRoot, relativePath), "utf8");
+  assert.ok(
+    content.includes(TOOL_ROUTING_RESOURCE_URI),
+    `${relativePath} does not advertise the routing resource`,
+  );
+  for (const [, preferredTool] of routingPairs) {
+    assert.ok(
+      content.includes(preferredTool),
+      `${relativePath} omits preferred route ${preferredTool}`,
+    );
+  }
+}
+
+console.log(
+  "PASS: canonical tool-routing resource, overlap precedence and bilingual documentation agree",
+);

--- a/src/mcp-server/resources/toolRoutingResource.ts
+++ b/src/mcp-server/resources/toolRoutingResource.ts
@@ -1,0 +1,70 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+
+export const TOOL_ROUTING_RESOURCE_URI =
+  "optimike://guides/tool-routing" as const;
+
+export const TOOL_ROUTING_RESOURCE_TEXT = `# Optimike MCP tool routing
+
+Use the narrowest tool that owns the required guarantee. Tool availability is
+runtime-dependent; never infer that an absent tool can be emulated safely.
+
+## Canonical priorities
+
+- Read, list and exact text search: use the dedicated read/search tools.
+- Semantic search: use \`smart_semantic_search\`. \`smart_search\` and
+  \`smart-search\` are legacy compatibility aliases of the same implementation.
+- Operon-managed tasks: use \`operon_list_tasks\` or \`operon_query_tasks\`. Use
+  \`list_all_tasks\` and \`query_tasks\` only for legacy Obsidian Tasks-compatible
+  Markdown inspection.
+- Complete replacement of an existing Markdown note in live/hybrid mode: prefer
+  \`obsidian_note_replace_plan\`, then apply the sealed plan. After a lost response,
+  call status before recover; never issue a new blind mutation. Use
+  \`obsidian_update_note\` for intentional direct append/prepend/create operations;
+  its overwrite mode is a compatibility path without a durable receipt.
+- \`obsidian_search_replace\` is a direct edit without durable recovery. For a
+  high-assurance replacement, compute the intended complete content and route it
+  through \`obsidian_note_replace_plan\`.
+- Top-level frontmatter set/delete in live/hybrid mode: prefer
+  \`obsidian_frontmatter_patch_plan\`. Use \`obsidian_manage_frontmatter\` for
+  direct reads, compatibility, or a runtime where the governed tool is absent.
+- Named Base formula set/delete: prefer \`bases_formula_patch_plan\`.
+  \`bases_upsert_config\` is a legacy whole-config compatibility path and must not
+  bypass the governed formula contract.
+- Direct append/prepend/search-replace/tag tools do not provide a durable
+  plan/status/recovery receipt. Use them only when that narrower direct contract
+  is intentional and allowed by the active runtime policy.
+- Headless filesystem mutations are bounded fallback operations for copied or
+  dedicated vaults. They do not claim Obsidian Desktop or plugin semantics.
+
+## Governed sequence
+
+1. Call the domain-specific \`*_plan\` tool once with a caller-owned idempotency key.
+2. Inspect the returned receipt and retain its opaque \`planRef\`.
+3. Call the matching \`*_apply\` tool with the same key.
+4. After timeout or transport loss, call \`*_status\` first.
+5. Call \`*_recover\` only when the receipt authorizes recovery of that exact plan.
+
+There is intentionally no generic public \`operation_*\` surface.
+`;
+
+export function registerToolRoutingResource(server: McpServer): void {
+  server.registerResource(
+    "optimike-tool-routing",
+    TOOL_ROUTING_RESOURCE_URI,
+    {
+      title: "Optimike MCP tool routing",
+      description:
+        "Canonical precedence between direct, legacy and governed Optimike MCP tools.",
+      mimeType: "text/markdown",
+    },
+    async () => ({
+      contents: [
+        {
+          uri: TOOL_ROUTING_RESOURCE_URI,
+          mimeType: "text/markdown",
+          text: TOOL_ROUTING_RESOURCE_TEXT,
+        },
+      ],
+    }),
+  );
+}

--- a/src/mcp-server/server.ts
+++ b/src/mcp-server/server.ts
@@ -71,6 +71,7 @@ import {
 // Import transport setup functions.
 import { startHttpTransport } from "./transports/httpTransport.js";
 import { connectStdioTransport } from "./transports/stdioTransport.js";
+import { registerToolRoutingResource } from "./resources/toolRoutingResource.js";
 
 async function updateCacheAfterGuardedWrite(
   vaultCacheService: VaultCacheService | undefined,
@@ -196,7 +197,7 @@ function registerHeadlessGuardedWriteTools(
 
   server.tool(
     "obsidian_update_note",
-    "Headless-guarded filesystem note update. Supports filePath targets with append or prepend. Uses atomic writes and vault path safety.",
+    "Headless-guarded direct filesystem append/prepend for explicit filePath targets on a copied or dedicated vault. Uses atomic file writes, path safety and optional preconditions, but has no durable plan/status/recovery receipt.",
     {
       targetType: z.literal("filePath"),
       targetIdentifier: z.string().min(1),
@@ -264,7 +265,7 @@ function registerHeadlessGuardedWriteTools(
 
   server.tool(
     "obsidian_search_replace",
-    "Headless-guarded filesystem exact search/replace for filePath targets.",
+    "Headless-guarded direct filesystem exact search/replace for explicit filePath targets on a copied or dedicated vault. Optional hash/mtime preconditions prevent stale writes; no durable plan/status/recovery receipt is created.",
     {
       targetType: z.literal("filePath"),
       targetIdentifier: z.string().min(1),
@@ -333,7 +334,7 @@ function registerHeadlessGuardedWriteTools(
 
   server.tool(
     "obsidian_manage_frontmatter",
-    "Headless-guarded filesystem frontmatter setter for a single key.",
+    "Headless-guarded direct filesystem frontmatter setter for one key on a copied or dedicated vault. This fallback is exposed only when the live governed projection is unavailable and creates no durable receipt.",
     {
       filePath: z.string().min(1),
       operation: z.literal("set"),
@@ -1310,7 +1311,7 @@ function registerHeadlessGuardedWriteTools(
 
   server.tool(
     "bases_create",
-    "Headless-guarded filesystem .base create/validate. Writes YAML directly and does not evaluate Obsidian Bases semantics.",
+    "Headless-filesystem direct .base create/validate for a copied or dedicated vault. It writes YAML without evaluating Obsidian Bases semantics and creates no durable plan/status/recovery receipt.",
     {
       path: z.string().min(1),
       spec: z.record(z.any()),
@@ -1403,7 +1404,7 @@ function registerHeadlessGuardedWriteTools(
 
   server.tool(
     "bases_upsert_config",
-    "Headless-guarded filesystem .base config replacement/validation.",
+    "Headless-filesystem direct .base config replacement/validation for a copied or dedicated vault. It does not provide the live governed formula contract or a durable recovery receipt.",
     {
       base_id: z.string().min(1),
       yaml: z.string().optional(),
@@ -1494,7 +1495,7 @@ function registerHeadlessGuardedWriteTools(
 
   server.tool(
     "bases_upsert_rows",
-    "Headless-guarded filesystem frontmatter set operations for notes referenced by a .base. Unset is not supported.",
+    "Headless-filesystem direct frontmatter set operations for notes referenced by a .base. Unset is unsupported; the multi-note request is not one atomic batch and has no durable batch recovery receipt.",
     {
       base_id: z.string().min(1),
       operations: z
@@ -1668,6 +1669,8 @@ async function createMcpServerInstance(
     const localBasesService = vaultCacheService
       ? new LocalBasesService(vaultCacheService)
       : undefined;
+
+    registerToolRoutingResource(server);
 
     // Register read/cache-friendly tools first. In headless-readonly, the REST
     // service is intentionally absent and these tools must use the shared cache.

--- a/src/mcp-server/tools/basesCreateTool/registration.ts
+++ b/src/mcp-server/tools/basesCreateTool/registration.ts
@@ -16,7 +16,7 @@ import {
 
 const TOOL_NAME = "bases_create";
 const TOOL_DESCRIPTION =
-  "Crée (ou valide) une nouvelle base .base en générant le YAML via le bridge REST.";
+  "Direct validation or creation of one .base YAML document through the REST bridge. Overwrite is a legacy whole-config compatibility effect and has no durable plan/status/recovery receipt.";
 
 export async function registerBasesCreateTool(
   server: McpServer,

--- a/src/mcp-server/tools/basesUpsertConfigTool/registration.ts
+++ b/src/mcp-server/tools/basesUpsertConfigTool/registration.ts
@@ -16,7 +16,7 @@ import {
 
 const TOOL_NAME = "bases_upsert_config";
 const TOOL_DESCRIPTION =
-  "Met à jour (ou valide) la configuration YAML/JSON d'une base via le bridge REST.";
+  "Legacy compatibility path for validating or replacing a complete Base YAML/JSON configuration through the REST bridge. Prefer bases_formula_patch_plan for named formula set/delete: it is source-preserving and provides durable status/recovery. Whole-config effects remain default-off at the Bridge.";
 
 export async function registerBasesUpsertConfigTool(
   server: McpServer,

--- a/src/mcp-server/tools/basesUpsertRowsTool/registration.ts
+++ b/src/mcp-server/tools/basesUpsertRowsTool/registration.ts
@@ -16,7 +16,7 @@ import {
 
 const TOOL_NAME = "bases_upsert_rows";
 const TOOL_DESCRIPTION =
-  "Met à jour les propriétés de notes issues d'une base via le bridge REST (set/unset + mtime).";
+  "Direct multi-row Base property set/unset through the REST bridge. This compatibility operation is not one atomic batch and may return partial results; it has no durable batch recovery receipt.";
 
 export async function registerBasesUpsertRowsTool(
   server: McpServer,

--- a/src/mcp-server/tools/listAllTasksTool/registration.ts
+++ b/src/mcp-server/tools/listAllTasksTool/registration.ts
@@ -20,7 +20,7 @@ export const registerListAllTasksTool = async (
 ): Promise<void> => {
   const toolName = "list_all_tasks";
   const toolDescription =
-    "Extract all tasks from markdown files in a directory. Recursively scans all markdown files and extracts tasks based on the Obsidian Tasks format. Returns structured data about each task including status, dates, and tags. Supports include/exclude path filters, optional non-task inclusion, optional file metadata (created/modified), optional meta dates (frontmatter), and optional global filter application. The path parameter is optional; if not specified, it defaults to the vault root directory. The path must be relative to the vault directory and cannot contain directory traversal components (..).";
+    "Legacy Obsidian Tasks-compatible Markdown inventory, not Operon task authority. Recursively extracts task status, dates and tags with path filters and optional metadata. Use operon_list_tasks for Operon-managed tasks, stable IDs, workflow state and validated snapshots.";
 
   const registrationContext: RequestContext =
     requestContextService.createRequestContext({
@@ -39,13 +39,12 @@ export const registerListAllTasksTool = async (
         ListAllTasksInputSchemaShape,
         READ_ONLY_TOOL_ANNOTATIONS,
         async (params: ListAllTasksInput) => {
-          const handlerContext =
-            requestContextService.createRequestContext({
-              parentContext: registrationContext,
-              operation: "HandleListAllTasksRequest",
-              toolName,
-              params,
-            });
+          const handlerContext = requestContextService.createRequestContext({
+            parentContext: registrationContext,
+            operation: "HandleListAllTasksRequest",
+            toolName,
+            params,
+          });
 
           return await ErrorHandler.tryCatch(
             async () => {
@@ -76,7 +75,10 @@ export const registerListAllTasksTool = async (
         },
       );
 
-      logger.info(`Tool registered successfully: ${toolName}`, registrationContext);
+      logger.info(
+        `Tool registered successfully: ${toolName}`,
+        registrationContext,
+      );
     },
     {
       operation: `registering tool ${toolName}`,

--- a/src/mcp-server/tools/listAllTasksTool/registration.ts
+++ b/src/mcp-server/tools/listAllTasksTool/registration.ts
@@ -20,7 +20,7 @@ export const registerListAllTasksTool = async (
 ): Promise<void> => {
   const toolName = "list_all_tasks";
   const toolDescription =
-    "Legacy Obsidian Tasks-compatible Markdown inventory, not Operon task authority. Recursively extracts task status, dates and tags with path filters and optional metadata. Use operon_list_tasks for Operon-managed tasks, stable IDs, workflow state and validated snapshots.";
+    "Legacy Obsidian Tasks-compatible Markdown inventory, not Operon task authority. Recursively scans Markdown and returns structured task status, dates and tags. Supports include/exclude path filters, optional non-task inclusion, file created/modified metadata, frontmatter meta dates, and the configured global Tasks filter. The optional path is vault-relative, defaults to the vault root, and must not contain traversal components (`..`). Use operon_list_tasks for Operon-managed tasks, stable IDs, workflow state and validated snapshots.";
 
   const registrationContext: RequestContext =
     requestContextService.createRequestContext({

--- a/src/mcp-server/tools/obsidianDeleteNoteTool/registration.ts
+++ b/src/mcp-server/tools/obsidianDeleteNoteTool/registration.ts
@@ -45,7 +45,7 @@ export const registerObsidianDeleteNoteTool = async (
   const toolName = "obsidian_delete_note";
   // Updated description to accurately reflect the response (no timestamp)
   const toolDescription =
-    "Permanently deletes a specified file from the Obsidian vault. Tries the exact path first, then attempts a case-insensitive fallback if the file is not found. Requires the vault-relative path including the file extension. Returns a success message.";
+    "Direct permanent deletion of one vault file by explicit path. This operation has no governed recovery or undo receipt; use only when irreversible deletion is intentional and allowed by policy. Exact path is tried before a case-insensitive fallback.";
 
   // Create a context specifically for the registration process.
   const registrationContext: RequestContext =

--- a/src/mcp-server/tools/obsidianManageFrontmatterTool/registration.ts
+++ b/src/mcp-server/tools/obsidianManageFrontmatterTool/registration.ts
@@ -28,7 +28,7 @@ export const registerObsidianManageFrontmatterTool = async (
 ): Promise<void> => {
   const toolName = "obsidian_manage_frontmatter";
   const toolDescription =
-    "Atomically manages a note's YAML frontmatter. Supports getting, setting (creating/updating), and deleting specific keys without rewriting the entire file. Ideal for efficient metadata operations on primitive or structured Obsidian frontmatter data.";
+    "Direct Local REST frontmatter get/set/delete for one note. Prefer obsidian_frontmatter_patch_plan for live mutations when available: it preserves authorized source ranges and provides a durable plan/status/recovery receipt. Keep this tool for reads, compatibility, or runtimes without the governed projection.";
 
   const registrationContext: RequestContext =
     requestContextService.createRequestContext({

--- a/src/mcp-server/tools/obsidianManageTagsTool/registration.ts
+++ b/src/mcp-server/tools/obsidianManageTagsTool/registration.ts
@@ -28,7 +28,7 @@ export const registerObsidianManageTagsTool = async (
 ): Promise<void> => {
   const toolName = "obsidian_manage_tags";
   const toolDescription =
-    "Manages tags for a specified note, handling them in both the YAML frontmatter and inline content. Supports adding, removing, and listing tags to provide a comprehensive tag management solution.";
+    "Direct Local REST tag add/remove/list for YAML frontmatter and inline Markdown. It creates no durable plan/status/recovery receipt. For a frontmatter-only mutation, prefer obsidian_frontmatter_patch_plan when available.";
 
   const registrationContext: RequestContext =
     requestContextService.createRequestContext({

--- a/src/mcp-server/tools/obsidianSearchReplaceTool/registration.ts
+++ b/src/mcp-server/tools/obsidianSearchReplaceTool/registration.ts
@@ -48,7 +48,7 @@ export const registerObsidianSearchReplaceTool = async (
 ): Promise<void> => {
   const toolName = "obsidian_search_replace";
   const toolDescription =
-    "Performs one or more search-and-replace operations within a target Obsidian note (file path or active file). Reads the file, applies replacements sequentially in memory, and writes the modified content back, overwriting the original. Supports string/regex search, case sensitivity toggle, replacing first/all occurrences, flexible whitespace matching (non-regex), and whole word matching. Returns success status, message, replacement count, a formatted timestamp string, file stats (stats), and optionally the final file content.";
+    "Direct Local REST search/replace within one note. Supports string or regex matching and returns the replacement count and optional final content. It overwrites the resulting note without a durable plan/status/recovery receipt; for high-assurance changes, compute the intended complete content and prefer obsidian_note_replace_plan when available.";
 
   // Create a context specifically for the registration process.
   const registrationContext: RequestContext =

--- a/src/mcp-server/tools/obsidianUpdateNoteTool/registration.ts
+++ b/src/mcp-server/tools/obsidianUpdateNoteTool/registration.ts
@@ -48,7 +48,7 @@ export const registerObsidianUpdateNoteTool = async (
 ): Promise<void> => {
   const toolName = "obsidian_update_note";
   const toolDescription =
-    "Tool to modify Obsidian notes (specified by file path or the active file) using whole-file operations: 'append', 'prepend', or 'overwrite'. Options allow creating missing files/targets and controlling overwrite behavior. Returns success status, message, a formatted timestamp string, file stats (stats), and optionally the final file content.";
+    "Direct Local REST note edit for append, prepend, creation, or compatibility overwrite. For complete replacement of an existing Markdown note, prefer obsidian_note_replace_plan when available because direct overwrite has no durable plan/status/recovery receipt. Options allow explicit file path or active-file targets and optional final content.";
 
   // Create a context for the registration process itself for better traceability.
   const registrationContext: RequestContext =

--- a/src/mcp-server/tools/queryTasksTool/registration.ts
+++ b/src/mcp-server/tools/queryTasksTool/registration.ts
@@ -20,7 +20,7 @@ export const registerQueryTasksTool = async (
 ): Promise<void> => {
   const toolName = "query_tasks";
   const toolDescription =
-    "Legacy Obsidian Tasks-compatible Markdown query, not Operon task authority. Supports Tasks query syntax for status, dates, description, tags, priority and paths. Use operon_query_tasks for Operon-managed tasks, stable workflow IDs and validated snapshots.";
+    "Legacy Obsidian Tasks-compatible Markdown query, not Operon task authority. Each newline-separated query line is a filter and all lines are combined with AND logic. Supported predicates cover status, relative or absolute dates (EN/FR), description, tags, priority and path; examples include `done`, `not done`, `tag include #foo/bar`, `tag do not include #potato`, and `description includes keyword`. Supports include/exclude path filters, optional non-task inclusion, file created/modified metadata, frontmatter meta dates, and the configured global Tasks filter. The optional path is vault-relative, defaults to the vault root, and must not contain traversal components (`..`). Use operon_query_tasks for Operon-managed tasks, stable workflow IDs and validated snapshots.";
 
   const registrationContext: RequestContext =
     requestContextService.createRequestContext({

--- a/src/mcp-server/tools/queryTasksTool/registration.ts
+++ b/src/mcp-server/tools/queryTasksTool/registration.ts
@@ -20,7 +20,7 @@ export const registerQueryTasksTool = async (
 ): Promise<void> => {
   const toolName = "query_tasks";
   const toolDescription =
-    "Search for tasks based on Obsidian Tasks query syntax. Allows filtering tasks by status, dates (including relative, EN/FR), description, tags, priority, and path. Each line in the query is treated as a filter with AND logic between lines. Returns only tasks that match all query conditions. Examples of task filters are `done`, `not done`, `tag include #foo/bar`, `tag do not include #potato`, `description includes keyword`. Supports include/exclude path filters, optional non-task inclusion, optional file metadata (created/modified), optional meta dates (frontmatter), and optional global filter application. The path parameter is optional; if not specified, it defaults to the vault root directory. The path must be relative to the vault directory and cannot contain directory traversal components (..).";
+    "Legacy Obsidian Tasks-compatible Markdown query, not Operon task authority. Supports Tasks query syntax for status, dates, description, tags, priority and paths. Use operon_query_tasks for Operon-managed tasks, stable workflow IDs and validated snapshots.";
 
   const registrationContext: RequestContext =
     requestContextService.createRequestContext({
@@ -39,13 +39,12 @@ export const registerQueryTasksTool = async (
         QueryTasksInputSchemaShape,
         READ_ONLY_TOOL_ANNOTATIONS,
         async (params: QueryTasksInput) => {
-          const handlerContext =
-            requestContextService.createRequestContext({
-              parentContext: registrationContext,
-              operation: "HandleQueryTasksRequest",
-              toolName,
-              params,
-            });
+          const handlerContext = requestContextService.createRequestContext({
+            parentContext: registrationContext,
+            operation: "HandleQueryTasksRequest",
+            toolName,
+            params,
+          });
 
           return await ErrorHandler.tryCatch(
             async () => {
@@ -76,7 +75,10 @@ export const registerQueryTasksTool = async (
         },
       );
 
-      logger.info(`Tool registered successfully: ${toolName}`, registrationContext);
+      logger.info(
+        `Tool registered successfully: ${toolName}`,
+        registrationContext,
+      );
     },
     {
       operation: `registering tool ${toolName}`,

--- a/src/mcp-server/tools/semanticSearchTool/registration.ts
+++ b/src/mcp-server/tools/semanticSearchTool/registration.ts
@@ -3,7 +3,7 @@
  * - Lit les embeddings dans `.smart-env`
  * - Encode la requête via un embedder configurable (auto: s'aligne sur le modèle du vault)
  * - Classement cosinus, filtres dossier/tag, snippets optionnels
- * - Expose `smart_semantic_search` + alias `smart_search` et `smart-search`
+ * - Expose `smart_semantic_search` + legacy aliases `smart_search` and `smart-search`
  * Schéma JSON "Codex-friendly" (pas d'integer ni d'unions).
  */
 
@@ -203,7 +203,11 @@ async function detectOllamaBaseUrlFromSmartEnv(
 
     const defaultKey = smartEnv.embedding_models?.default_model_key;
     if (defaultKey) {
-      const modelsPath = path.join(smartEnvDir, "embedding_models", "embedding_models.ajson");
+      const modelsPath = path.join(
+        smartEnvDir,
+        "embedding_models",
+        "embedding_models.ajson",
+      );
       const modelsRaw = await fs.readFile(modelsPath, "utf-8");
       const models = JSON.parse(wrapLooseObjectToJson(modelsRaw)) as Record<
         string,
@@ -222,7 +226,11 @@ async function detectOllamaBaseUrlFromSmartEnv(
   // 2) Fallback: scan embedding_models.ajson for a matching model_key.
   if (preferredModel) {
     try {
-      const modelsPath = path.join(smartEnvDir, "embedding_models", "embedding_models.ajson");
+      const modelsPath = path.join(
+        smartEnvDir,
+        "embedding_models",
+        "embedding_models.ajson",
+      );
       const modelsRaw = await fs.readFile(modelsPath, "utf-8");
       const models = JSON.parse(wrapLooseObjectToJson(modelsRaw)) as Record<
         string,
@@ -373,8 +381,7 @@ async function performSearch(input: InType): Promise<OutType> {
       !input.folders ||
       input.folders.some((folder) => item.notePath.startsWith(folder));
     const tagsOk =
-      !input.tags ||
-      (item.tags ?? []).some((tag) => input.tags?.includes(tag));
+      !input.tags || (item.tags ?? []).some((tag) => input.tags?.includes(tag));
     return folderOk && tagsOk;
   });
   timings.filter = elapsedSince(filterStartedAt);
@@ -402,7 +409,10 @@ async function performSearch(input: InType): Promise<OutType> {
     let snippet: string | undefined;
 
     if (input.with_snippets) {
-      const absolutePath = resolveNoteAbsolutePath(item.notePath, OBSIDIAN_VAULT);
+      const absolutePath = resolveNoteAbsolutePath(
+        item.notePath,
+        OBSIDIAN_VAULT,
+      );
       try {
         const content = await fs.readFile(absolutePath, "utf-8");
         snippet = content.slice(0, 300);
@@ -492,7 +502,8 @@ export async function prewarmSemanticSearch(): Promise<SemanticSearchPrewarmResu
     return skipped(`No embeddings found in ${SMART_ENV_DIR}`);
   }
 
-  const dimension = snapshot.dominantDim ?? pickDominantDimension(snapshot.items);
+  const dimension =
+    snapshot.dominantDim ?? pickDominantDimension(snapshot.items);
   if (!dimension) {
     return skipped("Embeddings are missing vector data");
   }
@@ -575,11 +586,11 @@ export const registerSemanticSearchTool = async (
   );
   register(
     "smart_search",
-    "Alias of smart_semantic_search (same implementation).",
+    "Legacy compatibility alias of smart_semantic_search with the same implementation. Prefer smart_semantic_search for new calls.",
   );
   register(
     "smart-search",
-    "Alias of smart_semantic_search (same implementation).",
+    "Legacy compatibility alias of smart_semantic_search with the same implementation. Prefer smart_semantic_search for new calls.",
   );
 };
 


### PR DESCRIPTION
## What changed

- add a canonical `optimike://guides/tool-routing` MCP resource available over stdio and HTTP
- route overlapping direct/legacy tool descriptions toward their canonical governed or Operon alternatives
- identify the two semantic-search aliases as legacy compatibility names without removing them
- document the precedence in English and French
- add deterministic routing-contract, real stdio surface, and authenticated multi-client HTTP resource tests
- add the routing gate to the Windows/Linux Runtime workflow

## Why

The live registry exposes 68 tools. Names and schemas were unique, but several intentional overlaps did not state their precedence in the tool descriptions, and the existing routing guide was not discoverable as an MCP resource. This made selection dependent on model strength and surrounding prompt context.

This PR keeps compatibility intact while making the canonical route observable at tool-selection time. It does not add a mutation capability, remove an alias, or introduce a generic public `operation_*` API.

## Validation

- `npm run test:tool-routing`
- `npm run test:runtime`
- `npm run test:external-roots`
- `npm run test:operation-runtime`
- `npm run test:governed-frontmatter`
- `npm run test:governed-base`
- `npm run check:atomic-write`
- `npm run check:operon`
- governed note stdio and HTTP tests
- HTTP multiclient, backpressure, observability and headless multiclient suites
- `npm run test:tool-annotations`
- `npm run test:docs`
- `npm run test:package`
- `npm run test:migrations:windows`
- `npm run audit:production` (0 vulnerabilities)