### PR TITLE
feat: enforce MCP tool profiles before tools/list

### DIFF
--- a/.github/workflows/tool-surface-p0.yml
+++ b/.github/workflows/tool-surface-p0.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.7.5"
+          node-version: "22"
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/tool-surface-p1.yml
+++ b/.github/workflows/tool-surface-p1.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.7.5"
+          node-version: "22"
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/tool-surface-p2.yml
+++ b/.github/workflows/tool-surface-p2.yml
@@ -1,0 +1,41 @@
+name: Tool Surface P2
+
+on:
+  pull_request:
+    paths:
+      - "src/config/toolProfileCli.ts"
+      - "src/mcp-server/toolProfiles.ts"
+      - "src/mcp-server/toolProfileRuntime.ts"
+      - "src/mcp-server/resources/toolRoutingResource.ts"
+      - "src/stdio-proxy.ts"
+      - "scripts/test-tool-profile-runtime.mjs"
+      - "scripts/test-tool-profile-stdio-proxy.mjs"
+      - "scripts/test-tool-routing-contract.mjs"
+      - ".github/workflows/tool-surface-p2.yml"
+  push:
+    branches:
+      - "agent/tool-surface-p2"
+
+permissions:
+  contents: read
+
+jobs:
+  runtime-profiles:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: node scripts/test-tool-profiles.mjs
+      - run: node scripts/test-tool-profile-runtime.mjs
+      - run: node scripts/test-tool-profile-stdio-proxy.mjs
+      - run: node scripts/test-tool-routing-contract.mjs

--- a/scripts/test-tool-profile-runtime.mjs
+++ b/scripts/test-tool-profile-runtime.mjs
@@ -83,7 +83,14 @@ try {
 
       let rejected = false;
       try {
-        await client.callTool({ name: "smart_search", arguments: { query: "x" } });
+        const hidden = await client.callTool({
+          name: "smart_search",
+          arguments: { query: "x" },
+        });
+        const text = hidden.content.map((item) => item.text ?? "").join("\n");
+        rejected =
+          hidden.isError === true &&
+          /disabled|not found|not exposed/iu.test(text);
       } catch (error) {
         rejected = /disabled|not found|not exposed/iu.test(
           error instanceof Error ? error.message : String(error),

--- a/scripts/test-tool-profile-runtime.mjs
+++ b/scripts/test-tool-profile-runtime.mjs
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+async function createVault() {
+  const root = await mkdtemp(path.join(os.tmpdir(), "optimike-profile-runtime-"));
+  await mkdir(path.join(root, ".obsidian", "optimike-mcp"), { recursive: true });
+  await writeFile(path.join(root, "Root.md"), "# profile runtime\n", "utf8");
+  return root;
+}
+
+function envFor(vault, extra = {}) {
+  return {
+    ...process.env,
+    OBSIDIAN_RUNTIME_MODE: "headless-readonly",
+    OBSIDIAN_VAULT: vault,
+    OBSIDIAN_CACHE_SOURCE: "filesystem",
+    OBSIDIAN_SHARED_CACHE_DB_PATH: path.join(
+      vault,
+      ".obsidian",
+      "optimike-mcp",
+      "shared-cache.sqlite",
+    ),
+    OBSIDIAN_ENABLE_CACHE: "true",
+    SEMANTIC_SEARCH_PREWARM: "false",
+    MCP_TRANSPORT_TYPE: "stdio",
+    MCP_LOG_LEVEL: "error",
+    MCP_WRITE_MODE: "readonly",
+    ...extra,
+  };
+}
+
+async function openClient({ vault, args = [], env = {} }) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["dist/index.js", ...args],
+    cwd: process.cwd(),
+    env: envFor(vault, env),
+  });
+  const client = new Client({ name: "tool-profile-runtime-test", version: "0" });
+  await client.connect(transport);
+  return { client, transport };
+}
+
+async function listedNames(client) {
+  const result = await client.listTools();
+  return result.tools.map((tool) => tool.name).sort((a, b) => a.localeCompare(b));
+}
+
+const vault = await createVault();
+try {
+  {
+    const { client } = await openClient({ vault });
+    try {
+      const names = await listedNames(client);
+      assert.equal(names.length, 48, "2.x default must remain full");
+      assert.ok(names.includes("smart_semantic_search"));
+      assert.ok(names.includes("smart_search"));
+      assert.ok(names.includes("smart-search"));
+      assert.ok(names.includes("external_read"));
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  }
+
+  {
+    const { client } = await openClient({
+      vault,
+      args: ["--tool-profile", "standard"],
+      env: { MCP_TOOL_PROFILE: "full" },
+    });
+    try {
+      const names = await listedNames(client);
+      assert.equal(names.length, 9, "CLI standard must override env full");
+      assert.ok(names.includes("smart_semantic_search"));
+      assert.ok(!names.includes("smart_search"));
+      assert.ok(!names.includes("smart-search"));
+      assert.ok(!names.includes("external_read"));
+      assert.ok(!names.includes("obsidian_runtime_maintenance"));
+
+      let rejected = false;
+      try {
+        await client.callTool({ name: "smart_search", arguments: { query: "x" } });
+      } catch (error) {
+        rejected = /disabled|not found|not exposed/iu.test(
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      assert.ok(rejected, "a hidden direct-server tool call must be rejected");
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  }
+
+  {
+    const previous = process.env.MCP_TOOL_PROFILE;
+    process.env.MCP_TOOL_PROFILE = "full";
+    const { applyToolProfileCliOverride } = await import(
+      "../dist/config/toolProfileCli.js"
+    );
+    applyToolProfileCliOverride(["--tool-profile=tasks"]);
+    assert.equal(process.env.MCP_TOOL_PROFILE, "tasks");
+    assert.throws(
+      () => applyToolProfileCliOverride(["--tool-profile", "nope"]),
+      /Unknown MCP tool profile/,
+    );
+    assert.throws(
+      () => applyToolProfileCliOverride(["--tool-profile"]),
+      /requires one of/,
+    );
+    if (previous === undefined) delete process.env.MCP_TOOL_PROFILE;
+    else process.env.MCP_TOOL_PROFILE = previous;
+  }
+
+  console.log("PASS: direct server profiles preserve full compatibility and hide semantic aliases in standard");
+} finally {
+  await rm(vault, { recursive: true, force: true });
+}

--- a/scripts/test-tool-profile-stdio-proxy.mjs
+++ b/scripts/test-tool-profile-stdio-proxy.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+async function freePort() {
+  const server = createServer();
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port = address.port;
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+async function createVault() {
+  const root = await mkdtemp(path.join(os.tmpdir(), "optimike-profile-proxy-"));
+  await mkdir(path.join(root, ".obsidian", "optimike-mcp"), { recursive: true });
+  await writeFile(path.join(root, "Root.md"), "# profile proxy\n", "utf8");
+  return root;
+}
+
+function sharedEnv(vault, port, extra = {}) {
+  return {
+    ...process.env,
+    OBSIDIAN_RUNTIME_MODE: "headless-readonly",
+    OBSIDIAN_VAULT: vault,
+    OBSIDIAN_CACHE_SOURCE: "filesystem",
+    OBSIDIAN_SHARED_CACHE_DB_PATH: path.join(
+      vault,
+      ".obsidian",
+      "optimike-mcp",
+      "shared-cache.sqlite",
+    ),
+    OBSIDIAN_ENABLE_CACHE: "true",
+    SEMANTIC_SEARCH_PREWARM: "false",
+    MCP_HTTP_HOST: "127.0.0.1",
+    MCP_HTTP_PORT: String(port),
+    MCP_LOG_LEVEL: "error",
+    MCP_WRITE_MODE: "readonly",
+    ...extra,
+  };
+}
+
+async function waitForHealth(port, child) {
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`backend exited early with ${child.exitCode}`);
+    }
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/healthz`);
+      if (response.ok) return;
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+  throw new Error("backend did not become healthy");
+}
+
+async function openProxy(vault, port, profile) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["dist/stdio-proxy.js", "--tool-profile", profile],
+    cwd: process.cwd(),
+    env: sharedEnv(vault, port, {
+      MCP_TRANSPORT_TYPE: "stdio",
+      // Deliberately conflicting env proves CLI precedence inside each proxy.
+      MCP_TOOL_PROFILE: profile === "standard" ? "full" : "standard",
+    }),
+  });
+  const client = new Client({
+    name: `tool-profile-proxy-${profile}`,
+    version: "0",
+  });
+  await client.connect(transport);
+  return client;
+}
+
+const vault = await createVault();
+const port = await freePort();
+const backend = spawn(process.execPath, ["dist/index.js"], {
+  cwd: process.cwd(),
+  env: sharedEnv(vault, port, {
+    MCP_TRANSPORT_TYPE: "http",
+    MCP_TOOL_PROFILE: "full",
+  }),
+  stdio: "ignore",
+});
+
+try {
+  await waitForHealth(port, backend);
+
+  const standard = await openProxy(vault, port, "standard");
+  try {
+    const result = await standard.listTools();
+    const names = result.tools.map((tool) => tool.name);
+    assert.equal(names.length, 9);
+    assert.ok(names.includes("smart_semantic_search"));
+    assert.ok(!names.includes("smart_search"));
+    assert.ok(!names.includes("smart-search"));
+    assert.ok(!names.includes("external_read"));
+
+    const hidden = await standard.callTool({
+      name: "external_read",
+      arguments: { rootId: "missing", relativePath: "x.txt" },
+    });
+    assert.equal(hidden.isError, true);
+    const hiddenText = hidden.content.map((item) => item.text ?? "").join("\n");
+    assert.match(hiddenText, /tool_not_exposed/);
+    assert.match(hiddenText, /standard/);
+  } finally {
+    await standard.close().catch(() => undefined);
+  }
+
+  const full = await openProxy(vault, port, "full");
+  try {
+    const result = await full.listTools();
+    const names = result.tools.map((tool) => tool.name);
+    assert.equal(names.length, 48);
+    assert.ok(names.includes("smart_semantic_search"));
+    assert.ok(names.includes("smart_search"));
+    assert.ok(names.includes("smart-search"));
+    assert.ok(names.includes("external_read"));
+  } finally {
+    await full.close().catch(() => undefined);
+  }
+
+  console.log("PASS: stdio proxy profiles are per-client while the shared backend remains full");
+} finally {
+  if (backend.exitCode === null) backend.kill("SIGTERM");
+  await new Promise((resolve) => {
+    if (backend.exitCode !== null) return resolve();
+    const timer = setTimeout(() => {
+      if (backend.exitCode === null) backend.kill("SIGKILL");
+      resolve();
+    }, 5_000);
+    backend.once("exit", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+  await rm(vault, { recursive: true, force: true });
+}

--- a/scripts/test-tool-routing-contract.mjs
+++ b/scripts/test-tool-routing-contract.mjs
@@ -40,9 +40,17 @@ assert.deepEqual(readResult, {
   ],
 });
 
+assert.ok(
+  TOOL_ROUTING_RESOURCE_TEXT.includes("smart_semantic_search"),
+  "routing resource must expose the canonical semantic-search name",
+);
+assert.ok(
+  !TOOL_ROUTING_RESOURCE_TEXT.includes("`smart_search`") &&
+    !TOOL_ROUTING_RESOURCE_TEXT.includes("`smart-search`"),
+  "canonical routing resource must not teach semantic-search compatibility aliases",
+);
+
 const routingPairs = [
-  ["smart_search", "smart_semantic_search"],
-  ["smart-search", "smart_semantic_search"],
   ["list_all_tasks", "operon_list_tasks"],
   ["query_tasks", "operon_query_tasks"],
   ["obsidian_update_note", "obsidian_note_replace_plan"],
@@ -70,6 +78,10 @@ for (const relativePath of [
   assert.ok(
     content.includes(TOOL_ROUTING_RESOURCE_URI),
     `${relativePath} does not advertise the routing resource`,
+  );
+  assert.ok(
+    content.includes("smart_semantic_search"),
+    `${relativePath} omits canonical semantic search`,
   );
   for (const [, preferredTool] of routingPairs) {
     assert.ok(

--- a/src/config/toolProfileCli.ts
+++ b/src/config/toolProfileCli.ts
@@ -1,0 +1,34 @@
+import { parseToolProfileId } from "../mcp-server/toolProfiles.js";
+
+export function applyToolProfileCliOverride(
+  argv: readonly string[] = process.argv.slice(2),
+): void {
+  const values: string[] = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--tool-profile") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error(
+          "--tool-profile requires one of: standard, authoring, tasks, full.",
+        );
+      }
+      values.push(value);
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--tool-profile=")) {
+      values.push(arg.slice("--tool-profile=".length));
+    }
+  }
+
+  if (values.length === 0) return;
+  if (values.length > 1) {
+    throw new Error("--tool-profile may be provided only once.");
+  }
+
+  process.env.MCP_TOOL_PROFILE = parseToolProfileId(values[0]);
+}
+
+applyToolProfileCliOverride();

--- a/src/mcp-server/resources/toolRoutingResource.ts
+++ b/src/mcp-server/resources/toolRoutingResource.ts
@@ -1,4 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import "../../config/toolProfileCli.js";
+import { installToolProfileRegistrationGate } from "../toolProfileRuntime.js";
 
 export const TOOL_ROUTING_RESOURCE_URI =
   "optimike://guides/tool-routing" as const;
@@ -6,13 +8,14 @@ export const TOOL_ROUTING_RESOURCE_URI =
 export const TOOL_ROUTING_RESOURCE_TEXT = `# Optimike MCP tool routing
 
 Use the narrowest tool that owns the required guarantee. Tool availability is
-runtime-dependent; never infer that an absent tool can be emulated safely.
+runtime- and profile-dependent; never infer that an absent tool can be emulated safely.
 
 ## Canonical priorities
 
 - Read, list and exact text search: use the dedicated read/search tools.
-- Semantic search: use \`smart_semantic_search\`. \`smart_search\` and
-  \`smart-search\` are legacy compatibility aliases of the same implementation.
+- Semantic search: use \`smart_semantic_search\`. It is the only semantic-search
+  name exposed by modern 2.10 profiles; compatibility aliases remain a \`full\`
+  2.x concern and are not part of canonical routing.
 - Operon-managed tasks: use \`operon_list_tasks\` or \`operon_query_tasks\`. Use
   \`list_all_tasks\` and \`query_tasks\` only for legacy Obsidian Tasks-compatible
   Markdown inspection.
@@ -28,8 +31,8 @@ runtime-dependent; never infer that an absent tool can be emulated safely.
   \`obsidian_frontmatter_patch_plan\`. Use \`obsidian_manage_frontmatter\` for
   direct reads, compatibility, or a runtime where the governed tool is absent.
 - Named Base formula set/delete: prefer \`bases_formula_patch_plan\`.
-  \`bases_upsert_config\` is a legacy whole-config compatibility path and must not
-  bypass the governed formula contract.
+  \`bases_upsert_config\` is a whole-config compatibility path and must not bypass
+  the governed formula contract.
 - Existing JSON Canvas graph mutation in live/hybrid mode: prefer
   \`obsidian_canvas_patch_plan\`, then its matching apply/status/recover tools.
   \`obsidian_manage_canvas\` is a direct headless-filesystem helper without a
@@ -52,13 +55,17 @@ There is intentionally no generic public \`operation_*\` surface.
 `;
 
 export function registerToolRoutingResource(server: McpServer): void {
+  // server.ts calls this bootstrap point before registering any MCP tools.
+  // Install the selected profile first so hidden tools never reach tools/list.
+  installToolProfileRegistrationGate(server);
+
   server.registerResource(
     "optimike-tool-routing",
     TOOL_ROUTING_RESOURCE_URI,
     {
       title: "Optimike MCP tool routing",
       description:
-        "Canonical precedence between direct, legacy and governed Optimike MCP tools.",
+        "Canonical precedence between direct, compatibility and governed Optimike MCP tools.",
       mimeType: "text/markdown",
     },
     async () => ({

--- a/src/mcp-server/toolProfileRuntime.ts
+++ b/src/mcp-server/toolProfileRuntime.ts
@@ -1,0 +1,77 @@
+import type {
+  McpServer,
+  RegisteredTool,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  parseToolProfileId,
+  selectAvailableToolProfileNames,
+  type ToolProfileId,
+} from "./toolProfiles.js";
+
+export function resolveToolProfile(
+  raw = process.env.MCP_TOOL_PROFILE?.trim() || "full",
+): ToolProfileId {
+  return parseToolProfileId(raw);
+}
+
+/**
+ * Installs a registration-time exposure gate on one McpServer instance.
+ *
+ * The SDK's public RegisteredTool handles are authoritative: disabling a tool
+ * removes it from tools/list and rejects direct callTool invocation. We keep
+ * every registered handle, recompute the selected profile from the concrete
+ * names currently present, and reconcile enabled state after each registration.
+ * This makes canonical/direct fallback resolution independent of registration
+ * order while preserving `full` as the unfiltered 2.x compatibility surface.
+ */
+export function installToolProfileRegistrationGate(
+  server: McpServer,
+  profile: ToolProfileId = resolveToolProfile(),
+): void {
+  if (profile === "full") return;
+
+  const handles = new Map<string, RegisteredTool>();
+  const originalTool = server.tool.bind(server) as (
+    name: string,
+    ...rest: unknown[]
+  ) => RegisteredTool;
+  const originalRegisterTool = server.registerTool.bind(server) as (
+    name: string,
+    ...rest: unknown[]
+  ) => RegisteredTool;
+
+  const reconcile = () => {
+    const allowed = new Set(
+      selectAvailableToolProfileNames({
+        profile,
+        availableNames: [...handles.keys()],
+      }),
+    );
+
+    for (const [name, handle] of handles) {
+      const shouldEnable = allowed.has(name);
+      if (handle.enabled !== shouldEnable) {
+        handle.update({ enabled: shouldEnable });
+      }
+    }
+  };
+
+  const remember = (name: string, handle: RegisteredTool): RegisteredTool => {
+    handles.set(name, handle);
+    reconcile();
+    return handle;
+  };
+
+  // The project still uses the v1 convenience `tool()` API extensively, while
+  // future registrations may migrate to `registerTool()`. Intercept both public
+  // entrypoints so the profile contract cannot drift during that migration.
+  (server as unknown as { tool: typeof server.tool }).tool = ((
+    name: string,
+    ...rest: unknown[]
+  ) => remember(name, originalTool(name, ...rest))) as typeof server.tool;
+
+  (server as unknown as { registerTool: typeof server.registerTool }).registerTool = ((
+    name: string,
+    ...rest: unknown[]
+  ) => remember(name, originalRegisterTool(name, ...rest))) as typeof server.registerTool;
+}

--- a/src/mcp-server/toolProfiles.ts
+++ b/src/mcp-server/toolProfiles.ts
@@ -1,6 +1,7 @@
 import {
   TOOL_GROUP_IDS,
   compileToolSurface,
+  getToolSurfaceEntry,
   type ToolGroupId,
   type ToolRegistrationMode,
   type ToolStaticRequirement,
@@ -137,28 +138,66 @@ function assertGovernedFamiliesAtomic(entries: readonly ToolSurfaceEntry[]): voi
   }
 }
 
+function finalizeProfileEntries(
+  definition: ToolProfileDefinition,
+  entries: readonly ToolSurfaceEntry[],
+): readonly ToolSurfaceEntry[] {
+  const selected = definition.preferCanonicalAlternatives
+    ? suppressPreferredFallbacks(entries)
+    : entries;
+  assertGovernedFamiliesAtomic(selected);
+  return [...selected].sort((left, right) => left.name.localeCompare(right.name));
+}
+
 export function compileToolProfile({
   profile,
   registrationMode,
   availableStaticRequirements,
 }: CompileToolProfileInput): readonly ToolSurfaceEntry[] {
   const definition = TOOL_PROFILES[profile];
-  let entries = compileToolSurface({
+  const entries = compileToolSurface({
     registrationMode,
     groups: definition.groups,
     availableStaticRequirements,
   });
-
-  if (definition.preferCanonicalAlternatives) {
-    entries = suppressPreferredFallbacks(entries);
-  }
-
-  assertGovernedFamiliesAtomic(entries);
-  return [...entries].sort((left, right) => left.name.localeCompare(right.name));
+  return finalizeProfileEntries(definition, entries);
 }
 
 export function compileToolProfileNames(
   input: CompileToolProfileInput,
 ): readonly string[] {
   return compileToolProfile(input).map((entry) => entry.name);
+}
+
+export interface SelectAvailableToolProfileInput {
+  profile: ToolProfileId;
+  availableNames: readonly string[];
+}
+
+/**
+ * Select a profile from the tools that a concrete server/proxy actually has.
+ * This is the runtime authority used by P2/P3: it intersects the portable
+ * profile contract with real registration rather than predicting availability.
+ *
+ * `full` intentionally preserves unknown future names for 2.x compatibility.
+ * Modern profiles fail closed on unknown names by omitting them until the
+ * canonical registry classifies them.
+ */
+export function selectAvailableToolProfileNames({
+  profile,
+  availableNames,
+}: SelectAvailableToolProfileInput): readonly string[] {
+  const uniqueNames = [...new Set(availableNames)];
+  if (profile === "full") {
+    return uniqueNames.sort((left, right) => left.localeCompare(right));
+  }
+
+  const definition = TOOL_PROFILES[profile];
+  const groups = new Set<ToolGroupId>(definition.groups);
+  const entries = uniqueNames
+    .map((name) => getToolSurfaceEntry(name))
+    .filter((entry): entry is ToolSurfaceEntry => Boolean(entry))
+    .filter((entry) => groups.has(entry.group));
+
+  return finalizeProfileEntries(definition, entries).map((entry) => entry.name);
 }

--- a/src/stdio-proxy.ts
+++ b/src/stdio-proxy.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import "./config/toolProfileCli.js";
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -25,6 +26,11 @@ import {
   ExternalStatSchema,
   externalRootsResult,
 } from "./mcp-server/tools/externalRootsTools/registration.js";
+import {
+  selectAvailableToolProfileNames,
+  type ToolProfileId,
+} from "./mcp-server/toolProfiles.js";
+import { resolveToolProfile } from "./mcp-server/toolProfileRuntime.js";
 import { config, profileExternalMoveJournalPath } from "./config/index.js";
 import { ensureLocalBackendRunning } from "./runtime/localBackend.js";
 import {
@@ -57,6 +63,7 @@ const port = Number(process.env.MCP_HTTP_PORT || "3010");
 const backendUrl = new URL(`http://${host}:${port}/mcp`);
 const healthUrl = new URL(`http://${host}:${port}/healthz`);
 const backendBearerToken = process.env.MCP_BACKEND_BEARER_TOKEN?.trim();
+const toolProfile: ToolProfileId = resolveToolProfile();
 
 const proxyServer = new Server(
   { name: `${packageName}-stdio-proxy`, version: packageVersion },
@@ -64,6 +71,7 @@ const proxyServer = new Server(
 );
 
 let backend: BackendClient | undefined;
+let allowedToolNames: Set<string> | undefined;
 let externalRootsService: ExternalRootsService | undefined;
 let externalMoveCoordinator: ExternalMoveCoordinator | undefined;
 let externalMoveBindingIdentity: ExternalMoveBindingIdentity | undefined;
@@ -124,6 +132,26 @@ function invalidExternalArguments(
   };
 }
 
+function hiddenToolResult(toolName: string) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            error: "tool_not_exposed",
+            message: `Tool ${toolName} is not exposed by MCP tool profile ${toolProfile}.`,
+            toolProfile,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+    isError: true,
+  };
+}
+
 function isReconnectableBackendError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return (
@@ -149,6 +177,7 @@ async function ensureBackendConnected(forceReconnect = false): Promise<Client> {
     ]);
     backend = undefined;
   }
+  allowedToolNames = undefined;
 
   await ensureLocalBackendRunning({
     serviceName: packageName,
@@ -159,6 +188,9 @@ async function ensureBackendConnected(forceReconnect = false): Promise<Client> {
     env: {
       ...process.env,
       MCP_TRANSPORT_TYPE: "http",
+      // One shared backend must never inherit a per-agent stdio profile.
+      // Per-client exposure is enforced by this proxy; the backend stays full.
+      MCP_TOOL_PROFILE: "full",
     },
     startupTimeoutMs: Number(process.env.MCP_PROXY_START_TIMEOUT_MS || "20000"),
   });
@@ -217,6 +249,30 @@ async function withBackendRetry<T>(
   }
 }
 
+async function filteredBackendTools(params?: Record<string, unknown>) {
+  const result = await withBackendRetry("listTools", (client) =>
+    client.listTools(params),
+  );
+  const selected = new Set(
+    selectAvailableToolProfileNames({
+      profile: toolProfile,
+      availableNames: result.tools.map((tool) => tool.name),
+    }),
+  );
+  allowedToolNames = selected;
+  return {
+    ...result,
+    tools: result.tools.filter((tool) => selected.has(tool.name)),
+  };
+}
+
+async function toolIsExposed(toolName: string): Promise<boolean> {
+  if (!allowedToolNames) {
+    await filteredBackendTools();
+  }
+  return allowedToolNames?.has(toolName) ?? false;
+}
+
 async function shutdown(signal: string) {
   console.error(`[${packageName}] proxy shutdown on ${signal}`);
   await Promise.allSettled([
@@ -268,10 +324,14 @@ async function start() {
   }
 
   proxyServer.setRequestHandler(ListToolsRequestSchema, async (request) =>
-    withBackendRetry("listTools", (client) => client.listTools(request.params)),
+    filteredBackendTools(request.params),
   );
 
   proxyServer.setRequestHandler(CallToolRequestSchema, async (request) => {
+    if (!(await toolIsExposed(request.params.name))) {
+      return hiddenToolResult(request.params.name);
+    }
+
     if (request.params.name === "external_runtime_status") {
       return externalRootsResult(async () => ({
         enabled: Boolean(externalRootsService),
@@ -494,7 +554,7 @@ async function start() {
   const stdioTransport = new StdioServerTransport();
   await proxyServer.connect(stdioTransport);
   console.error(
-    `[${packageName}] stdio proxy connected to ${backendUrl.toString()}`,
+    `[${packageName}] stdio proxy connected to ${backendUrl.toString()} with tool profile ${toolProfile}`,
   );
 }
 


### PR DESCRIPTION
## Scope

Implements P2 on top of P0/P1.

### Direct server

- `MCP_TOOL_PROFILE=standard|authoring|tasks|full` selects the server exposure profile;
- `--tool-profile <name>` and `--tool-profile=<name>` override the environment;
- invalid names fail closed;
- default remains `full` for 2.x compatibility;
- the profile gate is installed before tool registration and uses public SDK `RegisteredTool` handles, so hidden tools disappear from `tools/list` and direct calls are rejected by the SDK.

### Stdio proxy

- the stdio proxy applies the selected profile per client;
- if it starts the shared HTTP backend, it explicitly starts that backend as `full`, preventing one agent's profile from shrinking every other client's surface;
- `listTools` is filtered by the proxy profile;
- direct calls to hidden tools are rejected even for External Roots tools implemented locally inside the proxy.

## Semantic aliases

This PR enforces the 2.10 compatibility policy:

- `standard`, `authoring`, `tasks`: only `smart_semantic_search` is exposed;
- `smart_search` and `smart-search` are absent from `tools/list` and direct calls are rejected;
- `full`: both aliases remain available for 2.x compatibility;
- physical alias removal remains deferred to 3.0.

The canonical MCP routing resource now teaches only `smart_semantic_search`; it no longer teaches clients to choose a compatibility alias.

## Validation

Linux/Windows CI covers:

- profile compilation;
- default full compatibility;
- CLI precedence over env;
- hidden direct-server call rejection;
- per-client stdio proxy filtering over one shared full backend;
- hidden local-proxy tool rejection;
- semantic alias policy;
- canonical routing resource contract.