### PR TITLE
feat: add canonical tool surface registry

### DIFF
--- a/.github/workflows/tool-surface-p0.yml
+++ b/.github/workflows/tool-surface-p0.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "src/mcp-server/**"
       - "scripts/test-tool-surface-registry.mjs"
+      - "scripts/test-tool-surface-runtime-conformance.mjs"
       - ".github/workflows/tool-surface-p0.yml"
   push:
     branches:
@@ -12,6 +13,7 @@ on:
     paths:
       - "src/mcp-server/**"
       - "scripts/test-tool-surface-registry.mjs"
+      - "scripts/test-tool-surface-runtime-conformance.mjs"
       - ".github/workflows/tool-surface-p0.yml"
 
 permissions:
@@ -34,3 +36,4 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: node scripts/test-tool-surface-registry.mjs
+      - run: node scripts/test-tool-surface-runtime-conformance.mjs

--- a/.github/workflows/tool-surface-p0.yml
+++ b/.github/workflows/tool-surface-p0.yml
@@ -1,0 +1,36 @@
+name: Tool Surface P0
+
+on:
+  pull_request:
+    paths:
+      - "src/mcp-server/**"
+      - "scripts/test-tool-surface-registry.mjs"
+      - ".github/workflows/tool-surface-p0.yml"
+  push:
+    branches:
+      - "agent/tool-surface-p0"
+    paths:
+      - "src/mcp-server/**"
+      - "scripts/test-tool-surface-registry.mjs"
+      - ".github/workflows/tool-surface-p0.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  registry:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.7.5"
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: node scripts/test-tool-surface-registry.mjs

--- a/.github/workflows/tool-surface-p0.yml
+++ b/.github/workflows/tool-surface-p0.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.7.5"
+          node-version: "22"
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/scripts/test-tool-surface-registry.mjs
+++ b/scripts/test-tool-surface-registry.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  TOOL_GROUP_IDS,
+  TOOL_REGISTRATION_MODES,
+  TOOL_SURFACE_REGISTRY,
+  compileToolNames,
+  compileToolSurface,
+  getToolSurfaceEntry,
+} from "../dist/mcp-server/toolSurfaceRegistry.js";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const EXPECTED_UNION_COUNT = 76;
+const EXPECTED_COUNTS_BY_MODE = {
+  live: 72,
+  "hybrid-live": 72,
+  "hybrid-degraded": 45,
+  "headless-readonly": 48,
+  "headless-guarded": 51,
+  "headless-filesystem": 60,
+};
+
+assert.equal(
+  TOOL_SURFACE_REGISTRY.length,
+  EXPECTED_UNION_COUNT,
+  "canonical registry must cover the union of all currently registered tool names",
+);
+
+const names = TOOL_SURFACE_REGISTRY.map((entry) => entry.name);
+assert.equal(new Set(names).size, names.length, "tool names must be unique");
+
+for (const mode of TOOL_REGISTRATION_MODES) {
+  const compiled = compileToolNames({ registrationMode: mode });
+  assert.equal(
+    compiled.length,
+    EXPECTED_COUNTS_BY_MODE[mode],
+    `unexpected full tool count for ${mode}`,
+  );
+  assert.deepEqual(
+    compiled,
+    [...compiled].sort((left, right) => left.localeCompare(right)),
+    `${mode} compilation must be deterministic and sorted`,
+  );
+  assert.equal(
+    new Set(compiled).size,
+    compiled.length,
+    `${mode} compilation must not contain duplicate tools`,
+  );
+}
+
+assert.equal(
+  compileToolNames({ registrationMode: "live" }).length,
+  72,
+  "72 is the current full live/hybrid surface, not the cross-runtime registry size",
+);
+
+for (const entry of TOOL_SURFACE_REGISTRY) {
+  assert.ok(TOOL_GROUP_IDS.includes(entry.group), `unknown group for ${entry.name}`);
+  assert.ok(
+    entry.registrationModes.length > 0,
+    `${entry.name} must be registered in at least one mode`,
+  );
+  if (entry.aliasOf) {
+    assert.equal(entry.surfaceClass, "legacy", `${entry.name} alias must be legacy`);
+    assert.equal(
+      entry.canonicalName,
+      entry.aliasOf,
+      `${entry.name} canonicalName must resolve to aliasOf`,
+    );
+    assert.ok(
+      getToolSurfaceEntry(entry.aliasOf),
+      `${entry.name} points to missing canonical tool ${entry.aliasOf}`,
+    );
+  } else {
+    assert.equal(
+      entry.canonicalName,
+      entry.name,
+      `${entry.name} must be self-canonical when it is not an alias`,
+    );
+  }
+}
+
+assert.equal(getToolSurfaceEntry("smart_search")?.aliasOf, "smart_semantic_search");
+assert.equal(getToolSurfaceEntry("smart-search")?.aliasOf, "smart_semantic_search");
+
+const expectedLifecycleRoles = ["apply", "plan", "recover", "status"];
+const governedFamilies = new Map();
+for (const entry of TOOL_SURFACE_REGISTRY) {
+  if (!entry.lifecycleRole) continue;
+  const items = governedFamilies.get(entry.family) ?? [];
+  items.push(entry);
+  governedFamilies.set(entry.family, items);
+}
+assert.equal(governedFamilies.size, 4, "exactly four governed lifecycle families are expected");
+
+for (const [family, entries] of governedFamilies) {
+  assert.deepEqual(
+    entries.map((entry) => entry.lifecycleRole).sort(),
+    expectedLifecycleRoles,
+    `${family} must expose plan/apply/status/recover as one atomic family`,
+  );
+  assert.equal(
+    new Set(entries.map((entry) => entry.group)).size,
+    1,
+    `${family} lifecycle must stay in one group`,
+  );
+  assert.equal(
+    new Set(entries.map((entry) => entry.registrationModes.join("|"))).size,
+    1,
+    `${family} lifecycle must share one registration boundary`,
+  );
+}
+
+const selected = compileToolSurface({
+  registrationMode: "live",
+  groups: ["semantic.canonical", "validation"],
+});
+assert.deepEqual(
+  selected.map((entry) => entry.name),
+  ["obsidian_validate_format", "smart_semantic_search"],
+  "group composition must expose only the requested canonical tools",
+);
+
+function collectSourceFiles(root) {
+  const result = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const absolute = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      result.push(...collectSourceFiles(absolute));
+    } else if (entry.isFile() && entry.name.endsWith(".ts")) {
+      result.push(absolute);
+    }
+  }
+  return result;
+}
+
+const sourceFiles = collectSourceFiles(path.join(repoRoot, "src", "mcp-server"));
+const sourceCorpus = sourceFiles.map((file) => fs.readFileSync(file, "utf8")).join("\n");
+
+for (const entry of TOOL_SURFACE_REGISTRY) {
+  assert.ok(
+    sourceCorpus.includes(`\"${entry.name}\"`) || sourceCorpus.includes(`'${entry.name}'`),
+    `registry entry ${entry.name} is not present in MCP source`,
+  );
+}
+
+const sourceDeclaredTools = new Set();
+const literalPatterns = [
+  /server\.tool\(\s*["'`]([^"'`]+)["'`]/gu,
+  /const\s+toolName\s*=\s*["'`]([^"'`]+)["'`]/gu,
+  /register\(\s*["'`](smart(?:_|-)[^"'`]+)["'`]/gu,
+  /name:\s*["'`](external_[^"'`]+)["'`]/gu,
+];
+for (const sourceFile of sourceFiles) {
+  const source = fs.readFileSync(sourceFile, "utf8");
+  for (const pattern of literalPatterns) {
+    pattern.lastIndex = 0;
+    for (const match of source.matchAll(pattern)) {
+      sourceDeclaredTools.add(match[1]);
+    }
+  }
+}
+
+for (const name of sourceDeclaredTools) {
+  assert.ok(
+    getToolSurfaceEntry(name),
+    `MCP source declares ${name} but the canonical registry does not`,
+  );
+}
+
+console.log(
+  `PASS: canonical tool registry covers ${TOOL_SURFACE_REGISTRY.length} cross-runtime names; live=${EXPECTED_COUNTS_BY_MODE.live}, headless-filesystem=${EXPECTED_COUNTS_BY_MODE["headless-filesystem"]}`,
+);

--- a/scripts/test-tool-surface-registry.mjs
+++ b/scripts/test-tool-surface-registry.mjs
@@ -137,13 +137,21 @@ function collectSourceFiles(root) {
   return result;
 }
 
-const sourceFiles = collectSourceFiles(path.join(repoRoot, "src", "mcp-server"));
+const registrySource = path.join(
+  repoRoot,
+  "src",
+  "mcp-server",
+  "toolSurfaceRegistry.ts",
+);
+const sourceFiles = collectSourceFiles(path.join(repoRoot, "src", "mcp-server")).filter(
+  (file) => path.resolve(file) !== path.resolve(registrySource),
+);
 const sourceCorpus = sourceFiles.map((file) => fs.readFileSync(file, "utf8")).join("\n");
 
 for (const entry of TOOL_SURFACE_REGISTRY) {
   assert.ok(
     sourceCorpus.includes(`\"${entry.name}\"`) || sourceCorpus.includes(`'${entry.name}'`),
-    `registry entry ${entry.name} is not present in MCP source`,
+    `registry entry ${entry.name} is not present outside the registry itself`,
   );
 }
 

--- a/scripts/test-tool-surface-runtime-conformance.mjs
+++ b/scripts/test-tool-surface-runtime-conformance.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { compileToolNames } from "../dist/mcp-server/toolSurfaceRegistry.js";
+
+const MODES = [
+  "live",
+  "hybrid-live",
+  "hybrid-degraded",
+  "headless-readonly",
+  "headless-guarded",
+  "headless-filesystem",
+];
+
+async function createTempVault() {
+  const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "optimike-tool-surface-"));
+  await mkdir(path.join(vaultRoot, ".obsidian", "optimike-mcp"), {
+    recursive: true,
+  });
+  await writeFile(path.join(vaultRoot, "Root.md"), "# Tool surface smoke\n", "utf8");
+  return vaultRoot;
+}
+
+async function createFakeRestServer() {
+  const server = createServer((request, response) => {
+    if (request.url === "/") {
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify({
+          service: "Obsidian Local REST API",
+          authenticated: true,
+          versions: { obsidian: "surface-smoke", self: "surface-smoke" },
+        }),
+      );
+      return;
+    }
+    response.statusCode = 404;
+    response.end("not found");
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  return {
+    server,
+    url: `http://127.0.0.1:${address.port}`,
+  };
+}
+
+async function listToolsForMode(registrationMode) {
+  const vaultRoot = await createTempVault();
+  const needsRest = registrationMode === "live" || registrationMode === "hybrid-live";
+  const fakeRest = needsRest ? await createFakeRestServer() : undefined;
+  const runtimeMode = registrationMode.startsWith("hybrid")
+    ? "hybrid"
+    : registrationMode;
+  const apiKey = needsRest ? "surface-smoke-key" : "";
+  const writeMode =
+    registrationMode === "headless-readonly" ||
+    registrationMode === "hybrid-degraded"
+      ? "readonly"
+      : registrationMode === "headless-guarded" ||
+          registrationMode === "headless-filesystem"
+        ? "guarded"
+        : "full";
+
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["dist/index.js"],
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      OBSIDIAN_RUNTIME_MODE: runtimeMode,
+      OBSIDIAN_VAULT: vaultRoot,
+      OBSIDIAN_CACHE_SOURCE: "filesystem",
+      OBSIDIAN_SHARED_CACHE_DB_PATH: path.join(
+        vaultRoot,
+        ".obsidian",
+        "optimike-mcp",
+        "shared-cache.sqlite",
+      ),
+      OBSIDIAN_ENABLE_CACHE: "true",
+      OBSIDIAN_API_KEY: apiKey,
+      OBSIDIAN_BASE_URL: fakeRest?.url ?? "http://127.0.0.1:9",
+      OBSIDIAN_STARTUP_BLOCKING: "true",
+      SEMANTIC_SEARCH_PREWARM: "false",
+      MCP_TRANSPORT_TYPE: "stdio",
+      MCP_LOG_LEVEL: "error",
+      MCP_WRITE_MODE: writeMode,
+    },
+  });
+  const client = new Client({
+    name: `optimike-tool-surface-${registrationMode}`,
+    version: "0",
+  });
+
+  try {
+    await client.connect(transport);
+    const tools = await client.listTools();
+    return tools.tools.map((tool) => tool.name).sort((a, b) => a.localeCompare(b));
+  } finally {
+    await client.close().catch(() => undefined);
+    await transport.close().catch(() => undefined);
+    if (fakeRest) {
+      await new Promise((resolve) => fakeRest.server.close(resolve));
+    }
+    await rm(vaultRoot, { recursive: true, force: true });
+  }
+}
+
+for (const registrationMode of MODES) {
+  const actual = await listToolsForMode(registrationMode);
+  const expected = [...compileToolNames({ registrationMode })];
+  assert.deepEqual(
+    actual,
+    expected,
+    `${registrationMode} tools/list diverges from the canonical registry`,
+  );
+  console.log(`PASS ${registrationMode}: ${actual.length} tools`);
+}
+
+console.log("PASS: runtime tools/list matches the canonical registry in every registration mode");

--- a/scripts/test-tool-surface-runtime-conformance.mjs
+++ b/scripts/test-tool-surface-runtime-conformance.mjs
@@ -102,7 +102,6 @@ async function listToolsForMode(registrationMode) {
     return tools.tools.map((tool) => tool.name).sort((a, b) => a.localeCompare(b));
   } finally {
     await client.close().catch(() => undefined);
-    await transport.close().catch(() => undefined);
     if (fakeRest) {
       await new Promise((resolve) => fakeRest.server.close(resolve));
     }

--- a/src/mcp-server/toolSurfaceRegistry.ts
+++ b/src/mcp-server/toolSurfaceRegistry.ts
@@ -18,12 +18,16 @@ export const TOOL_GROUP_IDS = [
   "canvas.governed",
   "external.move",
   "external.read",
-  "metadata.direct",
+  "metadata.direct.batch",
+  "metadata.direct.frontmatter",
+  "metadata.direct.tags",
   "metadata.governed",
-  "notes.direct",
+  "notes.direct.admin",
+  "notes.direct.common",
   "notes.governed",
   "notes.read",
-  "runtime",
+  "runtime.maintenance",
+  "runtime.status",
   "semantic.canonical",
   "semantic.legacy",
   "tasks.markdown",
@@ -46,6 +50,12 @@ export type ToolAnnotationClass =
   | "governed-mutation";
 
 export type GovernedLifecycleRole = "plan" | "apply" | "status" | "recover";
+export type ToolStaticRequirement = "vault-cache";
+
+export interface ToolAvailabilityRule {
+  modes: readonly ToolRegistrationMode[];
+  requires: readonly ToolStaticRequirement[];
+}
 
 export interface ToolSurfaceEntry {
   name: string;
@@ -57,6 +67,8 @@ export interface ToolSurfaceEntry {
   annotationClass: ToolAnnotationClass;
   lifecycleRole?: GovernedLifecycleRole;
   aliasOf?: string;
+  preferredAlternativeFamily?: string;
+  availabilityRules?: readonly ToolAvailabilityRule[];
 }
 
 const ALL_MODES = TOOL_REGISTRATION_MODES;
@@ -102,6 +114,8 @@ function defineTool(
     annotationClass?: ToolAnnotationClass;
     lifecycleRole?: GovernedLifecycleRole;
     aliasOf?: string;
+    preferredAlternativeFamily?: string;
+    availabilityRules?: readonly ToolAvailabilityRule[];
   } = {},
 ): ToolSurfaceEntry {
   return {
@@ -114,6 +128,12 @@ function defineTool(
     annotationClass: options.annotationClass ?? "read-only",
     ...(options.lifecycleRole ? { lifecycleRole: options.lifecycleRole } : {}),
     ...(options.aliasOf ? { aliasOf: options.aliasOf } : {}),
+    ...(options.preferredAlternativeFamily
+      ? { preferredAlternativeFamily: options.preferredAlternativeFamily }
+      : {}),
+    ...(options.availabilityRules
+      ? { availabilityRules: options.availabilityRules }
+      : {}),
   };
 }
 
@@ -172,33 +192,40 @@ const OPERON_MUTATION_TOOLS = [
 export const TOOL_SURFACE_REGISTRY: readonly ToolSurfaceEntry[] = [
   defineTool("obsidian_read_note", "notes.read", "notes-core", ALL_MODES),
   defineTool("obsidian_list_notes", "notes.read", "notes-core", ALL_MODES),
-  defineTool("obsidian_global_search", "notes.read", "notes-core", ALL_MODES),
+  defineTool("obsidian_global_search", "notes.read", "notes-core", ALL_MODES, {
+    availabilityRules: [
+      {
+        modes: ALL_MODES,
+        requires: ["vault-cache"],
+      },
+    ],
+  }),
 
   defineTool(
     "obsidian_update_note",
-    "notes.direct",
+    "notes.direct.common",
     "notes-core",
     GUARDED_NOTE_MODES,
     { surfaceClass: "direct", annotationClass: "destructive" },
   ),
   defineTool(
     "obsidian_search_replace",
-    "notes.direct",
+    "notes.direct.common",
     "notes-core",
     GUARDED_NOTE_MODES,
     { surfaceClass: "direct", annotationClass: "destructive" },
   ),
   defineTool(
     "obsidian_delete_note",
-    "notes.direct",
-    "notes-core",
+    "notes.direct.admin",
+    "notes-admin",
     LIVE_OR_FILESYSTEM_MODES,
     { surfaceClass: "direct", annotationClass: "destructive" },
   ),
   defineTool(
     "obsidian_move_note",
-    "notes.direct",
-    "notes-core",
+    "notes.direct.admin",
+    "notes-admin",
     FILESYSTEM_ONLY,
     { surfaceClass: "direct", annotationClass: "destructive" },
   ),
@@ -211,22 +238,26 @@ export const TOOL_SURFACE_REGISTRY: readonly ToolSurfaceEntry[] = [
 
   defineTool(
     "obsidian_manage_frontmatter",
-    "metadata.direct",
-    "frontmatter",
+    "metadata.direct.frontmatter",
+    "frontmatter-direct",
     GUARDED_NOTE_MODES,
-    { surfaceClass: "direct", annotationClass: "destructive" },
+    {
+      surfaceClass: "direct",
+      annotationClass: "destructive",
+      preferredAlternativeFamily: "frontmatter-patch",
+    },
   ),
   defineTool(
     "obsidian_manage_tags",
-    "metadata.direct",
+    "metadata.direct.tags",
     "tags",
     LIVE_OR_FILESYSTEM_MODES,
     { surfaceClass: "direct", annotationClass: "destructive" },
   ),
   defineTool(
     "obsidian_batch_frontmatter",
-    "metadata.direct",
-    "frontmatter",
+    "metadata.direct.batch",
+    "frontmatter-batch",
     FILESYSTEM_ONLY,
     { surfaceClass: "direct", annotationClass: "destructive" },
   ),
@@ -237,9 +268,30 @@ export const TOOL_SURFACE_REGISTRY: readonly ToolSurfaceEntry[] = [
     "frontmatter-patch",
   ),
 
-  defineTool("bases_list", "bases.read", "bases", BASE_READ_MODES),
-  defineTool("bases_get_schema", "bases.read", "bases", BASE_READ_MODES),
-  defineTool("bases_query", "bases.read", "bases", BASE_READ_MODES),
+  defineTool("bases_list", "bases.read", "bases", BASE_READ_MODES, {
+    availabilityRules: [
+      {
+        modes: ["headless-readonly"],
+        requires: ["vault-cache"],
+      },
+    ],
+  }),
+  defineTool("bases_get_schema", "bases.read", "bases", BASE_READ_MODES, {
+    availabilityRules: [
+      {
+        modes: ["headless-readonly"],
+        requires: ["vault-cache"],
+      },
+    ],
+  }),
+  defineTool("bases_query", "bases.read", "bases", BASE_READ_MODES, {
+    availabilityRules: [
+      {
+        modes: ["headless-readonly"],
+        requires: ["vault-cache"],
+      },
+    ],
+  }),
 
   defineTool(
     "bases_create",
@@ -274,7 +326,11 @@ export const TOOL_SURFACE_REGISTRY: readonly ToolSurfaceEntry[] = [
     "canvas.direct",
     "canvas",
     FILESYSTEM_ONLY,
-    { surfaceClass: "direct", annotationClass: "destructive" },
+    {
+      surfaceClass: "direct",
+      annotationClass: "destructive",
+      preferredAlternativeFamily: "canvas-patch",
+    },
   ),
 
   ...governedFamily(
@@ -342,10 +398,10 @@ export const TOOL_SURFACE_REGISTRY: readonly ToolSurfaceEntry[] = [
     },
   ),
 
-  defineTool("obsidian_runtime_status", "runtime", "runtime", ALL_MODES),
+  defineTool("obsidian_runtime_status", "runtime.status", "runtime", ALL_MODES),
   defineTool(
     "obsidian_runtime_maintenance",
-    "runtime",
+    "runtime.maintenance",
     "runtime",
     ALL_MODES,
     { annotationClass: "maintenance" },
@@ -440,17 +496,36 @@ export const TOOL_SURFACE_REGISTRY: readonly ToolSurfaceEntry[] = [
 export interface CompileToolSurfaceInput {
   registrationMode: ToolRegistrationMode;
   groups?: readonly ToolGroupId[];
+  availableStaticRequirements?: readonly ToolStaticRequirement[];
+}
+
+function staticRequirementsSatisfied(
+  entry: ToolSurfaceEntry,
+  registrationMode: ToolRegistrationMode,
+  availableStaticRequirements: readonly ToolStaticRequirement[] | undefined,
+): boolean {
+  if (!availableStaticRequirements) return true;
+  const available = new Set<ToolStaticRequirement>(availableStaticRequirements);
+  return (entry.availabilityRules ?? [])
+    .filter((rule) => rule.modes.includes(registrationMode))
+    .every((rule) => rule.requires.every((requirement) => available.has(requirement)));
 }
 
 export function compileToolSurface({
   registrationMode,
   groups = TOOL_GROUP_IDS,
+  availableStaticRequirements,
 }: CompileToolSurfaceInput): readonly ToolSurfaceEntry[] {
   const selectedGroups = new Set<ToolGroupId>(groups);
   return TOOL_SURFACE_REGISTRY.filter(
     (entry) =>
       selectedGroups.has(entry.group) &&
-      entry.registrationModes.includes(registrationMode),
+      entry.registrationModes.includes(registrationMode) &&
+      staticRequirementsSatisfied(
+        entry,
+        registrationMode,
+        availableStaticRequirements,
+      ),
   ).sort((left, right) => left.name.localeCompare(right.name));
 }
 

--- a/src/mcp-server/toolSurfaceRegistry.ts
+++ b/src/mcp-server/toolSurfaceRegistry.ts
@@ -1,0 +1,467 @@
+export const TOOL_REGISTRATION_MODES = [
+  "live",
+  "hybrid-live",
+  "hybrid-degraded",
+  "headless-readonly",
+  "headless-guarded",
+  "headless-filesystem",
+] as const;
+
+export type ToolRegistrationMode = (typeof TOOL_REGISTRATION_MODES)[number];
+
+export const TOOL_GROUP_IDS = [
+  "admin",
+  "bases.direct",
+  "bases.governed",
+  "bases.read",
+  "canvas.direct",
+  "canvas.governed",
+  "external.move",
+  "external.read",
+  "metadata.direct",
+  "metadata.governed",
+  "notes.direct",
+  "notes.governed",
+  "notes.read",
+  "runtime",
+  "semantic.canonical",
+  "semantic.legacy",
+  "tasks.markdown",
+  "tasks.operon.read",
+  "tasks.operon.write",
+  "validation",
+] as const;
+
+export type ToolGroupId = (typeof TOOL_GROUP_IDS)[number];
+
+export type ToolSurfaceClass = "canonical" | "direct" | "legacy";
+
+export type ToolAnnotationClass =
+  | "read-only"
+  | "read-only-open-world"
+  | "mutation"
+  | "destructive"
+  | "maintenance"
+  | "governed-plan"
+  | "governed-mutation";
+
+export type GovernedLifecycleRole = "plan" | "apply" | "status" | "recover";
+
+export interface ToolSurfaceEntry {
+  name: string;
+  canonicalName: string;
+  group: ToolGroupId;
+  family: string;
+  registrationModes: readonly ToolRegistrationMode[];
+  surfaceClass: ToolSurfaceClass;
+  annotationClass: ToolAnnotationClass;
+  lifecycleRole?: GovernedLifecycleRole;
+  aliasOf?: string;
+}
+
+const ALL_MODES = TOOL_REGISTRATION_MODES;
+
+const LIVE_MODES = [
+  "live",
+  "hybrid-live",
+] as const satisfies readonly ToolRegistrationMode[];
+
+const BASE_READ_MODES = [
+  "live",
+  "hybrid-live",
+  "headless-readonly",
+  "headless-guarded",
+  "headless-filesystem",
+] as const satisfies readonly ToolRegistrationMode[];
+
+const GUARDED_NOTE_MODES = [
+  "live",
+  "hybrid-live",
+  "headless-guarded",
+  "headless-filesystem",
+] as const satisfies readonly ToolRegistrationMode[];
+
+const LIVE_OR_FILESYSTEM_MODES = [
+  "live",
+  "hybrid-live",
+  "headless-filesystem",
+] as const satisfies readonly ToolRegistrationMode[];
+
+const FILESYSTEM_ONLY = [
+  "headless-filesystem",
+] as const satisfies readonly ToolRegistrationMode[];
+
+function defineTool(
+  name: string,
+  group: ToolGroupId,
+  family: string,
+  registrationModes: readonly ToolRegistrationMode[],
+  options: {
+    canonicalName?: string;
+    surfaceClass?: ToolSurfaceClass;
+    annotationClass?: ToolAnnotationClass;
+    lifecycleRole?: GovernedLifecycleRole;
+    aliasOf?: string;
+  } = {},
+): ToolSurfaceEntry {
+  return {
+    name,
+    canonicalName: options.canonicalName ?? options.aliasOf ?? name,
+    group,
+    family,
+    registrationModes,
+    surfaceClass: options.surfaceClass ?? "canonical",
+    annotationClass: options.annotationClass ?? "read-only",
+    ...(options.lifecycleRole ? { lifecycleRole: options.lifecycleRole } : {}),
+    ...(options.aliasOf ? { aliasOf: options.aliasOf } : {}),
+  };
+}
+
+function governedFamily(
+  prefix: string,
+  group: ToolGroupId,
+  family: string,
+): readonly ToolSurfaceEntry[] {
+  return [
+    defineTool(`${prefix}_plan`, group, family, LIVE_MODES, {
+      annotationClass: "governed-plan",
+      lifecycleRole: "plan",
+    }),
+    defineTool(`${prefix}_apply`, group, family, LIVE_MODES, {
+      annotationClass: "governed-mutation",
+      lifecycleRole: "apply",
+    }),
+    defineTool(`${prefix}_status`, group, family, LIVE_MODES, {
+      lifecycleRole: "status",
+    }),
+    defineTool(`${prefix}_recover`, group, family, LIVE_MODES, {
+      annotationClass: "governed-mutation",
+      lifecycleRole: "recover",
+    }),
+  ];
+}
+
+const OPERON_READ_TOOLS = [
+  "operon_status",
+  "operon_get_configuration",
+  "operon_list_tasks",
+  "operon_query_tasks",
+  "operon_query_saved_filter",
+  "operon_get_task",
+  "operon_validate",
+  "operon_get_diagnostics",
+  "operon_find_tasks",
+  "operon_resolve_task",
+  "operon_get_relationships",
+  "operon_build_context",
+  "operon_get_timer_state",
+  "operon_list_pending_recoveries",
+] as const;
+
+const OPERON_MUTATION_TOOLS = [
+  "operon_adopt_task",
+  "operon_create_task",
+  "operon_update_task",
+  "operon_transition_task",
+  "operon_relocate_task",
+  "operon_set_relationships",
+  "operon_update_recurrence",
+  "operon_recover_mutation",
+] as const;
+
+export const TOOL_SURFACE_REGISTRY: readonly ToolSurfaceEntry[] = [
+  defineTool("obsidian_read_note", "notes.read", "notes-core", ALL_MODES),
+  defineTool("obsidian_list_notes", "notes.read", "notes-core", ALL_MODES),
+  defineTool("obsidian_global_search", "notes.read", "notes-core", ALL_MODES),
+
+  defineTool(
+    "obsidian_update_note",
+    "notes.direct",
+    "notes-core",
+    GUARDED_NOTE_MODES,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+  defineTool(
+    "obsidian_search_replace",
+    "notes.direct",
+    "notes-core",
+    GUARDED_NOTE_MODES,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+  defineTool(
+    "obsidian_delete_note",
+    "notes.direct",
+    "notes-core",
+    LIVE_OR_FILESYSTEM_MODES,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+  defineTool(
+    "obsidian_move_note",
+    "notes.direct",
+    "notes-core",
+    FILESYSTEM_ONLY,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+
+  ...governedFamily(
+    "obsidian_note_replace",
+    "notes.governed",
+    "note-replace",
+  ),
+
+  defineTool(
+    "obsidian_manage_frontmatter",
+    "metadata.direct",
+    "frontmatter",
+    GUARDED_NOTE_MODES,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+  defineTool(
+    "obsidian_manage_tags",
+    "metadata.direct",
+    "tags",
+    LIVE_OR_FILESYSTEM_MODES,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+  defineTool(
+    "obsidian_batch_frontmatter",
+    "metadata.direct",
+    "frontmatter",
+    FILESYSTEM_ONLY,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+
+  ...governedFamily(
+    "obsidian_frontmatter_patch",
+    "metadata.governed",
+    "frontmatter-patch",
+  ),
+
+  defineTool("bases_list", "bases.read", "bases", BASE_READ_MODES),
+  defineTool("bases_get_schema", "bases.read", "bases", BASE_READ_MODES),
+  defineTool("bases_query", "bases.read", "bases", BASE_READ_MODES),
+
+  defineTool(
+    "bases_create",
+    "bases.direct",
+    "bases",
+    LIVE_OR_FILESYSTEM_MODES,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+  defineTool(
+    "bases_upsert_config",
+    "bases.direct",
+    "bases",
+    LIVE_OR_FILESYSTEM_MODES,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+  defineTool(
+    "bases_upsert_rows",
+    "bases.direct",
+    "bases",
+    LIVE_OR_FILESYSTEM_MODES,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+
+  ...governedFamily(
+    "bases_formula_patch",
+    "bases.governed",
+    "base-formula-patch",
+  ),
+
+  defineTool(
+    "obsidian_manage_canvas",
+    "canvas.direct",
+    "canvas",
+    FILESYSTEM_ONLY,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+
+  ...governedFamily(
+    "obsidian_canvas_patch",
+    "canvas.governed",
+    "canvas-patch",
+  ),
+
+  defineTool(
+    "list_all_tasks",
+    "tasks.markdown",
+    "markdown-tasks",
+    ALL_MODES,
+  ),
+  defineTool(
+    "query_tasks",
+    "tasks.markdown",
+    "markdown-tasks",
+    ALL_MODES,
+  ),
+
+  ...OPERON_READ_TOOLS.map((name) =>
+    defineTool(name, "tasks.operon.read", "operon", ALL_MODES),
+  ),
+  ...OPERON_MUTATION_TOOLS.map((name) =>
+    defineTool(name, "tasks.operon.write", "operon", ALL_MODES, {
+      annotationClass: "mutation",
+    }),
+  ),
+  defineTool(
+    "operon_convert_task",
+    "tasks.operon.write",
+    "operon",
+    ALL_MODES,
+    { annotationClass: "destructive" },
+  ),
+
+  defineTool(
+    "smart_semantic_search",
+    "semantic.canonical",
+    "semantic-search",
+    ALL_MODES,
+    { annotationClass: "read-only-open-world" },
+  ),
+  defineTool(
+    "smart_search",
+    "semantic.legacy",
+    "semantic-search",
+    ALL_MODES,
+    {
+      aliasOf: "smart_semantic_search",
+      surfaceClass: "legacy",
+      annotationClass: "read-only-open-world",
+    },
+  ),
+  defineTool(
+    "smart-search",
+    "semantic.legacy",
+    "semantic-search",
+    ALL_MODES,
+    {
+      aliasOf: "smart_semantic_search",
+      surfaceClass: "legacy",
+      annotationClass: "read-only-open-world",
+    },
+  ),
+
+  defineTool("obsidian_runtime_status", "runtime", "runtime", ALL_MODES),
+  defineTool(
+    "obsidian_runtime_maintenance",
+    "runtime",
+    "runtime",
+    ALL_MODES,
+    { annotationClass: "maintenance" },
+  ),
+
+  defineTool(
+    "obsidian_validate_format",
+    "validation",
+    "format-validation",
+    ALL_MODES,
+  ),
+
+  defineTool(
+    "obsidian_admin_filesystem",
+    "admin",
+    "filesystem-admin",
+    FILESYSTEM_ONLY,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+
+  defineTool(
+    "external_runtime_status",
+    "external.read",
+    "external-roots",
+    ALL_MODES,
+  ),
+  defineTool(
+    "external_roots_list",
+    "external.read",
+    "external-roots",
+    ALL_MODES,
+  ),
+  defineTool(
+    "external_list",
+    "external.read",
+    "external-roots",
+    ALL_MODES,
+  ),
+  defineTool(
+    "external_stat",
+    "external.read",
+    "external-roots",
+    ALL_MODES,
+  ),
+  defineTool(
+    "external_read",
+    "external.read",
+    "external-roots",
+    ALL_MODES,
+  ),
+  defineTool(
+    "external_handoff",
+    "external.read",
+    "external-roots",
+    ALL_MODES,
+  ),
+  defineTool(
+    "external_references_scan",
+    "external.read",
+    "external-roots",
+    ALL_MODES,
+  ),
+
+  defineTool(
+    "external_move_plan",
+    "external.move",
+    "external-move",
+    ALL_MODES,
+  ),
+  defineTool(
+    "external_move_status",
+    "external.move",
+    "external-move",
+    ALL_MODES,
+  ),
+  defineTool(
+    "external_move_apply",
+    "external.move",
+    "external-move",
+    ALL_MODES,
+    { annotationClass: "destructive" },
+  ),
+  defineTool(
+    "external_move_rollback",
+    "external.move",
+    "external-move",
+    ALL_MODES,
+    { annotationClass: "destructive" },
+  ),
+] as const;
+
+export interface CompileToolSurfaceInput {
+  registrationMode: ToolRegistrationMode;
+  groups?: readonly ToolGroupId[];
+}
+
+export function compileToolSurface({
+  registrationMode,
+  groups = TOOL_GROUP_IDS,
+}: CompileToolSurfaceInput): readonly ToolSurfaceEntry[] {
+  const selectedGroups = new Set<ToolGroupId>(groups);
+  return TOOL_SURFACE_REGISTRY.filter(
+    (entry) =>
+      selectedGroups.has(entry.group) &&
+      entry.registrationModes.includes(registrationMode),
+  ).sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export function compileToolNames(
+  input: CompileToolSurfaceInput,
+): readonly string[] {
+  return compileToolSurface(input).map((entry) => entry.name);
+}
+
+export function getToolSurfaceEntry(
+  name: string,
+): ToolSurfaceEntry | undefined {
+  return TOOL_SURFACE_REGISTRY.find((entry) => entry.name === name);
+}


### PR DESCRIPTION
## Scope

Implements P0 of the planned 2.10 portable tool-surface work without changing transport behavior or default exposure.

- adds one canonical cross-runtime registry for MCP tools;
- separates tool groups from future public profiles so there is only one source of truth;
- records family, registration modes, canonical/direct/legacy class, annotation class, aliases, and governed lifecycle role;
- models the actual union as 76 unique names while preserving the current 72-tool full live/hybrid surface;
- adds a compiler that projects groups onto a concrete registration mode;
- adds contract tests for counts, alias integrity, deterministic compilation, source coverage, and atomic plan/apply/status/recover families;
- adds a runtime conformance test comparing the real `tools/list` result with the registry across live, hybrid-live, hybrid-degraded and the three headless modes;
- adds Linux/Windows CI for the P0 contract.

## Semantic-search compatibility policy

P0 deliberately keeps `smart_search` and `smart-search` in the registry as `legacy` aliases of `smart_semantic_search`.

Planned P1 behavior for 2.10:

- modern profiles (`standard`, `authoring`, `tasks`) expose only `smart_semantic_search`;
- `full` preserves the two legacy aliases during the 2.x line;
- physical alias removal is deferred to 3.0 unless an explicit SemVer break is chosen later.

This removes the duplicate choice from the normal agent surface without silently breaking an existing public client.

## Non-goals

This PR does not yet add `standard`, `authoring`, `tasks`, or `full` profile definitions, CLI/env selection, HTTP profile routes, session binding, or client-specific configuration. Those remain P1-P4.

## Important invariants

- Governed lifecycle families are complete quartets. P1 must compose them atomically; no profile may expose only part of plan/apply/status/recover.
- Session/profile binding belongs to P3. Durable governed plans must never derive authority from the profile that created them.
- Visibility is not authorization: existing runtime/write/security gates remain authoritative.

## Validation

The dedicated workflow builds TypeScript and runs both registry-contract and real-runtime `tools/list` conformance tests on Ubuntu and Windows.