### PR TITLE
chore: release Optimike Obsidian MCP 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,46 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.9.0] - 2026-08-17
+
+### Added
+
+- Governed JSON Canvas P3 surface:
+  `obsidian_canvas_patch_plan`, `obsidian_canvas_patch_apply`,
+  `obsidian_canvas_patch_status`, and `obsidian_canvas_patch_recover`.
+- Atomic Write Bridge `0.4.0` adds an independent default-off Canvas write
+  gate, typed read/CAS routes, vault binding, SHA-256 compare-and-swap inside
+  `Vault.process`, and JSON Canvas 1.0 graph validation.
+- The MCP routing guide is now exposed as the canonical
+  `optimike://guides/tool-routing` resource over stdio and HTTP.
+
+### Changed
+
+- Tool descriptions and routing documentation now direct governed note,
+  Frontmatter, Base, Canvas, and Operon mutations to their canonical lifecycle
+  while keeping direct helpers as explicit compatibility paths.
+- Canvas node and edge intentions project over the shared durable operation
+  runtime; no generic public `operation_*` API is introduced.
+
+### Security
+
+- Planning and CAS reject malformed standard JSON Canvas fields, dangling
+  edges, duplicate or ambiguous entity histories, padded/non-canonical paths,
+  sources or projections above 5 MiB, and projected effects above the active
+  guarded policy before any durable write is admitted.
+- Localized edge deletion preserves untouched JSON literals and each surviving
+  edge's original adjacent separator instead of reparsing or globally
+  normalizing unknown values.
+
+### Validation
+
+- The exact release candidate passed 19 Windows/Linux PR checks, an independent
+  hostile contract audit, and the live Operon Bridge pilot-vault canary. The
+  canary proved no-write planning, invalid-graph rejection, exact-plan recovery
+  after a pre-dispatch interruption, post-write lost-response reconciliation,
+  idempotent replay, stale-plan conflict, and exact restoration of the original
+  Canvas SHA-256.
+
 ## [2.8.3] - 2026-08-17
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Validation
 
-- The exact release candidate passed 19 Windows/Linux PR checks, an independent
-  hostile contract audit, and the live Operon Bridge pilot-vault canary. The
+- The governed Canvas feature head passed 19 Windows/Linux PR checks and an
+  independent hostile contract audit. The exact release candidate passed its
+  15 triggered checks and the live Operon Bridge pilot-vault canary. The
   canary proved no-write planning, invalid-graph rejection, exact-plan recovery
   after a pre-dispatch interruption, post-write lost-response reconciliation,
   idempotent replay, stale-plan conflict, and exact restoration of the original

--- a/docs/adr/ADR-Governed-Canvas-P3.md
+++ b/docs/adr/ADR-Governed-Canvas-P3.md
@@ -1,6 +1,6 @@
 # ADR: P3 governed Canvas graph operation
 
-- Status: accepted for implementation; release admission requires the live pilot
+- Status: accepted, implemented and released in `2.9.0`; live pilot passed
 - Date: 2026-08-17
 - Parent: [Common Operation Runtime](ADR-Common-Operation-Runtime.md)
 - Contract: [Governed Canvas P3](../governed-canvas-p3.md)
@@ -44,3 +44,13 @@ Do not release if a supported operation changes an unknown value, if malformed
 or dangling graph state can reach CAS, if Canvas requires the Markdown write
 gate, or if the live pilot cannot restore the disposable fixture to its exact
 initial SHA-256.
+
+## Release evidence
+
+The bounded compiler, shared durable runtime, Atomic Write Bridge 0.4.0,
+stdio/HTTP surfaces and Windows/Linux CI passed on the exact feature head. The
+live Operon Bridge pilot then proved invalid-graph rejection without a write,
+recovery before CAS dispatch, reconciliation after a lost successful response,
+idempotent replay, stale-plan conflict and exact restoration of the disposable
+Canvas SHA-256. An independent hostile contract audit returned `ship` before
+the feature was merged into `main` for release `2.9.0`.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -12,7 +12,7 @@ setup or operations guides, not in this index.
 | [Common governed operation runtime](ADR-Common-Operation-Runtime.md)                                               | Accepted and released in 2.6.0; public atomic-note projection and live canary complete | Shared plan, apply, status, receipt and exact-plan recovery vocabulary      |
 | [P1 governed frontmatter projection](ADR-Governed-Frontmatter-P1.md)                                               | Accepted, implemented and released in 2.7.0                                            | Source-preserving domain compiler projected over the released P0 runtime    |
 | [P2 governed Base formula operation](ADR-Governed-Base-Formula-P2.md)                                              | Accepted, implemented and released in 2.8.0; live pilot passed                         | Second typed backend, source-preserving formula intent and legacy migration |
-| [P3 governed Canvas graph operation](ADR-Governed-Canvas-P3.md)                                                    | Accepted for implementation; live pilot required before release                        | Typed Canvas CAS, graph intent, unknown-value preservation                  |
+| [P3 governed Canvas graph operation](ADR-Governed-Canvas-P3.md)                                                    | Accepted, implemented and released in 2.9.0; live pilot passed                         | Typed Canvas CAS, graph intent, unknown-value preservation                  |
 
 ## Status vocabulary
 
@@ -35,3 +35,7 @@ The P2 ADR is accepted and implemented after its parsed-node
 source-preservation proof, second typed Bridge CAS, HTTP mutation backpressure,
 Linux/Windows CI, exact-head Codex Review, live Base canary, merge, and
 post-merge `main` workflow all passed. It is released in `2.8.0`.
+The P3 ADR is accepted and implemented after its bounded graph compiler,
+typed Canvas CAS, durable recovery tests, Linux/Windows CI, live Obsidian
+canary, independent hostile audit, merge, and post-merge `main` workflow all
+passed. It is released in `2.9.0`.

--- a/docs/governed-canvas-p3.fr.md
+++ b/docs/governed-canvas-p3.fr.md
@@ -29,6 +29,12 @@ ciblées ou non ciblées. Il refuse un graphe initial invalide et valide le
 graphe final : IDs uniques, forme des nœuds, géométrie, côtés et références des
 edges. Il ne rend pas le Canvas et ne juge pas la qualité visuelle du layout.
 
+Un plan accepte de 1 à 64 intentions publiques. Le Canvas initial et chaque
+projection intermédiaire/finale doivent rester au plus à 5 Mio en UTF-8. Le
+mode guarded peut imposer une limite effective plus basse selon le nombre
+d'effets scellés sur les nœuds et edges, y compris les edges incidentes
+supprimées avec un nœud.
+
 ## Frontière durable et atomique
 
 Le plan lit le `.canvas`, compile le JSON strict suivant, enregistre une preuve

--- a/docs/governed-canvas-p3.md
+++ b/docs/governed-canvas-p3.md
@@ -29,6 +29,11 @@ entities. It rejects an invalid current graph and validates the final graph,
 including unique IDs, node shape, geometry, edge sides, and edge references.
 It does not render the Canvas or judge visual layout quality.
 
+One plan accepts 1 to 64 public intentions. The current Canvas and every
+intermediate/final projection must remain at or below 5 MiB of UTF-8 content.
+Guarded mode may impose a lower effective limit based on the sealed number of
+node and edge effects, including incident edges removed with a node.
+
 ## Durable and atomic boundary
 
 Planning reads the current `.canvas`, compiles the next strict JSON, records a

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optimike-obsidian-mcp",
-  "version": "2.8.3",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optimike-obsidian-mcp",
-      "version": "2.8.3",
+      "version": "2.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optimike-obsidian-mcp",
-  "version": "2.8.3",
+  "version": "2.9.0",
   "description": "Unified Obsidian MCP server with shared local cache, Operon and Tasks tools, Bases support, semantic search, runtime observability, and degraded read mode for durable agent workflows.",
   "main": "dist/index.js",
   "files": [

--- a/scripts/smoke-governed-base-formula-live.mjs
+++ b/scripts/smoke-governed-base-formula-live.mjs
@@ -5,6 +5,7 @@ import { createHash, randomUUID } from "node:crypto";
 import {
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   renameSync,
   rmSync,
   writeFileSync,
@@ -27,6 +28,9 @@ const writeMode = process.env.MCP_WRITE_MODE?.trim() ?? "readonly";
 const CONFIRMATION =
   "I_UNDERSTAND_THIS_DISPOSABLE_BASE_WILL_BE_TEMPORARILY_PATCHED";
 const FORMULA = "_optimike_p2_canary";
+const packageVersion = JSON.parse(
+  readFileSync(path.join(process.cwd(), "package.json"), "utf8"),
+).version;
 
 if (!canaryPath?.toLowerCase().endsWith(".base")) {
   throw new Error(
@@ -286,7 +290,7 @@ try {
         originalSha256: original.sha256,
         finalSha256: final.sha256,
         bridgeVersion: status.plugin.version,
-        mcpVersion: process.env.MCP_SERVER_VERSION ?? "2.8.3",
+        mcpVersion: process.env.MCP_SERVER_VERSION ?? packageVersion,
         checks: [
           "typed_base_binding",
           "plan_without_write",

--- a/scripts/test-doc-contract.mjs
+++ b/scripts/test-doc-contract.mjs
@@ -106,8 +106,8 @@ assert.match(matrixFr, /\| Admin filesystem\s+\| Non\s+\| Non/);
 const packageJson = JSON.parse(await text("package.json"));
 assert.equal(
   packageJson.version,
-  "2.8.3",
-  "released package metadata must match the 2.8.3 dynamic date-property patch",
+  "2.9.0",
+  "released package metadata must match the 2.9.0 governed Canvas release",
 );
 assert.equal(packageJson.scripts["start:http"], "node scripts/run-http.mjs");
 assert.equal(packageJson.scripts["start:daemon"], "node scripts/run-http.mjs");

--- a/scripts/test-governed-canvas-doc-contract.mjs
+++ b/scripts/test-governed-canvas-doc-contract.mjs
@@ -43,6 +43,10 @@ for (const invariant of [
   "OBSIDIAN_BASE_URL",
   "MCP_WRITE_MODE",
   "smoke:governed-canvas-live",
+  "5 MiB",
+  "5 Mio",
+  "1 to 64",
+  "1 à 64",
 ]) {
   assert.equal(
     joined.includes(invariant),


### PR DESCRIPTION
## Release

- publish governed Canvas P3 and the canonical MCP routing resource in Optimike Obsidian MCP 2.9.0
- mark the Canvas ADR accepted, implemented and released after the live pilot
- document the 64-intent and 5 MiB boundaries in English and French
- keep the Base canary evidence version aligned with package metadata

## Validation

- post-merge main Runtime workflow for PR #62: green
- `npm run test:docs`
- `npm run test:package`
- `npm run test:governed-canvas`
- `npm run audit:production` (0 vulnerabilities)
- exact release-candidate live Canvas canary on `5cfbdad`: PASS, package 2.9.0, exact SHA restoration

The release commit changes metadata and documentation only; Canvas behavior remains the independently audited and canary-proven implementation merged by #62.