### PR TITLE
feat: bind HTTP MCP sessions to tool profiles

### DIFF
--- a/.github/workflows/tool-surface-p3.yml
+++ b/.github/workflows/tool-surface-p3.yml
@@ -1,0 +1,37 @@
+name: Tool Surface P3
+
+on:
+  pull_request:
+    paths:
+      - "src/mcp-server/toolProfileContext.ts"
+      - "src/mcp-server/toolProfileRuntime.ts"
+      - "src/mcp-server/transports/httpToolProfileRouting.ts"
+      - "src/mcp-server/transports/httpTransport.ts"
+      - "scripts/test-http-tool-profiles.mjs"
+      - ".github/workflows/tool-surface-p3.yml"
+  push:
+    branches:
+      - "agent/tool-surface-p3"
+
+permissions:
+  contents: read
+
+jobs:
+  http-profiles:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: node scripts/test-http-tool-profiles.mjs
+      - run: npm run test:http-multiclient
+      - run: npm run test:http-headless-multiclient

--- a/scripts/test-http-tool-profiles.mjs
+++ b/scripts/test-http-tool-profiles.mjs
@@ -143,7 +143,9 @@ async function waitForHealth(baseUrl, child) {
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
     if (child.exitCode !== null) {
-      throw new Error(`backend exited early with ${child.exitCode}`);
+      throw new Error(
+        `backend exited early with ${child.exitCode}: ${child.stderrText}`,
+      );
     }
     try {
       const response = await fetch(new URL("/healthz", baseUrl));
@@ -151,7 +153,7 @@ async function waitForHealth(baseUrl, child) {
     } catch {}
     await sleep(100);
   }
-  throw new Error("backend did not become healthy");
+  throw new Error(`backend did not become healthy: ${child.stderrText}`);
 }
 
 function toolNames(payload) {
@@ -162,7 +164,7 @@ function toolNames(payload) {
 
 const vault = await createVault();
 const port = await unusedPort();
-const logDir = path.join(vault, "logs");
+const logDir = path.join(process.cwd(), ".tmp", `http-tool-profiles-${port}`);
 await mkdir(logDir, { recursive: true });
 const child = spawn(process.execPath, ["dist/index.js"], {
   cwd: process.cwd(),
@@ -196,7 +198,11 @@ const child = spawn(process.execPath, ["dist/index.js"], {
     // A process-wide env profile must not change the public /mcp legacy contract.
     MCP_TOOL_PROFILE: "tasks",
   },
-  stdio: "ignore",
+  stdio: ["ignore", "pipe", "pipe"],
+});
+child.stderrText = "";
+child.stderr?.on("data", (chunk) => {
+  child.stderrText += String(chunk);
 });
 
 try {
@@ -310,5 +316,6 @@ try {
     sleep(5_000),
   ]);
   if (child.exitCode === null) child.kill("SIGKILL");
+  await rm(logDir, { recursive: true, force: true });
   await rm(vault, { recursive: true, force: true });
 }

--- a/scripts/test-http-tool-profiles.mjs
+++ b/scripts/test-http-tool-profiles.mjs
@@ -1,0 +1,314 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:net";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { SignJWT } from "jose";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const jwtSecret =
+  "tool-profile-http-test-secret-must-be-at-least-32-characters";
+
+async function unusedPort() {
+  const server = createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const port = address.port;
+  await new Promise((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  return port;
+}
+
+async function signToken(clientId) {
+  return new SignJWT({ cid: clientId, scp: ["vault:read"] })
+    .setProtectedHeader({ alg: "HS256" })
+    .setSubject(clientId)
+    .setIssuedAt()
+    .setExpirationTime("10m")
+    .sign(new TextEncoder().encode(jwtSecret));
+}
+
+function parseProtocolPayload(text, contentType, expectedId) {
+  if (contentType.includes("application/json")) return JSON.parse(text);
+  const candidates = [];
+  for (const block of text.split(/\r?\n\r?\n/u)) {
+    const data = block
+      .split(/\r?\n/u)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trim())
+      .join("\n");
+    if (!data || data === "[DONE]") continue;
+    try {
+      candidates.push(JSON.parse(data));
+    } catch {}
+  }
+  return (
+    candidates.find((candidate) => candidate?.id === expectedId) ??
+    candidates[0] ??
+    null
+  );
+}
+
+async function protocolRequest({
+  baseUrl,
+  profilePath,
+  token,
+  body,
+  sessionId,
+  method = "POST",
+}) {
+  const response = await fetch(new URL(profilePath, baseUrl), {
+    method,
+    headers: {
+      Accept: "application/json, text/event-stream",
+      ...(method === "POST" ? { "Content-Type": "application/json" } : {}),
+      Authorization: `Bearer ${token}`,
+      ...(sessionId ? { "Mcp-Session-Id": sessionId } : {}),
+    },
+    body: method === "POST" ? JSON.stringify(body) : undefined,
+  });
+  const text = await response.text();
+  const payload = text
+    ? parseProtocolPayload(
+        text,
+        response.headers.get("content-type") ?? "",
+        body?.id,
+      )
+    : null;
+  return { response, payload, text };
+}
+
+async function initializeClient(baseUrl, profilePath, token, name, id) {
+  const initialized = await protocolRequest({
+    baseUrl,
+    profilePath,
+    token,
+    body: {
+      jsonrpc: "2.0",
+      id,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name, version: "0" },
+      },
+    },
+  });
+  assert.equal(initialized.response.status, 200, initialized.text);
+  const sessionId = initialized.response.headers.get("mcp-session-id");
+  assert.ok(sessionId, `${name} did not receive an MCP session id`);
+
+  const notification = await protocolRequest({
+    baseUrl,
+    profilePath,
+    token,
+    sessionId,
+    body: { jsonrpc: "2.0", method: "notifications/initialized" },
+  });
+  assert.ok(
+    [200, 202, 204].includes(notification.response.status),
+    `${name} initialization notification failed: ${notification.response.status} ${notification.text}`,
+  );
+  return { token, sessionId, profilePath, nextId: id + 100 };
+}
+
+async function call(client, baseUrl, method, params = {}) {
+  const id = client.nextId++;
+  const result = await protocolRequest({
+    baseUrl,
+    profilePath: client.profilePath,
+    token: client.token,
+    sessionId: client.sessionId,
+    body: { jsonrpc: "2.0", id, method, params },
+  });
+  assert.equal(result.response.status, 200, result.text);
+  assert.equal(result.payload?.error, undefined, result.text);
+  return result.payload;
+}
+
+async function createVault() {
+  const vault = await mkdtemp(path.join(os.tmpdir(), "optimike-http-profiles-"));
+  await mkdir(path.join(vault, ".obsidian", "optimike-mcp"), { recursive: true });
+  await writeFile(path.join(vault, "Root.md"), "# HTTP profile smoke\n", "utf8");
+  return vault;
+}
+
+async function waitForHealth(baseUrl, child) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`backend exited early with ${child.exitCode}`);
+    }
+    try {
+      const response = await fetch(new URL("/healthz", baseUrl));
+      if (response.ok) return;
+    } catch {}
+    await sleep(100);
+  }
+  throw new Error("backend did not become healthy");
+}
+
+function toolNames(payload) {
+  return (payload?.result?.tools ?? [])
+    .map((tool) => tool.name)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+const vault = await createVault();
+const port = await unusedPort();
+const logDir = path.join(vault, "logs");
+await mkdir(logDir, { recursive: true });
+const child = spawn(process.execPath, ["dist/index.js"], {
+  cwd: process.cwd(),
+  env: {
+    ...process.env,
+    NODE_ENV: "test",
+    OBSIDIAN_RUNTIME_MODE: "headless-readonly",
+    OBSIDIAN_VAULT: vault,
+    OBSIDIAN_CACHE_SOURCE: "filesystem",
+    OBSIDIAN_SHARED_CACHE_DB_PATH: path.join(
+      vault,
+      ".obsidian",
+      "optimike-mcp",
+      "shared-cache.sqlite",
+    ),
+    OBSIDIAN_ENABLE_CACHE: "true",
+    SEMANTIC_SEARCH_PREWARM: "false",
+    MCP_WRITE_MODE: "readonly",
+    MCP_TRANSPORT_TYPE: "http",
+    MCP_HTTP_HOST: "127.0.0.1",
+    MCP_HTTP_PORT: String(port),
+    MCP_HTTP_PORT_RETRIES: "0",
+    MCP_LOG_LEVEL: "error",
+    LOGS_DIR: logDir,
+    MCP_AUTH_MODE: "jwt",
+    MCP_AUTH_SECRET_KEY: jwtSecret,
+    MCP_ALLOWED_ORIGINS: "",
+    MCP_HTTP_LOOPBACK_POLICY: "shared",
+    MCP_HTTP_PREAUTH_RATE_LIMIT_MAX: "1000",
+    MCP_HTTP_IDENTITY_RATE_LIMIT_MAX: "1000",
+    // A process-wide env profile must not change the public /mcp legacy contract.
+    MCP_TOOL_PROFILE: "tasks",
+  },
+  stdio: "ignore",
+});
+
+try {
+  const baseUrl = new URL(`http://127.0.0.1:${port}`);
+  await waitForHealth(baseUrl, child);
+
+  const [standardToken, tasksToken, fullToken, legacyToken] = await Promise.all([
+    signToken("profile-standard"),
+    signToken("profile-tasks"),
+    signToken("profile-full"),
+    signToken("profile-legacy"),
+  ]);
+
+  const [standard, tasks, full, legacy] = await Promise.all([
+    initializeClient(baseUrl, "/mcp/standard", standardToken, "standard", 1),
+    initializeClient(baseUrl, "/mcp/tasks", tasksToken, "tasks", 2),
+    initializeClient(baseUrl, "/mcp/full", fullToken, "full", 3),
+    initializeClient(baseUrl, "/mcp", legacyToken, "legacy", 4),
+  ]);
+
+  const [standardList, tasksList, fullList, legacyList] = await Promise.all([
+    call(standard, baseUrl, "tools/list"),
+    call(tasks, baseUrl, "tools/list"),
+    call(full, baseUrl, "tools/list"),
+    call(legacy, baseUrl, "tools/list"),
+  ]);
+
+  const standardNames = toolNames(standardList);
+  const tasksNames = toolNames(tasksList);
+  const fullNames = toolNames(fullList);
+  const legacyNames = toolNames(legacyList);
+
+  assert.equal(standardNames.length, 9);
+  assert.equal(tasksNames.length, 31);
+  assert.equal(fullNames.length, 48);
+  assert.deepEqual(legacyNames, fullNames, "/mcp must remain an alias of /mcp/full");
+
+  for (const modern of [standardNames, tasksNames]) {
+    assert.ok(modern.includes("smart_semantic_search"));
+    assert.ok(!modern.includes("smart_search"));
+    assert.ok(!modern.includes("smart-search"));
+  }
+  assert.ok(fullNames.includes("smart_semantic_search"));
+  assert.ok(fullNames.includes("smart_search"));
+  assert.ok(fullNames.includes("smart-search"));
+
+  assert.ok(!standardNames.includes("operon_create_task"));
+  assert.ok(tasksNames.includes("operon_create_task"));
+  assert.ok(tasksNames.includes("operon_list_pending_recoveries"));
+  assert.ok(tasksNames.includes("operon_recover_mutation"));
+
+  const mismatchPost = await protocolRequest({
+    baseUrl,
+    profilePath: "/mcp/full",
+    token: standard.token,
+    sessionId: standard.sessionId,
+    body: {
+      jsonrpc: "2.0",
+      id: 999,
+      method: "tools/list",
+      params: {},
+    },
+  });
+  assert.equal(mismatchPost.response.status, 404, mismatchPost.text);
+  assert.match(mismatchPost.text, /Invalid or expired session ID/);
+
+  const mismatchDelete = await protocolRequest({
+    baseUrl,
+    profilePath: "/mcp/full",
+    token: standard.token,
+    sessionId: standard.sessionId,
+    method: "DELETE",
+  });
+  assert.equal(mismatchDelete.response.status, 404, mismatchDelete.text);
+  assert.match(mismatchDelete.text, /Invalid or expired session ID/);
+
+  const sameSessionStillWorks = await call(standard, baseUrl, "tools/list");
+  assert.equal(toolNames(sameSessionStillWorks).length, 9);
+
+  const unknown = await fetch(new URL("/mcp/nope", baseUrl), {
+    method: "POST",
+    headers: {
+      Accept: "application/json, text/event-stream",
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${standardToken}`,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1000,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "unknown", version: "0" },
+      },
+    }),
+  });
+  assert.equal(unknown.status, 404);
+  assert.match(await unknown.text(), /unknown_tool_profile/);
+
+  console.log(
+    "PASS: HTTP profile endpoints coexist on one backend, /mcp stays full, semantic aliases are modern-profile-hidden, and sessions cannot cross profile routes",
+  );
+} finally {
+  if (child.exitCode === null) child.kill("SIGTERM");
+  await Promise.race([
+    new Promise((resolve) => {
+      if (child.exitCode !== null) return resolve();
+      child.once("exit", resolve);
+    }),
+    sleep(5_000),
+  ]);
+  if (child.exitCode === null) child.kill("SIGKILL");
+  await rm(vault, { recursive: true, force: true });
+}

--- a/src/mcp-server/toolProfileContext.ts
+++ b/src/mcp-server/toolProfileContext.ts
@@ -1,0 +1,15 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { ToolProfileId } from "./toolProfiles.js";
+
+const toolProfileContext = new AsyncLocalStorage<ToolProfileId>();
+
+export function currentToolProfileContext(): ToolProfileId | undefined {
+  return toolProfileContext.getStore();
+}
+
+export function withToolProfileContext<T>(
+  profile: ToolProfileId,
+  operation: () => Promise<T>,
+): Promise<T> {
+  return toolProfileContext.run(profile, operation);
+}

--- a/src/mcp-server/toolProfileRuntime.ts
+++ b/src/mcp-server/toolProfileRuntime.ts
@@ -2,16 +2,20 @@ import type {
   McpServer,
   RegisteredTool,
 } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { currentToolProfileContext } from "./toolProfileContext.js";
 import {
   parseToolProfileId,
   selectAvailableToolProfileNames,
   type ToolProfileId,
 } from "./toolProfiles.js";
 
-export function resolveToolProfile(
-  raw = process.env.MCP_TOOL_PROFILE?.trim() || "full",
-): ToolProfileId {
-  return parseToolProfileId(raw);
+export function resolveToolProfile(raw?: string): ToolProfileId {
+  const selected =
+    raw?.trim() ||
+    currentToolProfileContext() ||
+    process.env.MCP_TOOL_PROFILE?.trim() ||
+    "full";
+  return parseToolProfileId(selected);
 }
 
 /**
@@ -23,6 +27,9 @@ export function resolveToolProfile(
  * names currently present, and reconcile enabled state after each registration.
  * This makes canonical/direct fallback resolution independent of registration
  * order while preserving `full` as the unfiltered 2.x compatibility surface.
+ *
+ * HTTP session creation may provide a request-scoped profile through
+ * AsyncLocalStorage; stdio falls back to CLI/env selection.
  */
 export function installToolProfileRegistrationGate(
   server: McpServer,

--- a/src/mcp-server/transports/httpToolProfileRouting.ts
+++ b/src/mcp-server/transports/httpToolProfileRouting.ts
@@ -1,0 +1,70 @@
+import {
+  TOOL_PROFILE_IDS,
+  parseToolProfileId,
+  type ToolProfileId,
+} from "../toolProfiles.js";
+
+export const INTERNAL_TOOL_PROFILE_HEADER =
+  "x-optimike-internal-tool-profile" as const;
+
+export function toolProfileForMcpPath(
+  pathname: string,
+): ToolProfileId | undefined {
+  if (pathname === "/mcp") return "full";
+  if (!pathname.startsWith("/mcp/")) return undefined;
+
+  const suffix = pathname.slice("/mcp/".length);
+  if (!suffix || suffix.includes("/")) {
+    throw new Error("Invalid MCP tool profile path.");
+  }
+  return parseToolProfileId(decodeURIComponent(suffix));
+}
+
+/**
+ * Public profile endpoints are rewritten internally to the existing /mcp Hono
+ * route. The internal profile header is always overwritten from the path, so a
+ * caller cannot inject or switch profile through a custom header.
+ */
+export function rewriteProfiledMcpRequest(request: Request): Request | Response {
+  const url = new URL(request.url);
+  let profile: ToolProfileId | undefined;
+  try {
+    profile = toolProfileForMcpPath(url.pathname);
+  } catch {
+    return new Response(
+      JSON.stringify({
+        error: "unknown_tool_profile",
+        message: `MCP profile must be one of: ${TOOL_PROFILE_IDS.join(", ")}.`,
+      }),
+      {
+        status: 404,
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+          "cache-control": "no-store",
+        },
+      },
+    );
+  }
+
+  if (!profile) return request;
+
+  const headers = new Headers(request.headers);
+  headers.set(INTERNAL_TOOL_PROFILE_HEADER, profile);
+  url.pathname = "/mcp";
+  return new Request(url, {
+    method: request.method,
+    headers,
+    body:
+      request.method === "GET" || request.method === "HEAD"
+        ? undefined
+        : request.body,
+    duplex: request.body ? "half" : undefined,
+    signal: request.signal,
+  } as RequestInit & { duplex?: "half" });
+}
+
+export function toolProfileFromInternalRequest(request: Request): ToolProfileId {
+  return parseToolProfileId(
+    request.headers.get(INTERNAL_TOOL_PROFILE_HEADER) ?? "full",
+  );
+}

--- a/src/mcp-server/transports/httpTransport.ts
+++ b/src/mcp-server/transports/httpTransport.ts
@@ -7,8 +7,9 @@
  * 2. a bounded functional limiter keyed by verified authentication claims.
  *
  * Proxy headers are ignored unless the immediate peer belongs to the explicit
- * `MCP_TRUSTED_PROXIES` allowlist. MCP sessions are bound to the verified identity
- * that initialized them. Raw bearer tokens are never used as keys or log fields.
+ * `MCP_TRUSTED_PROXIES` allowlist. MCP sessions are bound to both the verified
+ * identity and the public tool profile that initialized them. Raw bearer tokens
+ * are never used as keys or log fields.
  *
  * @module src/mcp-server/transports/httpTransport
  */
@@ -37,6 +38,12 @@ import {
   RequestContext,
   requestContextService,
 } from "../../utils/index.js";
+import { withToolProfileContext } from "../toolProfileContext.js";
+import type { ToolProfileId } from "../toolProfiles.js";
+import {
+  rewriteProfiledMcpRequest,
+  toolProfileFromInternalRequest,
+} from "./httpToolProfileRouting.js";
 import {
   jwtAuthMiddleware,
   oauthMiddleware,
@@ -81,6 +88,7 @@ type HttpSession = {
   transport: WebStandardStreamableHTTPServerTransport;
   identityKey: string;
   identityPseudonym: string;
+  toolProfile: ToolProfileId;
   createdAt: number;
   lastSeenAt: number;
   activeRequests: number;
@@ -164,6 +172,10 @@ function originAllowed(origin: string): boolean {
   return (config.mcpAllowedOrigins ?? []).includes(origin);
 }
 
+function requestToolProfile(c: Context): ToolProfileId {
+  return toolProfileFromInternalRequest(c.req.raw);
+}
+
 async function authMiddleware(
   c: Context<{ Bindings: HttpBindings }>,
   next: Next,
@@ -200,8 +212,6 @@ async function rateLimitResponse(
   const requestState = getHttpRequestState(c.req.raw);
   const preAuthRejection = scope !== "client-identity";
   if (preAuthRejection && c.req.method === "POST") {
-    // Source limiting runs before the request-body guard. Never clone or parse
-    // an untrusted body on this rejection path; cancel it instead.
     void c.req.raw.body
       ?.cancel("pre-authentication source rate limit")
       .catch(() => undefined);
@@ -238,8 +248,6 @@ async function rateLimitResponse(
             ? "Rate-limit state capacity is temporarily exhausted."
             : "Rate limit exceeded.",
       },
-      // Quota rejection happens before request-body admission. Do not clone or
-      // parse an attacker-controlled body merely to recover its JSON-RPC id.
       id: null,
     },
     429,
@@ -412,6 +420,7 @@ function sessionForRequest(
   const session = transports.get(sessionId);
   if (!session) return undefined;
   const identity = requireIdentity(c);
+  const requestedProfile = requestToolProfile(c);
   if (session.identityKey !== identity.key) {
     logger.warning(
       "HTTP session identity mismatch rejected.",
@@ -419,6 +428,22 @@ function sessionForRequest(
         requestId: getHttpRequestState(c.req.raw).requestId,
         operation: "httpSessionIdentityMismatch",
         clientIdentity: identity.pseudonym,
+      }),
+    );
+    throw new McpError(
+      BaseErrorCode.NOT_FOUND,
+      "Invalid or expired session ID.",
+    );
+  }
+  if (session.toolProfile !== requestedProfile) {
+    logger.warning(
+      "HTTP session tool-profile mismatch rejected.",
+      requestContextService.createRequestContext({
+        requestId: getHttpRequestState(c.req.raw).requestId,
+        operation: "httpSessionToolProfileMismatch",
+        clientIdentity: identity.pseudonym,
+        sessionToolProfile: session.toolProfile,
+        requestedToolProfile: requestedProfile,
       }),
     );
     throw new McpError(
@@ -567,13 +592,18 @@ function startHttpServerWithRetry(
       }
 
       try {
+        const fetch = async (request: Request) => {
+          const routed = rewriteProfiledMcpRequest(request);
+          return routed instanceof Response ? routed : app.fetch(routed);
+        };
         const serverInstance = serve(
-          { fetch: app.fetch, port: currentPort, hostname: host },
+          { fetch, port: currentPort, hostname: host },
           (info: { address: string; port: number }) => {
             const serverAddress = `http://${info.address}:${info.port}${MCP_ENDPOINT_PATH}`;
             logger.info(`HTTP transport listening at ${serverAddress}`, {
               ...attemptContext,
               address: serverAddress,
+              toolProfiles: ["standard", "authoring", "tasks", "full"],
             });
             if (process.stdout.isTTY) {
               console.log(`\n🚀 MCP Server running at: ${serverAddress}\n`);
@@ -687,8 +717,6 @@ export async function startHttpTransport(
 
   app.use(MCP_ENDPOINT_PATH, preAuthRateLimitMiddleware);
   app.use(externalHandoffEndpoint, preAuthRateLimitMiddleware);
-  // Source limiting must happen before buffering. Its 429 path never reads the
-  // body; this guard then protects authentication and identity-quota errors.
   app.use(MCP_ENDPOINT_PATH, httpRequestBodyGuardMiddleware);
   app.use(MCP_ENDPOINT_PATH, authMiddleware);
   app.use(externalHandoffEndpoint, authMiddleware);
@@ -748,11 +776,13 @@ export async function startHttpTransport(
   app.post(MCP_ENDPOINT_PATH, async (c: Context) => {
     const state = getHttpRequestState(c.req.raw);
     const identity = requireIdentity(c);
+    const toolProfile = requestToolProfile(c);
     const postContext = requestContextService.createRequestContext({
       ...transportContext,
       requestId: state.requestId,
       operation: "handlePost",
       clientIdentity: identity.pseudonym,
+      toolProfile,
     });
     const body = await c.req.raw.clone().json();
     const sessionId = c.req.header("mcp-session-id");
@@ -787,6 +817,7 @@ export async function startHttpTransport(
             transport: newTransport,
             identityKey: identity.key,
             identityPseudonym: identity.pseudonym,
+            toolProfile,
             createdAt: now,
             lastSeenAt: now,
             activeRequests: 1,
@@ -800,6 +831,7 @@ export async function startHttpTransport(
                 requestContextService.createRequestContext({
                   operation: "expireHttpSessionMaxLifetime",
                   clientIdentity: identity.pseudonym,
+                  toolProfile,
                   sessionCount: transports.size,
                 }),
               );
@@ -835,7 +867,9 @@ export async function startHttpTransport(
       };
 
       try {
-        const server = await createServerInstanceFn();
+        const server = await withToolProfileContext(toolProfile, () =>
+          createServerInstanceFn(),
+        );
         await server.connect(newTransport);
         transport = newTransport;
       } catch (error) {

--- a/src/mcp-server/transports/httpTransport.ts
+++ b/src/mcp-server/transports/httpTransport.ts
@@ -592,9 +592,11 @@ function startHttpServerWithRetry(
       }
 
       try {
-        const fetch = async (request: Request) => {
+        const fetch: typeof app.fetch = (request, env, executionCtx) => {
           const routed = rewriteProfiledMcpRequest(request);
-          return routed instanceof Response ? routed : app.fetch(routed);
+          return routed instanceof Response
+            ? routed
+            : app.fetch(routed, env, executionCtx);
         };
         const serverInstance = serve(
           { fetch, port: currentPort, hostname: host },


### PR DESCRIPTION
## Scope

Implements P3 on top of P0-P2.

Adds explicit public HTTP MCP profile endpoints:

- `/mcp` — legacy 2.x alias of `full`;
- `/mcp/standard`;
- `/mcp/authoring`;
- `/mcp/tasks`;
- `/mcp/full`.

The public profile path is resolved before Hono's existing `/mcp` transport pipeline and rewritten internally to the existing endpoint. A server-owned internal marker carries the resolved profile; caller-supplied values are overwritten.

## Session binding

Each HTTP session now stores `toolProfile` alongside its verified identity. `POST`, `GET`, and `DELETE` session reuse must match both identity and profile. Reusing a session created on `/mcp/standard` through `/mcp/full` fails closed with the same generic invalid/expired-session contract used for identity mismatches.

Profile selection is request-scoped through `AsyncLocalStorage` only while the per-session `McpServer` instance is created. It never mutates process-wide profile state, so standard/tasks/full sessions can coexist concurrently on one backend.

## Durable-plan authority

This PR deliberately does **not** bind governed plans or journals to the HTTP profile. The profile is a session exposure contract only. Existing planRef, idempotency, backend binding and write/security policies remain the sole mutation/recovery authority.

## Semantic aliases

- `/mcp/standard`, `/mcp/authoring`, `/mcp/tasks`: only `smart_semantic_search` is exposed;
- `/mcp/full` and legacy `/mcp`: preserve `smart_search` and `smart-search` for 2.x compatibility.

## Validation

The dedicated Linux/Windows test creates simultaneous authenticated standard, tasks, full and legacy sessions on one headless-readonly backend, verifies expected tool counts and semantic alias policy, proves `/mcp == /mcp/full`, rejects cross-profile session reuse in POST and DELETE, proves the original session remains usable, and verifies unknown profile paths fail closed. Existing HTTP multiclient and headless-multiclient suites also run.