### PR TITLE
feat: add portable MCP tool profiles

### DIFF
--- a/.github/workflows/tool-surface-p0.yml
+++ b/.github/workflows/tool-surface-p0.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.7.5"
+          node-version: "22"
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/tool-surface-p1.yml
+++ b/.github/workflows/tool-surface-p1.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.7.5"
+          node-version: "22"
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/tool-surface-p1.yml
+++ b/.github/workflows/tool-surface-p1.yml
@@ -1,0 +1,35 @@
+name: Tool Surface P1
+
+on:
+  pull_request:
+    paths:
+      - "src/mcp-server/toolSurfaceRegistry.ts"
+      - "src/mcp-server/toolProfiles.ts"
+      - "scripts/test-tool-surface-registry.mjs"
+      - "scripts/test-tool-profiles.mjs"
+      - ".github/workflows/tool-surface-p1.yml"
+  push:
+    branches:
+      - "agent/tool-surface-p1"
+
+permissions:
+  contents: read
+
+jobs:
+  profiles:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.7.5"
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: node scripts/test-tool-surface-registry.mjs
+      - run: node scripts/test-tool-profiles.mjs

--- a/scripts/test-tool-profiles.mjs
+++ b/scripts/test-tool-profiles.mjs
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import {
+  TOOL_PROFILE_IDS,
+  TOOL_PROFILES,
+  compileToolProfile,
+  compileToolProfileNames,
+  parseToolProfileId,
+} from "../dist/mcp-server/toolProfiles.js";
+import { TOOL_REGISTRATION_MODES } from "../dist/mcp-server/toolSurfaceRegistry.js";
+
+const WITH_CACHE = ["vault-cache"];
+
+const EXPECTED_COUNTS = {
+  live: { standard: 19, authoring: 31, tasks: 31, full: 72 },
+  "hybrid-live": { standard: 19, authoring: 31, tasks: 31, full: 72 },
+  "hybrid-degraded": { standard: 6, authoring: 6, tasks: 31, full: 45 },
+  "headless-readonly": { standard: 9, authoring: 9, tasks: 31, full: 48 },
+  "headless-guarded": { standard: 12, authoring: 12, tasks: 31, full: 51 },
+  "headless-filesystem": { standard: 12, authoring: 17, tasks: 31, full: 60 },
+};
+
+assert.deepEqual(TOOL_PROFILE_IDS, ["standard", "authoring", "tasks", "full"]);
+for (const profile of TOOL_PROFILE_IDS) {
+  assert.equal(TOOL_PROFILES[profile].id, profile);
+  assert.ok(TOOL_PROFILES[profile].groups.length > 0);
+}
+
+assert.equal(parseToolProfileId("standard"), "standard");
+assert.throws(() => parseToolProfileId("standrad"), /Unknown MCP tool profile/);
+assert.throws(() => parseToolProfileId(""), /Unknown MCP tool profile/);
+
+for (const registrationMode of TOOL_REGISTRATION_MODES) {
+  for (const profile of TOOL_PROFILE_IDS) {
+    const names = compileToolProfileNames({
+      profile,
+      registrationMode,
+      availableStaticRequirements: WITH_CACHE,
+    });
+    assert.equal(
+      names.length,
+      EXPECTED_COUNTS[registrationMode][profile],
+      `${profile}/${registrationMode} count drifted`,
+    );
+    assert.deepEqual(
+      names,
+      [...names].sort((left, right) => left.localeCompare(right)),
+      `${profile}/${registrationMode} must be deterministically sorted`,
+    );
+    assert.equal(
+      new Set(names).size,
+      names.length,
+      `${profile}/${registrationMode} must not contain duplicates`,
+    );
+  }
+}
+
+for (const profile of ["standard", "authoring", "tasks"]) {
+  for (const registrationMode of TOOL_REGISTRATION_MODES) {
+    const names = compileToolProfileNames({
+      profile,
+      registrationMode,
+      availableStaticRequirements: WITH_CACHE,
+    });
+    assert.ok(
+      names.includes("smart_semantic_search"),
+      `${profile}/${registrationMode} lost canonical semantic search`,
+    );
+    assert.ok(
+      !names.includes("smart_search") && !names.includes("smart-search"),
+      `${profile}/${registrationMode} must hide semantic-search compatibility aliases`,
+    );
+    for (const hidden of [
+      "obsidian_runtime_maintenance",
+      "obsidian_admin_filesystem",
+      "external_runtime_status",
+      "external_read",
+      "external_move_plan",
+    ]) {
+      assert.ok(
+        !names.includes(hidden),
+        `${profile}/${registrationMode} unexpectedly exposes ${hidden}`,
+      );
+    }
+  }
+}
+
+for (const registrationMode of TOOL_REGISTRATION_MODES) {
+  const full = compileToolProfileNames({
+    profile: "full",
+    registrationMode,
+    availableStaticRequirements: WITH_CACHE,
+  });
+  assert.ok(full.includes("smart_semantic_search"));
+  assert.ok(full.includes("smart_search"));
+  assert.ok(full.includes("smart-search"));
+}
+
+for (const profile of TOOL_PROFILE_IDS) {
+  for (const registrationMode of TOOL_REGISTRATION_MODES) {
+    const entries = compileToolProfile({
+      profile,
+      registrationMode,
+      availableStaticRequirements: WITH_CACHE,
+    });
+    const lifecycleFamilies = new Map();
+    for (const entry of entries) {
+      if (!entry.lifecycleRole) continue;
+      const roles = lifecycleFamilies.get(entry.family) ?? [];
+      roles.push(entry.lifecycleRole);
+      lifecycleFamilies.set(entry.family, roles);
+    }
+    for (const [family, roles] of lifecycleFamilies) {
+      assert.deepEqual(
+        roles.sort(),
+        ["apply", "plan", "recover", "status"],
+        `${profile}/${registrationMode} exposes a partial ${family} lifecycle`,
+      );
+    }
+  }
+}
+
+for (const profile of ["standard", "authoring"]) {
+  const live = compileToolProfileNames({
+    profile,
+    registrationMode: "live",
+    availableStaticRequirements: WITH_CACHE,
+  });
+  assert.ok(live.includes("obsidian_frontmatter_patch_plan"));
+  assert.ok(
+    !live.includes("obsidian_manage_frontmatter"),
+    `${profile}/live must prefer the governed frontmatter family`,
+  );
+
+  const guarded = compileToolProfileNames({
+    profile,
+    registrationMode: "headless-guarded",
+    availableStaticRequirements: WITH_CACHE,
+  });
+  assert.ok(
+    guarded.includes("obsidian_manage_frontmatter"),
+    `${profile}/headless-guarded must keep the direct frontmatter fallback`,
+  );
+  assert.ok(!guarded.includes("obsidian_frontmatter_patch_plan"));
+}
+
+const tasksLive = compileToolProfileNames({
+  profile: "tasks",
+  registrationMode: "live",
+  availableStaticRequirements: WITH_CACHE,
+});
+for (const required of [
+  "operon_list_tasks",
+  "operon_query_tasks",
+  "operon_create_task",
+  "operon_update_task",
+  "operon_transition_task",
+  "operon_list_pending_recoveries",
+  "operon_recover_mutation",
+  "list_all_tasks",
+  "query_tasks",
+]) {
+  assert.ok(tasksLive.includes(required), `tasks profile lost ${required}`);
+}
+
+const standardWithoutCache = compileToolProfileNames({
+  profile: "standard",
+  registrationMode: "live",
+  availableStaticRequirements: [],
+});
+assert.ok(!standardWithoutCache.includes("obsidian_global_search"));
+assert.equal(standardWithoutCache.length, 18);
+
+const readonlyWithoutCache = compileToolProfileNames({
+  profile: "standard",
+  registrationMode: "headless-readonly",
+  availableStaticRequirements: [],
+});
+for (const absent of [
+  "obsidian_global_search",
+  "bases_list",
+  "bases_get_schema",
+  "bases_query",
+]) {
+  assert.ok(!readonlyWithoutCache.includes(absent));
+}
+assert.equal(readonlyWithoutCache.length, 5);
+
+console.log("PASS: standard, authoring, tasks and full profiles are deterministic, portable and SemVer-safe for semantic aliases");

--- a/src/mcp-server/toolProfiles.ts
+++ b/src/mcp-server/toolProfiles.ts
@@ -1,0 +1,164 @@
+import {
+  TOOL_GROUP_IDS,
+  compileToolSurface,
+  type ToolGroupId,
+  type ToolRegistrationMode,
+  type ToolStaticRequirement,
+  type ToolSurfaceEntry,
+} from "./toolSurfaceRegistry.js";
+
+export const TOOL_PROFILE_IDS = [
+  "standard",
+  "authoring",
+  "tasks",
+  "full",
+] as const;
+
+export type ToolProfileId = (typeof TOOL_PROFILE_IDS)[number];
+
+export interface ToolProfileDefinition {
+  id: ToolProfileId;
+  description: string;
+  groups: readonly ToolGroupId[];
+  preferCanonicalAlternatives: boolean;
+}
+
+const STANDARD_GROUPS = [
+  "notes.read",
+  "notes.direct.common",
+  "notes.governed",
+  "metadata.direct.frontmatter",
+  "metadata.governed",
+  "bases.read",
+  "semantic.canonical",
+  "runtime.status",
+  "validation",
+] as const satisfies readonly ToolGroupId[];
+
+const AUTHORING_GROUPS = [
+  ...STANDARD_GROUPS,
+  "metadata.direct.tags",
+  "bases.direct",
+  "bases.governed",
+  "canvas.direct",
+  "canvas.governed",
+] as const satisfies readonly ToolGroupId[];
+
+const TASK_GROUPS = [
+  "notes.read",
+  "tasks.markdown",
+  "tasks.operon.read",
+  "tasks.operon.write",
+  "semantic.canonical",
+  "runtime.status",
+  "validation",
+] as const satisfies readonly ToolGroupId[];
+
+export const TOOL_PROFILES: Readonly<Record<ToolProfileId, ToolProfileDefinition>> = {
+  standard: {
+    id: "standard",
+    description:
+      "General Obsidian work: read/search, canonical semantic search, bounded direct note edits, governed note/frontmatter lifecycles when available, Bases reads, format validation and runtime status.",
+    groups: STANDARD_GROUPS,
+    preferCanonicalAlternatives: true,
+  },
+  authoring: {
+    id: "authoring",
+    description:
+      "Content and structure authoring: standard plus tags, Bases writes/formulas and Canvas mutation surfaces appropriate to the active runtime.",
+    groups: AUTHORING_GROUPS,
+    preferCanonicalAlternatives: true,
+  },
+  tasks: {
+    id: "tasks",
+    description:
+      "Task-focused work: note context, Markdown Tasks compatibility, the complete Operon MCP contract, canonical semantic search, validation and runtime status.",
+    groups: TASK_GROUPS,
+    preferCanonicalAlternatives: true,
+  },
+  full: {
+    id: "full",
+    description:
+      "Compatibility surface: every tool registered by the active runtime, including legacy aliases, admin, maintenance and external-root capabilities.",
+    groups: TOOL_GROUP_IDS,
+    preferCanonicalAlternatives: false,
+  },
+};
+
+export function isToolProfileId(value: string): value is ToolProfileId {
+  return (TOOL_PROFILE_IDS as readonly string[]).includes(value);
+}
+
+export function parseToolProfileId(value: string): ToolProfileId {
+  if (!isToolProfileId(value)) {
+    throw new Error(
+      `Unknown MCP tool profile ${JSON.stringify(value)}. Expected one of: ${TOOL_PROFILE_IDS.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+export interface CompileToolProfileInput {
+  profile: ToolProfileId;
+  registrationMode: ToolRegistrationMode;
+  availableStaticRequirements?: readonly ToolStaticRequirement[];
+}
+
+function suppressPreferredFallbacks(
+  entries: readonly ToolSurfaceEntry[],
+): readonly ToolSurfaceEntry[] {
+  const availableFamilies = new Set(entries.map((entry) => entry.family));
+  return entries.filter(
+    (entry) =>
+      !entry.preferredAlternativeFamily ||
+      !availableFamilies.has(entry.preferredAlternativeFamily),
+  );
+}
+
+function assertGovernedFamiliesAtomic(entries: readonly ToolSurfaceEntry[]): void {
+  const lifecycleByFamily = new Map<string, Set<string>>();
+  for (const entry of entries) {
+    if (!entry.lifecycleRole) continue;
+    const roles = lifecycleByFamily.get(entry.family) ?? new Set<string>();
+    roles.add(entry.lifecycleRole);
+    lifecycleByFamily.set(entry.family, roles);
+  }
+
+  const complete = new Set(["plan", "apply", "status", "recover"]);
+  for (const [family, roles] of lifecycleByFamily) {
+    if (
+      roles.size !== complete.size ||
+      [...complete].some((role) => !roles.has(role))
+    ) {
+      throw new Error(
+        `Tool profile exposes an incomplete governed lifecycle for ${family}: ${[...roles].sort().join(", ")}.`,
+      );
+    }
+  }
+}
+
+export function compileToolProfile({
+  profile,
+  registrationMode,
+  availableStaticRequirements,
+}: CompileToolProfileInput): readonly ToolSurfaceEntry[] {
+  const definition = TOOL_PROFILES[profile];
+  let entries = compileToolSurface({
+    registrationMode,
+    groups: definition.groups,
+    availableStaticRequirements,
+  });
+
+  if (definition.preferCanonicalAlternatives) {
+    entries = suppressPreferredFallbacks(entries);
+  }
+
+  assertGovernedFamiliesAtomic(entries);
+  return [...entries].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export function compileToolProfileNames(
+  input: CompileToolProfileInput,
+): readonly string[] {
+  return compileToolProfile(input).map((entry) => entry.name);
+}


### PR DESCRIPTION
## Scope

Implements P1 on top of P0.

Adds four server-owned, client-agnostic profile contracts:

- `standard`: 19 tools in live/hybrid-live;
- `authoring`: 31 tools in live/hybrid-live;
- `tasks`: 31 tools in every currently modeled runtime, including the complete 23-tool Operon contract plus Markdown Tasks compatibility;
- `full`: unchanged compatibility surface for the active runtime (72 tools in live/hybrid-live).

Profiles are composed from P0 groups rather than copied onto individual tool entries.

## Semantic aliases

`smart_search` and `smart-search` remain physically registered for SemVer compatibility but are excluded from every modern profile. Only `smart_semantic_search` appears in `standard`, `authoring`, and `tasks`. `full` preserves all three names during 2.x.

## Canonical preference

Modern profiles prefer a governed family when a direct tool is explicitly marked as its fallback. The initial concrete case is Frontmatter:

- live/hybrid-live: expose the full `obsidian_frontmatter_patch_{plan,apply,status,recover}` family and hide `obsidian_manage_frontmatter`;
- headless guarded/filesystem: governed Frontmatter is unavailable, so the direct bounded fallback remains exposed.

`full` performs no such suppression.

## Invariants

- a governed lifecycle is all-or-nothing;
- modern profiles hide legacy semantic aliases, maintenance, admin and External Roots;
- `tasks` includes Operon pending-recovery inspection and exact recovery, not only mutation entrypoints;
- unknown profile names fail closed in the parser;
- profile compilation is deterministic and can account for static requirements such as the vault cache.

## Validation

Adds Linux/Windows profile contract tests covering every profile × runtime combination, alias policy, governed lifecycle atomicity, Frontmatter fallback and cache-dependent exposure.