### PR TITLE
feat: add portable MCP tool surface profiles

### DIFF
--- a/.github/workflows/tool-surface-p0.yml
+++ b/.github/workflows/tool-surface-p0.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - "src/mcp-server/**"
       - "scripts/test-tool-surface-registry.mjs"
+      - "scripts/test-tool-surface-runtime-conformance.mjs"
       - ".github/workflows/tool-surface-p0.yml"
   push:
     branches:
@@ -12,6 +13,7 @@ on:
     paths:
       - "src/mcp-server/**"
       - "scripts/test-tool-surface-registry.mjs"
+      - "scripts/test-tool-surface-runtime-conformance.mjs"
       - ".github/workflows/tool-surface-p0.yml"
 
 permissions:
@@ -34,3 +36,4 @@ jobs:
       - run: npm ci
       - run: npm run build
       - run: node scripts/test-tool-surface-registry.mjs
+      - run: node scripts/test-tool-surface-runtime-conformance.mjs

--- a/.github/workflows/tool-surface-p0.yml
+++ b/.github/workflows/tool-surface-p0.yml
@@ -1,0 +1,36 @@
+name: Tool Surface P0
+
+on:
+  pull_request:
+    paths:
+      - "src/mcp-server/**"
+      - "scripts/test-tool-surface-registry.mjs"
+      - ".github/workflows/tool-surface-p0.yml"
+  push:
+    branches:
+      - "agent/tool-surface-p0"
+    paths:
+      - "src/mcp-server/**"
+      - "scripts/test-tool-surface-registry.mjs"
+      - ".github/workflows/tool-surface-p0.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  registry:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.7.5"
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: node scripts/test-tool-surface-registry.mjs

--- a/.github/workflows/tool-surface-p0.yml
+++ b/.github/workflows/tool-surface-p0.yml
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.7.5"
+          node-version: "22"
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/tool-surface-p1.yml
+++ b/.github/workflows/tool-surface-p1.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "22.7.5"
+          node-version: "22"
           cache: npm
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/tool-surface-p1.yml
+++ b/.github/workflows/tool-surface-p1.yml
@@ -1,0 +1,35 @@
+name: Tool Surface P1
+
+on:
+  pull_request:
+    paths:
+      - "src/mcp-server/toolSurfaceRegistry.ts"
+      - "src/mcp-server/toolProfiles.ts"
+      - "scripts/test-tool-surface-registry.mjs"
+      - "scripts/test-tool-profiles.mjs"
+      - ".github/workflows/tool-surface-p1.yml"
+  push:
+    branches:
+      - "agent/tool-surface-p1"
+
+permissions:
+  contents: read
+
+jobs:
+  profiles:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.7.5"
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: node scripts/test-tool-surface-registry.mjs
+      - run: node scripts/test-tool-profiles.mjs

--- a/.github/workflows/tool-surface-p2.yml
+++ b/.github/workflows/tool-surface-p2.yml
@@ -1,0 +1,41 @@
+name: Tool Surface P2
+
+on:
+  pull_request:
+    paths:
+      - "src/config/toolProfileCli.ts"
+      - "src/mcp-server/toolProfiles.ts"
+      - "src/mcp-server/toolProfileRuntime.ts"
+      - "src/mcp-server/resources/toolRoutingResource.ts"
+      - "src/stdio-proxy.ts"
+      - "scripts/test-tool-profile-runtime.mjs"
+      - "scripts/test-tool-profile-stdio-proxy.mjs"
+      - "scripts/test-tool-routing-contract.mjs"
+      - ".github/workflows/tool-surface-p2.yml"
+  push:
+    branches:
+      - "agent/tool-surface-p2"
+
+permissions:
+  contents: read
+
+jobs:
+  runtime-profiles:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: node scripts/test-tool-profiles.mjs
+      - run: node scripts/test-tool-profile-runtime.mjs
+      - run: node scripts/test-tool-profile-stdio-proxy.mjs
+      - run: node scripts/test-tool-routing-contract.mjs

--- a/.github/workflows/tool-surface-p3.yml
+++ b/.github/workflows/tool-surface-p3.yml
@@ -1,0 +1,37 @@
+name: Tool Surface P3
+
+on:
+  pull_request:
+    paths:
+      - "src/mcp-server/toolProfileContext.ts"
+      - "src/mcp-server/toolProfileRuntime.ts"
+      - "src/mcp-server/transports/httpToolProfileRouting.ts"
+      - "src/mcp-server/transports/httpTransport.ts"
+      - "scripts/test-http-tool-profiles.mjs"
+      - ".github/workflows/tool-surface-p3.yml"
+  push:
+    branches:
+      - "agent/tool-surface-p3"
+
+permissions:
+  contents: read
+
+jobs:
+  http-profiles:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: node scripts/test-http-tool-profiles.mjs
+      - run: npm run test:http-multiclient
+      - run: npm run test:http-headless-multiclient

--- a/.github/workflows/tool-surface-p4.yml
+++ b/.github/workflows/tool-surface-p4.yml
@@ -6,6 +6,7 @@ on:
       - "package.json"
       - "README.md"
       - "README.fr.md"
+      - "docs/obsidian_mcp_tools_spec.md"
       - "docs/tool-surface-profiles.md"
       - "docs/tool-surface-profiles.fr.md"
       - "docs/mcp-routing-guide.md"

--- a/.github/workflows/tool-surface-p4.yml
+++ b/.github/workflows/tool-surface-p4.yml
@@ -1,0 +1,45 @@
+name: Tool Surface P4
+
+on:
+  pull_request:
+    paths:
+      - "docs/tool-surface-profiles.md"
+      - "docs/tool-surface-profiles.fr.md"
+      - "docs/mcp-routing-guide.md"
+      - "docs/mcp-routing-guide.fr.md"
+      - "docs/README.md"
+      - "docs/README.fr.md"
+      - "evals/**"
+      - "scripts/test-tool-routing-eval-corpus.mjs"
+      - "scripts/test-tool-routing-scorer.mjs"
+      - "scripts/score-tool-routing-evals.mjs"
+      - "scripts/test-tool-surface-profile-docs.mjs"
+      - ".github/workflows/tool-surface-p4.yml"
+  push:
+    branches:
+      - "agent/tool-surface-p4"
+
+permissions:
+  contents: read
+
+jobs:
+  docs-and-evals:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: node scripts/test-tool-profiles.mjs
+      - run: node scripts/test-tool-routing-eval-corpus.mjs
+      - run: node scripts/test-tool-routing-scorer.mjs
+      - run: node scripts/test-tool-surface-profile-docs.mjs
+      - run: node scripts/test-tool-routing-contract.mjs

--- a/.github/workflows/tool-surface-p4.yml
+++ b/.github/workflows/tool-surface-p4.yml
@@ -48,4 +48,5 @@ jobs:
       - run: node scripts/test-tool-routing-scorer.mjs
       - run: node scripts/test-tool-surface-profile-docs.mjs
       - run: node scripts/test-tool-routing-contract.mjs
+      - run: npm run build:bridges
       - run: npm run test:package

--- a/.github/workflows/tool-surface-p4.yml
+++ b/.github/workflows/tool-surface-p4.yml
@@ -3,6 +3,7 @@ name: Tool Surface P4
 on:
   pull_request:
     paths:
+      - "package.json"
       - "docs/tool-surface-profiles.md"
       - "docs/tool-surface-profiles.fr.md"
       - "docs/mcp-routing-guide.md"
@@ -10,6 +11,7 @@ on:
       - "docs/README.md"
       - "docs/README.fr.md"
       - "evals/**"
+      - "scripts/test-package-contents.mjs"
       - "scripts/test-tool-routing-eval-corpus.mjs"
       - "scripts/test-tool-routing-scorer.mjs"
       - "scripts/score-tool-routing-evals.mjs"
@@ -43,3 +45,4 @@ jobs:
       - run: node scripts/test-tool-routing-scorer.mjs
       - run: node scripts/test-tool-surface-profile-docs.mjs
       - run: node scripts/test-tool-routing-contract.mjs
+      - run: npm run test:package

--- a/.github/workflows/tool-surface-p4.yml
+++ b/.github/workflows/tool-surface-p4.yml
@@ -48,5 +48,14 @@ jobs:
       - run: node scripts/test-tool-routing-scorer.mjs
       - run: node scripts/test-tool-surface-profile-docs.mjs
       - run: node scripts/test-tool-routing-contract.mjs
+      - name: Install Bases Bridge dependencies
+        working-directory: plugins/obsidian-bases-bridge
+        run: npm ci
+      - name: Install Operon Bridge dependencies
+        working-directory: plugins/obsidian-operon-bridge
+        run: npm ci
+      - name: Install Atomic Write Bridge dependencies
+        working-directory: plugins/obsidian-atomic-write-bridge
+        run: npm ci
       - run: npm run build:bridges
       - run: npm run test:package

--- a/.github/workflows/tool-surface-p4.yml
+++ b/.github/workflows/tool-surface-p4.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - "package.json"
+      - "README.md"
+      - "README.fr.md"
       - "docs/tool-surface-profiles.md"
       - "docs/tool-surface-profiles.fr.md"
       - "docs/mcp-routing-guide.md"

--- a/OPERATIONS.fr.md
+++ b/OPERATIONS.fr.md
@@ -217,8 +217,9 @@ protégé et le write gate désactivé par défaut de l’Atomic Write Bridge re
 actifs au planning et avant chaque effet possible.
 
 Avant merge ou release, activer l’Atomic Write Bridge uniquement dans un coffre
-Desktop jetable, créer une note canary `.md` existante et dédiée, puis exécuter
-dans PowerShell :
+Desktop jetable, créer une note canary `.md` existante et dédiée, désactiver les
+plugins qui modifient automatiquement le frontmatter de modification, puis
+exécuter dans PowerShell :
 
 ```powershell
 $env:OBSIDIAN_ATOMIC_NOTE_CANARY_PATH="Canary/Atomic Note.md"
@@ -237,9 +238,13 @@ et sauvegarde. Un échec géré avant mutation supprime aussi ce dossier après
 avoir vérifié que la note est inchangée. Une interruption brutale ou une
 restauration non vérifiée conserve le dossier privé au chemin de récupération
 affiché au démarrage ; ne restaurer qu’à partir des métadonnées explicites de sa
-sauvegarde. Ne jamais viser une note utilisateur ordinaire.
+sauvegarde. Ne jamais viser une note utilisateur ordinaire. Le canary à
+restauration octet pour octet refuse avant mutation si le Bridge annonce une
+intégration de modification automatique active. La réactiver ensuite et lancer
+le canary de settlement dédié ci-dessous : ces deux gates prouvent volontairement
+deux contrats distincts.
 
-Atomic Write Bridge `0.3.0` expose les propriétés actives de création,
+Atomic Write Bridge `0.3.0` ou ultérieur expose les propriétés actives de création,
 modification et dernière vue prises en charge. Le MCP dérive leur protection
 structurelle sans doublon dans `MCP_PROTECTED_FRONTMATTER_KEYS`, qui reste
 additif pour les champs personnalisés. La gate live utilise volontairement une

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -212,7 +212,8 @@ current MCP write policy, protected frontmatter and the default-off Atomic Write
 Bridge gate remain effective at planning and before every possible effect.
 
 Before merge or release, enable the Atomic Write Bridge only in a disposable
-Desktop vault, create one dedicated existing `.md` canary note, then run:
+Desktop vault, create one dedicated existing `.md` canary note, disable any
+plugin that automatically changes modified-time frontmatter, then run:
 
 ```bash
 OBSIDIAN_ATOMIC_NOTE_CANARY_PATH="Canary/Atomic Note.md" \
@@ -230,9 +231,12 @@ logs, and backup. A handled failure before mutation also removes that directory
 after verifying the note is unchanged. An abrupt interruption or an unverified
 restoration retains the private directory at the recovery path printed when the
 script starts; restore only from its explicit backup metadata. Never point the
-canary at an ordinary user note.
+canary at an ordinary user note. The byte-exact canary refuses before mutation
+when the Bridge advertises an active modified-time integration. Re-enable the
+integration afterward and run the dedicated settlement canary below; the two
+gates deliberately prove separate contracts.
 
-Atomic Write Bridge `0.3.0` reports supported active creation, modification and
+Atomic Write Bridge `0.3.0` or later reports supported active creation, modification and
 last-viewed properties. The MCP derives their structural protection without a
 duplicate `MCP_PROTECTED_FRONTMATTER_KEYS` entry; that variable remains
 additive for custom fields. The live gate deliberately uses a static sentinel

--- a/README.fr.md
+++ b/README.fr.md
@@ -18,29 +18,66 @@ documents autorisés hors du coffre.
 | Domaine                 | Ce que fournit le MCP                                                                                 | Dépendance principale                                              |
 | ----------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
 | Notes                   | Lecture/recherche/update plus plans gouvernés de note atomique et Frontmatter source-preserving       | Coffre ; Local REST API + Atomic Write Bridge pour le CAS gouverné |
-| Bases et Canvas         | Requêtes/formules Base, plans de graphe Canvas gouvernés et helpers headless directs                   | Bases Bridge ; Atomic Write Bridge 0.4.0 pour le CAS Canvas         |
+| Bases et Canvas         | Requêtes/formules Base, plans de graphe Canvas gouvernés et helpers headless directs                  | Bases Bridge ; Atomic Write Bridge 0.4.0 pour le CAS Canvas        |
 | Tâches                  | Lecture/requête Tasks + 23 outils Operon gouvernés                                                    | Operon Developer API V1 via le Bridge                              |
-| Recherche sémantique    | Recherche Smart Connections avec cache de métadonnées durable                                         | `.smart-env` + embedding Ollama ou OpenAI                          |
+| Recherche sémantique    | Recherche Smart Connections avec cache de métadonnées durable                                        | `.smart-env` + embedding Ollama ou OpenAI                          |
 | Runtime                 | Cache SQLite partagé, santé, maintenance, mode dégradé et exclusions                                  | Filesystem local                                                   |
 | Documents externes      | Lectures/handoff gouvernés + move local opt-in avec réparation                                        | Allowlist ; stdio local pour le move                               |
 | Administration headless | Opérations bornées sur notes, métadonnées et filesystem du coffre                                     | Mode guarded/filesystem sur un coffre copié                        |
 
 Le registre actuel des outils vit dans
 [Surface des outils](docs/obsidian_mcp_tools_spec.md). Leur disponibilité dépend
-du mode runtime ; consulter la
-[Matrice des capacités](docs/runtime-capability-matrix.fr.md) avant d’activer
+du mode runtime et du profil d’outils ; consulter la
+[Matrice des capacités](docs/runtime-capability-matrix.fr.md) et les
+[Profils de surface d’outils](docs/tool-surface-profiles.fr.md) avant d’activer
 des écritures.
 
-## Choisir un profil
+## Choisir un runtime et un transport
 
-| Besoin                                   | Profil recommandé                              | Posture                     |
-| ---------------------------------------- | ---------------------------------------------- | --------------------------- |
-| Codex (vérifié) ou client stdio local    | `dist/stdio-proxy.js`                          | Profil local par défaut     |
-| Automatisation Obsidian Desktop          | `live` ou `hybrid` via le proxy stdio          | Desktop de confiance        |
-| CI, serveur ou copie synchronisée        | `headless-readonly`                            | Profil headless le plus sûr |
-| Écritures bornées sur coffre copié/dédié | `headless-guarded`, puis `headless-filesystem` | Opt-in explicite            |
-| HTTP direct sur la même machine          | HTTP loopback authentifié                      | Supporté avec limites       |
-| HTTP distant                             | Reverse proxy TLS revu + réseau privé          | Pilote seulement            |
+| Besoin                                   | Runtime / transport recommandé                     | Posture                     |
+| ---------------------------------------- | --------------------------------------------------- | --------------------------- |
+| Agent stdio local                        | `dist/stdio-proxy.js`                               | Proxy par client            |
+| Automatisation Obsidian Desktop          | `live` ou `hybrid` via le proxy stdio               | Desktop de confiance        |
+| CI, serveur ou copie synchronisée        | `headless-readonly`                                 | Mode headless le plus sûr   |
+| Écritures bornées sur coffre copié/dédié | `headless-guarded`, puis `headless-filesystem`      | Opt-in explicite            |
+| HTTP direct sur la même machine          | HTTP loopback authentifié                           | Supporté avec limites       |
+| HTTP distant                             | Reverse proxy TLS revu + réseau privé               | Pilote seulement            |
+
+Le runtime répond à « que peut faire le backend en sécurité ? ». Il ne décide
+pas combien d’outils un agent doit voir.
+
+## Choisir une surface d’outils
+
+| Besoin | Profil recommandé | Taille live/hybrid complète |
+| --- | --- | ---: |
+| Travail général sur le coffre | `standard` | 19 outils |
+| Notes + tags + authoring Bases/Canvas | `authoring` | 31 outils |
+| Workflows Tasks / Operon | `tasks` | 31 outils |
+| Compatibilité, administration et surfaces spécialisées | `full` | 72 outils |
+
+Les profils modernes n’exposent qu’un seul nom pour la recherche sémantique :
+`smart_semantic_search`. Les anciens alias de compatibilité restent accessibles
+uniquement dans `full` pendant la branche 2.x et leur suppression physique est
+réservée à la 3.0.
+
+En stdio, sélectionner le profil avant `tools/list` :
+
+```bash
+node dist/stdio-proxy.js --tool-profile standard
+```
+
+En HTTP, le profil vit dans l’URL MCP :
+
+```text
+/mcp/standard
+/mcp/authoring
+/mcp/tasks
+/mcp/full
+```
+
+Le `/mcp` historique reste équivalent à `/mcp/full` pendant la branche 2.x. Voir
+[Profils de surface d’outils](docs/tool-surface-profiles.fr.md) pour la liaison
+de session, les exemples clients et les règles de compatibilité.
 
 Le serveur Node ne doit jamais être exposé directement à Internet. Voir
 [Sécurité](SECURITY.fr.md) et
@@ -59,7 +96,7 @@ git clone https://github.com/optimikelabs/optimike-obsidian-mcp.git
 cd optimike-obsidian-mcp
 npm install
 npm run build
-node dist/stdio-proxy.js
+node dist/stdio-proxy.js --tool-profile standard
 ```
 
 Avec le package, le binaire proxy explicite est
@@ -71,7 +108,11 @@ Configuration Codex minimale :
 ```toml
 [mcp_servers.optimike-obsidian-mcp-stdio]
 command = "node"
-args = ["/chemin/vers/optimike-obsidian-mcp/dist/stdio-proxy.js"]
+args = [
+  "/chemin/vers/optimike-obsidian-mcp/dist/stdio-proxy.js",
+  "--tool-profile",
+  "standard"
+]
 
 [mcp_servers.optimike-obsidian-mcp-stdio.env]
 OBSIDIAN_VAULT = "/chemin/vers/coffre"
@@ -170,10 +211,11 @@ Commencer par
 
 ## Recherche sémantique
 
-`smart_semantic_search` interroge un index Smart Connections local. L’embedding
-de requête peut rester local via Ollama ou passer par OpenAI selon la
-configuration. Avec OpenAI, l’outil devient donc open-world même si l’index du
-coffre reste local.
+`smart_semantic_search` est l’outil canonique de recherche sémantique. Les
+profils modernes n’exposent que ce nom. Il interroge un index Smart Connections
+local. L’embedding de requête peut rester local via Ollama ou passer par OpenAI
+selon la configuration. Avec OpenAI, l’outil devient donc open-world même si
+l’index du coffre reste local.
 
 Voir [Exploitation](OPERATIONS.fr.md) pour les providers et le cache.
 
@@ -196,6 +238,7 @@ partagée hors du vrai coffre synchronisé.
 ## Documentation
 
 - Entrée par audience et besoin : [Hub documentaire](docs/README.fr.md)
+- Profils d’exposition et exemples clients : [Profils de surface d’outils](docs/tool-surface-profiles.fr.md)
 - Runtime et maintenance : [OPERATIONS.fr.md](OPERATIONS.fr.md)
 - Sécurité et frontière de déploiement : [SECURITY.fr.md](SECURITY.fr.md)
 - Outils actuels : [Surface des outils](docs/obsidian_mcp_tools_spec.md)

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,72 +1,58 @@
 # Optimike Obsidian MCP
 
 [![Dernière version](https://img.shields.io/github/v/release/optimikelabs/optimike-obsidian-mcp?display_name=tag&sort=semver)](https://github.com/optimikelabs/optimike-obsidian-mcp/releases/latest)
-English version: [README.md](README.md) · Hub documentaire : [docs/README.fr.md](docs/README.fr.md)
-Exploitation : [OPERATIONS.fr.md](OPERATIONS.fr.md)
-Sécurité : [SECURITY.fr.md](SECURITY.fr.md)
+
+English version: [README.md](README.md) · [Hub documentaire](docs/README.fr.md) · [Exploitation](OPERATIONS.fr.md) · [Sécurité](SECURITY.fr.md)
 
 ![Vue d’ensemble d’Optimike Obsidian MCP entre clients agentiques, Obsidian et documents externes gouvernés](docs/assets/readme/overview.fr.svg)
 
-Optimike Obsidian MCP fournit aux clients MCP une surface opérationnelle
-gouvernée au-dessus d’un coffre Obsidian. Il réunit opérations Desktop,
-fonctionnement headless résilient, Tasks et Operon, Bases, recherche
-sémantique, observabilité runtime et accès explicitement gouverné à des
-documents autorisés hors du coffre.
+Optimike Obsidian MCP fournit aux clients MCP une surface opérationnelle gouvernée au-dessus d’un coffre Obsidian : opérations Desktop live, modes headless résilients, Tasks et Operon, Bases et Canvas, recherche sémantique, observabilité runtime et accès borné à des documents externes configurés.
 
 ## Carte des capacités
 
-| Domaine                 | Ce que fournit le MCP                                                                                 | Dépendance principale                                              |
-| ----------------------- | ----------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| Notes                   | Lecture/recherche/update plus plans gouvernés de note atomique et Frontmatter source-preserving       | Coffre ; Local REST API + Atomic Write Bridge pour le CAS gouverné |
-| Bases et Canvas         | Requêtes/formules Base, plans de graphe Canvas gouvernés et helpers headless directs                  | Bases Bridge ; Atomic Write Bridge 0.4.0 pour le CAS Canvas        |
-| Tâches                  | Lecture/requête Tasks + 23 outils Operon gouvernés                                                    | Operon Developer API V1 via le Bridge                              |
-| Recherche sémantique    | Recherche Smart Connections avec cache de métadonnées durable                                        | `.smart-env` + embedding Ollama ou OpenAI                          |
-| Runtime                 | Cache SQLite partagé, santé, maintenance, mode dégradé et exclusions                                  | Filesystem local                                                   |
-| Documents externes      | Lectures/handoff gouvernés + move local opt-in avec réparation                                        | Allowlist ; stdio local pour le move                               |
-| Administration headless | Opérations bornées sur notes, métadonnées et filesystem du coffre                                     | Mode guarded/filesystem sur un coffre copié                        |
+| Domaine | Ce que fournit le MCP | Dépendance principale |
+| --- | --- | --- |
+| Notes | Lecture/recherche/éditions directes + opérations gouvernées Note et Frontmatter | Coffre ; Local REST API + Atomic Write Bridge |
+| Bases et Canvas | Requêtes, écritures bornées, formules et graphes Canvas gouvernés | Bases Bridge ; Atomic Write Bridge |
+| Tâches | Markdown Tasks-compatible + 23 outils Operon gouvernés | Operon Developer API V1 via le Bridge |
+| Recherche sémantique | Recherche dans l’index Smart Connections | `.smart-env` + embedding Ollama ou compatible OpenAI |
+| Runtime | Cache SQLite partagé, santé, maintenance et modes dégradés | Filesystem local |
+| Documents externes | Lectures/handoff default-deny + move local opt-in | Allowlist de racines |
+| Administration headless | Opérations métadonnées/filesystem bornées | Copie ou coffre dédié |
 
-Le registre actuel des outils vit dans
-[Surface des outils](docs/obsidian_mcp_tools_spec.md). Leur disponibilité dépend
-du mode runtime et du profil d’outils ; consulter la
-[Matrice des capacités](docs/runtime-capability-matrix.fr.md) et les
-[Profils de surface d’outils](docs/tool-surface-profiles.fr.md) avant d’activer
-des écritures.
+Le registre canonique des outils est documenté dans [Surface des outils](docs/obsidian_mcp_tools_spec.md).
 
-## Choisir un runtime et un transport
+## Runtime et transport
 
-| Besoin                                   | Runtime / transport recommandé                     | Posture                     |
-| ---------------------------------------- | --------------------------------------------------- | --------------------------- |
-| Agent stdio local                        | `dist/stdio-proxy.js`                               | Proxy par client            |
-| Automatisation Obsidian Desktop          | `live` ou `hybrid` via le proxy stdio               | Desktop de confiance        |
-| CI, serveur ou copie synchronisée        | `headless-readonly`                                 | Mode headless le plus sûr   |
-| Écritures bornées sur coffre copié/dédié | `headless-guarded`, puis `headless-filesystem`      | Opt-in explicite            |
-| HTTP direct sur la même machine          | HTTP loopback authentifié                           | Supporté avec limites       |
-| HTTP distant                             | Reverse proxy TLS revu + réseau privé               | Pilote seulement            |
+| Besoin | Runtime / transport recommandé |
+| --- | --- |
+| Agent local | proxy stdio |
+| Automatisation Obsidian Desktop | `live` ou `hybrid` |
+| CI/serveur/copie synchronisée | `headless-readonly` |
+| Écritures bornées sur copie/coffre dédié | `headless-guarded`, puis `headless-filesystem` |
+| HTTP sur la même machine | HTTP loopback authentifié |
+| HTTP distant | reverse proxy TLS revu + réseau privé ; pilote seulement |
 
-Le runtime répond à « que peut faire le backend en sécurité ? ». Il ne décide
-pas combien d’outils un agent doit voir.
+Le runtime répond à ce que le backend peut exécuter. Il ne décide pas combien d’outils le modèle doit voir.
 
-## Choisir une surface d’outils
+## Profils de surface d’outils
 
-| Besoin | Profil recommandé | Taille live/hybrid complète |
+| Besoin | Profil | Taille live/hybrid complète |
 | --- | --- | ---: |
-| Travail général sur le coffre | `standard` | 19 outils |
-| Notes + tags + authoring Bases/Canvas | `authoring` | 31 outils |
-| Workflows Tasks / Operon | `tasks` | 31 outils |
-| Compatibilité, administration et surfaces spécialisées | `full` | 72 outils |
+| Travail général sur le coffre | `standard` | 19 |
+| Notes, tags, Bases et Canvas | `authoring` | 31 |
+| Workflows Tasks / Operon | `tasks` | 31 |
+| Compatibilité, admin et surfaces spécialisées | `full` | 72 |
 
-Les profils modernes n’exposent qu’un seul nom pour la recherche sémantique :
-`smart_semantic_search`. Les anciens alias de compatibilité restent accessibles
-uniquement dans `full` pendant la branche 2.x et leur suppression physique est
-réservée à la 3.0.
+Pendant la branche 2.x, `full` conserve toute la surface de compatibilité. Les profils modernes n’exposent que `smart_semantic_search` ; les alias historiques `smart_search` et `smart-search` restent réservés à `full` jusqu’à la 3.0.
 
-En stdio, sélectionner le profil avant `tools/list` :
+Sélectionner le profil avant `tools/list` :
 
 ```bash
 node dist/stdio-proxy.js --tool-profile standard
 ```
 
-En HTTP, le profil vit dans l’URL MCP :
+Routes HTTP profilées :
 
 ```text
 /mcp/standard
@@ -75,21 +61,15 @@ En HTTP, le profil vit dans l’URL MCP :
 /mcp/full
 ```
 
-Le `/mcp` historique reste équivalent à `/mcp/full` pendant la branche 2.x. Voir
-[Profils de surface d’outils](docs/tool-surface-profiles.fr.md) pour la liaison
-de session, les exemples clients et les règles de compatibilité.
+Le `/mcp` historique reste équivalent à `/mcp/full` pendant la branche 2.x. Voir [Profils de surface d’outils](docs/tool-surface-profiles.fr.md).
 
-Le serveur Node ne doit jamais être exposé directement à Internet. Voir
-[Sécurité](SECURITY.fr.md) et
-[l’ADR de livraison HTTP](docs/adr/ADR-HTTP-External-Artifact-Delivery.md).
-
-## Démarrage rapide depuis les sources
+## Démarrage rapide
 
 Pré-requis :
 
 - Node.js `>=22.7.5` ;
-- Obsidian Desktop seulement pour les fonctions Desktop live ;
-- plugins propres aux capacités réellement utilisées.
+- Obsidian Desktop uniquement pour les fonctions live ;
+- plugins correspondant aux capacités activées.
 
 ```bash
 git clone https://github.com/optimikelabs/optimike-obsidian-mcp.git
@@ -99,9 +79,12 @@ npm run build
 node dist/stdio-proxy.js --tool-profile standard
 ```
 
-Avec le package, le binaire proxy explicite est
-`optimike-obsidian-mcp-proxy`. Le binaire historique
-`optimike-obsidian-mcp` démarre toujours directement le backend.
+Binaires du package :
+
+```text
+optimike-obsidian-mcp
+optimike-obsidian-mcp-proxy
+```
 
 Configuration Codex minimale :
 
@@ -121,101 +104,56 @@ OBSIDIAN_BASE_URL = "http://127.0.0.1:27123"
 OBSIDIAN_API_KEY = "<cle-local-rest-api>"
 ```
 
-Conserver chemins réels, clés API et configuration des racines externes hors du
-dépôt et hors des contenus distribuables du coffre.
+Conserver chemins réels, clés API, journaux et configuration External Roots hors du dépôt et des contenus distribuables.
 
 ## Intégrations Obsidian optionnelles
 
-Activer seulement les surfaces utilisées :
+N’activer que les surfaces utilisées :
 
-- [Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api) :
-  notes, métadonnées et tags en live ;
-- **Bases Bridge (REST)** inclus : requêtes `.base` live et CAS typé opt-in pour les formules source-preserving gouvernées `plan → apply → status → recover` ; les remplacements complets historiques sont désactivés par défaut ([contrat P2](docs/governed-base-formula-p2.fr.md)) ;
-- **Optimike Atomic Write Bridge** inclus : gates CAS SHA-256 indépendants et désactivés par défaut pour Markdown et JSON Canvas, avec cycles gouvernés note, Frontmatter et Canvas `plan → apply → status → recover` ; la 0.3.0 ajoute la protection/settlement borné des propriétés de date et la 0.4.0 le read/CAS Canvas typé avec validation du graphe ; `planRef` opaque, réponse perdue → `status`, recovery exact ≠ undo ([note](docs/governed-note-replacement.fr.md), [P1](docs/governed-frontmatter-p1.fr.md), [Canvas P3](docs/governed-canvas-p3.fr.md)) ;
-- **Smart Connections** : index sémantique `.smart-env` ;
-- **Operon Developer API V1** et **Optimike Operon Bridge** inclus : tâches live
-  gouvernées via la Developer API officielle V1 ;
-- la compatibilité Kairélys reste disponible comme chemin legacy/rollback
-  borné, mais n’est plus le moteur de production ;
-- **Obsidian Tasks** : parsing et configuration Tasks canoniques.
+- [Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api) pour notes, métadonnées et tags en live ;
+- **Bases Bridge** inclus pour Bases live et le CAS de formules gouvernées ;
+- **Optimike Atomic Write Bridge** inclus pour les cycles Note, Frontmatter et Canvas `plan → apply → status → recover` ;
+- **Smart Connections** pour l’index sémantique local ;
+- **Operon Developer API V1** et **Optimike Operon Bridge** pour les tâches gouvernées ;
+- **Obsidian Tasks** pour le parsing Markdown Tasks-compatible.
 
-L’apply Operon exige deux opt-ins :
+Les mutations Operon exigent le réglage de mutation du Bridge plus :
 
 ```text
-Réglage Optimike Operon Bridge : Allow task mutations
 OPERON_MUTATIONS_ENABLED=true
 ```
 
-Les snapshots Operon obsolètes restent en lecture seule. Les écritures Markdown
-et Canvas ont deux gates atomiques séparés, désactivés par défaut et indépendants d’Operon.
-Le MCP expose une surface agentique gouvernée, pas toutes les fonctions de la
-CLI Operon. Les diagnostics natifs, la recherche/résolution, les relations et
-contextes bornés ainsi que l’état du timer sont disponibles en lecture seule.
-Les relations et la récurrence disposent aussi d’écritures dédiées via des
-plans officiels scellés. Les agents passent par le MCP parce qu’il ajoute des
-schémas bornés, le moindre privilège, le dry-run, le verrouillage de révision,
-l’idempotence durable, la vérification postflight et la récupération du plan
-exact. Un relais CLI générique contournerait ces garanties. Les commandes
-destructives ou d’administration restent dans la CLI. Voir le
-[contrat MCP Operon](docs/operon-mcp-contract.fr.md) et
-l’[audit CLI / Developer API](docs/operon-cli-audit.fr.md).
+Les snapshots Operon obsolètes restent read-only. Aucune route Operon ne retombe sur du Markdown brut ou des API privées. Les versions certifiées/provisoires, la récupération et les gaps d’API sont détaillés dans le [Contrat MCP Operon](docs/operon-mcp-contract.fr.md) et l’[Audit CLI / Developer API](docs/operon-cli-audit.fr.md).
 
-Note de compatibilité : le Bridge `0.7.0` certifie les versions déjà validées
-jusqu’à `3.2.1` ; `3.2.0` reste la baseline certifiée antérieure. Operon `3.3.0` est admis
-en `compatible-provisional` comme version non refusée exposant l’accesseur.
-L’usage live exige aussi `developerApi`, `ok`, `index.ready` et la capacité
-exacte. Son pilote complet est validé sans revenir à une allowlist produit.
-Le settlement des frontmatters de date et le consentement multi-fenêtres
-ont été fusionnés upstream avant ces versions. L’exécution des filtres
-sauvegardés est maintenant disponible via la Developer API task-workflow après
-un grant exact, mais l’API officielle ne publie pas leur catalogue : il faut
-fournir un `filterSetId` exact obtenu dans l’UI/configuration d’Operon ou par un
-workflow opérateur. L’adoption reste indisponible dans l’API officielle. Operon
-omet encore le renderer déclaratif des contrôles de grant Developer API ;
-le correctif est suivi dans [#145](https://github.com/hasanyilmaz/operon/issues/145)
-et [#146](https://github.com/hasanyilmaz/operon/pull/146).
-Le MCP ne bascule jamais vers Markdown ou des API privées. Les renommages
-implicites de File Tasks restent suivis dans
-[#139](https://github.com/hasanyilmaz/operon/pull/139), et le cas particulier des
-transitions sans portée `project-serial` reste suivi dans
-[#99](https://github.com/hasanyilmaz/operon/issues/99) et
-[#101](https://github.com/hasanyilmaz/operon/pull/101).
+## Opérations gouvernées
+
+Les familles Note, Frontmatter, formule Base et Canvas sont exposées atomiquement :
+
+```text
+plan → apply → status → recover
+```
+
+Après timeout ou perte de transport, appeler `status` avant `recover` ; ne jamais recréer aveuglément une mutation. Les plans durables ne sont pas liés au profil qui les a créés.
 
 ## Racines documentaires externes
 
-Les racines externes sont désactivées par défaut. Leurs lectures et handoffs
-ordinaires forment un courtier d’autorisation default-deny, pas un index
-externe, un moteur de synchronisation ou une sauvegarde.
+Les racines externes sont désactivées par défaut. Elles forment un courtier d’autorisation, pas un index, un moteur de synchronisation ou une sauvegarde.
 
-Le même outil `external_handoff` choisit une livraison adaptée au transport :
+`external_handoff` adapte la livraison au transport :
 
 - le stdio local retourne un `local_path` vérifié et temporaire ;
-- le HTTP direct authentifié peut retourner un `http_ticket` opt-in, lié à
-  l’identité et à usage unique ;
-- aucun mode de livraison ne divulgue le chemin source ni n’autorise une
-  mutation.
+- le HTTP direct authentifié peut retourner un `http_ticket` opt-in, lié à l’identité et à usage unique ;
+- aucun mode de livraison n’autorise une mutation ni ne révèle le chemin source physique.
 
-Une seule mutation volontairement étroite existe hors du parcours de handoff :
-le stdio local via `headless-filesystem`, sur un coffre copié ou dédié, peut
-déplacer ou renommer un fichier régulier dans une même racine opt-in et réparer
-les références ÉLYSIA exactes. Elle exige inventaire et plan durable, gates
-d’écriture explicites, préconditions de hash/CAS, journal et rollback
-compensatoire. Elle n’est pas exposée en HTTP direct et n’ajoute ni création,
-ni remplacement, ni suppression, ni upload, ni synchronisation.
+Une transaction séparée en stdio local peut déplacer un fichier régulier dans une même racine configurée et réparer les références ÉLYSIA exactes. Elle exige inventaire, plan durable, gates d’écriture explicites, préconditions hash/CAS, journal et rollback. Elle n’est pas exposée en HTTP direct et n’ajoute pas de create, replace, delete, upload ou sync générique.
 
-Le cœur MCP n’embarque pas de moteur PDF, Office ou OCR. Le client appelant
-assure l’extraction binaire et vérifie taille et SHA-256.
+Le cœur MCP n’embarque pas de moteur PDF, Office ou OCR. Le client appelant assure l’extraction binaire et vérifie taille et SHA-256.
 
-Commencer par
-[Racines externes — configuration et exploitation](docs/external-roots-setup.fr.md).
+Voir [Configuration External Roots](docs/external-roots-setup.fr.md).
 
 ## Recherche sémantique
 
-`smart_semantic_search` est l’outil canonique de recherche sémantique. Les
-profils modernes n’exposent que ce nom. Il interroge un index Smart Connections
-local. L’embedding de requête peut rester local via Ollama ou passer par OpenAI
-selon la configuration. Avec OpenAI, l’outil devient donc open-world même si
-l’index du coffre reste local.
+`smart_semantic_search` est l’outil canonique. Il interroge l’index Smart Connections local. L’embedding de requête peut rester local via Ollama ou utiliser un fournisseur compatible OpenAI.
 
 Voir [Exploitation](OPERATIONS.fr.md) pour les providers et le cache.
 
@@ -223,7 +161,7 @@ Voir [Exploitation](OPERATIONS.fr.md) pour les providers et le cache.
 
 ```bash
 npm run build
-npm run test:runtime && npm run test:governed-note-replace-mcp && npm run test:governed-note-replace-http
+npm run test:runtime
 npm run check:operon
 npm run test:external-roots
 npm run test:docs
@@ -231,27 +169,20 @@ npm run test:package
 npm run audit:production
 ```
 
-Les suites runtime utilisent des coffres jetables et sont couvertes en CI
-Linux/Windows. Pour un test proche de la production, placer la base de cache
-partagée hors du vrai coffre synchronisé.
+Les suites runtime utilisent des coffres jetables et s’exécutent en CI Linux/Windows.
 
 ## Documentation
 
-- Entrée par audience et besoin : [Hub documentaire](docs/README.fr.md)
-- Profils d’exposition et exemples clients : [Profils de surface d’outils](docs/tool-surface-profiles.fr.md)
-- Runtime et maintenance : [OPERATIONS.fr.md](OPERATIONS.fr.md)
-- Sécurité et frontière de déploiement : [SECURITY.fr.md](SECURITY.fr.md)
-- Outils actuels : [Surface des outils](docs/obsidian_mcp_tools_spec.md)
-- Modes runtime : [Matrice des capacités](docs/runtime-capability-matrix.fr.md)
-- Routage agentique : [Guide de routage](docs/mcp-routing-guide.fr.md)
-- Outils Operon et garanties : [Contrat MCP Operon](docs/operon-mcp-contract.fr.md)
-- Surface Operon et routage CLI : [Audit CLI / Developer API](docs/operon-cli-audit.fr.md)
-- Déploiement headless : [Profil serveur headless](docs/headless-server-profile.fr.md)
-- Pilote Linux headless multi-client : [pilote et matrice des capacités](docs/headless-multiclient-pilot.fr.md)
-- Intégration gateway OSS : [Compatibilité gateways](docs/gateway-compatibility.fr.md)
-- Documents externes : [Configuration des racines](docs/external-roots-setup.fr.md)
-- Décisions d’architecture : [Index des ADR](docs/adr/README.md)
-- Profil public Tasks ÉLYSIA : [profiles/elysia-tasks/README.fr.md](profiles/elysia-tasks/README.fr.md)
+- [Hub documentaire](docs/README.fr.md)
+- [Profils de surface d’outils](docs/tool-surface-profiles.fr.md)
+- [Surface des outils](docs/obsidian_mcp_tools_spec.md)
+- [Matrice des capacités runtime](docs/runtime-capability-matrix.fr.md)
+- [Guide de routage](docs/mcp-routing-guide.fr.md)
+- [Contrat MCP Operon](docs/operon-mcp-contract.fr.md)
+- [Configuration External Roots](docs/external-roots-setup.fr.md)
+- [Profil serveur headless](docs/headless-server-profile.fr.md)
+- [Compatibilité gateways](docs/gateway-compatibility.fr.md)
+- [Index des ADR](docs/adr/README.md)
 
 ## Crédits
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -40,11 +40,11 @@ Le runtime répond à ce que le backend peut exécuter. Il ne décide pas combie
 | Besoin | Profil | Taille live/hybrid complète |
 | --- | --- | ---: |
 | Travail général sur le coffre | `standard` | 19 |
-| Notes, tags, Bases et Canvas | `authoring` | 31 |
+| Notes, tags, Bases et Canvas | `authoring` | 30 |
 | Workflows Tasks / Operon | `tasks` | 31 |
 | Compatibilité, admin et surfaces spécialisées | `full` | 72 |
 
-Pendant la branche 2.x, `full` conserve toute la surface de compatibilité. Les profils modernes n’exposent que `smart_semantic_search` ; les alias historiques `smart_search` et `smart-search` restent réservés à `full` jusqu’à la 3.0.
+Pendant la branche 2.x, `full` conserve toute la surface de compatibilité. Les profils modernes n’exposent que `smart_semantic_search` ; les alias historiques `smart_search` et `smart-search` restent réservés à `full` jusqu’à la 3.0. `bases_upsert_config` reste lui aussi une voie de compatibilité whole-Base réservée à `full` ; l’authoring normal utilise la création/écriture de lignes bornée et la famille gouvernée des formules.
 
 Sélectionner le profil avant `tools/list` :
 

--- a/README.fr.md
+++ b/README.fr.md
@@ -162,6 +162,7 @@ Voir [Exploitation](OPERATIONS.fr.md) pour les providers et le cache.
 ```bash
 npm run build
 npm run test:runtime
+npm run test:governed-note-replace-mcp
 npm run check:operon
 npm run test:external-roots
 npm run test:docs

--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ See [Operations](OPERATIONS.md) for providers and cache behavior.
 ```bash
 npm run build
 npm run test:runtime
+npm run test:governed-note-replace-mcp
 npm run check:operon
 npm run test:external-roots
 npm run test:docs

--- a/README.md
+++ b/README.md
@@ -1,68 +1,58 @@
 # Optimike Obsidian MCP
 
 [![Latest release](https://img.shields.io/github/v/release/optimikelabs/optimike-obsidian-mcp?display_name=tag&sort=semver)](https://github.com/optimikelabs/optimike-obsidian-mcp/releases/latest)
-French version: [README.fr.md](README.fr.md) · Documentation hub: [docs/README.md](docs/README.md)
-Operations: [OPERATIONS.md](OPERATIONS.md)
-Security: [SECURITY.md](SECURITY.md)
+
+French version: [README.fr.md](README.fr.md) · [Documentation hub](docs/README.md) · [Operations](OPERATIONS.md) · [Security](SECURITY.md)
 
 ![Overview of Optimike Obsidian MCP between agent clients, Obsidian and governed external documents](docs/assets/readme/overview.en.svg)
 
-Optimike Obsidian MCP gives MCP clients a governed operational surface over an
-Obsidian vault. It combines live Desktop operations, resilient headless modes,
-structured task and Bases support, semantic search, runtime observability, and
-explicitly governed access to configured documents outside the vault.
+Optimike Obsidian MCP gives MCP clients a governed operational surface over an Obsidian vault: live Desktop operations, resilient headless modes, Tasks and Operon, Bases and Canvas, semantic search, runtime observability, and bounded access to configured external documents.
 
 ## Capability map
 
-| Area                    | What the MCP provides                                                                                     | Main dependency                                              |
-| ----------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| Notes                   | Read/search/update plus governed atomic note and source-preserving Frontmatter plans                      | Vault; Local REST API + Atomic Write Bridge for governed CAS |
-| Bases and Canvas        | Bases queries/formula plans plus governed Canvas graph plans and direct headless helpers                  | Bases Bridge; Atomic Write Bridge 0.4.0 for Canvas CAS       |
-| Tasks                   | Obsidian Tasks-compatible list/query plus 23 governed Operon tools                                        | Operon Developer API V1 through the Bridge                   |
-| Semantic search         | Smart Connections index search with durable metadata cache                                                | `.smart-env` plus Ollama or OpenAI query embedding           |
-| Runtime                 | Shared SQLite cache, health, maintenance, degraded mode and exclusions                                    | Local filesystem                                             |
-| External documents      | Governed reads/handoff plus opt-in local move with exact link repair                                      | Allowlist; local stdio for move                              |
-| Headless administration | Guarded note, metadata and vault-filesystem operations                                                    | Guarded/filesystem mode on a copied vault                    |
+| Area | What the MCP provides | Main dependency |
+| --- | --- | --- |
+| Notes | Read/search/direct edits plus governed note and Frontmatter operations | Vault; Local REST API + Atomic Write Bridge |
+| Bases and Canvas | Queries, bounded writes, governed formulas and Canvas graph plans | Bases Bridge; Atomic Write Bridge |
+| Tasks | Tasks-compatible Markdown plus 23 governed Operon tools | Operon Developer API V1 through the Bridge |
+| Semantic search | Smart Connections index search | `.smart-env` + Ollama or OpenAI-compatible query embedding |
+| Runtime | Shared SQLite cache, health, maintenance and degraded modes | Local filesystem |
+| External documents | Default-deny reads/handoff plus opt-in local move | Explicit root allowlist |
+| Headless administration | Guarded metadata and filesystem operations | Copied or dedicated vault |
 
-The current tool registry is documented in
-[Tool Surface](docs/obsidian_mcp_tools_spec.md). Availability varies by runtime
-mode and by tool profile; use the [Runtime Capability Matrix](docs/runtime-capability-matrix.md)
-and [Tool Surface Profiles](docs/tool-surface-profiles.md) before enabling writes.
+The canonical tool registry is documented in [Tool Surface](docs/obsidian_mcp_tools_spec.md).
 
-## Choose a runtime and transport
+## Runtime and transport
 
-| Need                                       | Recommended runtime / transport                            | Posture                 |
-| ------------------------------------------ | ---------------------------------------------------------- | ----------------------- |
-| Local stdio agent                          | `dist/stdio-proxy.js`                                      | Per-client proxy        |
-| Obsidian Desktop automation                | `live` or `hybrid` through the stdio proxy                 | Trusted Desktop         |
-| CI, server or synchronized vault copy      | `headless-readonly`                                        | Safest headless mode    |
-| Bounded writes on a copied/dedicated vault | `headless-guarded` then `headless-filesystem`              | Explicit opt-in         |
-| Direct HTTP on the same machine            | Authenticated loopback HTTP                                | Supported with limits   |
-| Remote HTTP                                | Reviewed TLS reverse proxy and private network controls    | Pilot only              |
+| Need | Recommended runtime / transport |
+| --- | --- |
+| Local agent | stdio proxy |
+| Obsidian Desktop automation | `live` or `hybrid` |
+| CI/server/synchronized copy | `headless-readonly` |
+| Bounded writes on copied/dedicated vault | `headless-guarded`, then `headless-filesystem` |
+| Same-machine HTTP | authenticated loopback HTTP |
+| Remote HTTP | reviewed TLS reverse proxy + private network; pilot only |
 
-Runtime answers what the backend can safely do. It does not decide how many
-tools an agent should see.
+Runtime answers what the backend can execute. It does not decide how many tools the model should see.
 
-## Choose a tool surface
+## Tool surface profiles
 
-| Need | Recommended tool profile | Full live/hybrid size |
+| Need | Profile | Full live/hybrid size |
 | --- | --- | ---: |
-| General vault work | `standard` | 19 tools |
-| Notes + tags + Bases/Canvas authoring | `authoring` | 31 tools |
-| Tasks / Operon workflows | `tasks` | 31 tools |
-| Compatibility, admin and specialized surfaces | `full` | 72 tools |
+| General vault work | `standard` | 19 |
+| Notes, tags, Bases and Canvas authoring | `authoring` | 31 |
+| Tasks / Operon workflows | `tasks` | 31 |
+| Compatibility, admin and specialized surfaces | `full` | 72 |
 
-Modern profiles expose only `smart_semantic_search` for semantic search.
-Historical compatibility aliases remain available only in `full` during the 2.x
-line and are planned for physical removal in 3.0.
+During the 2.x line, `full` preserves the complete compatibility surface. Modern profiles expose only `smart_semantic_search`; the legacy aliases `smart_search` and `smart-search` remain `full`-only until 3.0.
 
-For stdio, select a profile before `tools/list`:
+Select the profile before `tools/list`:
 
 ```bash
 node dist/stdio-proxy.js --tool-profile standard
 ```
 
-For HTTP, select it in the MCP URL:
+HTTP profile routes:
 
 ```text
 /mcp/standard
@@ -71,20 +61,14 @@ For HTTP, select it in the MCP URL:
 /mcp/full
 ```
 
-Legacy `/mcp` remains equivalent to `/mcp/full` during 2.x. See
-[Tool Surface Profiles](docs/tool-surface-profiles.md) for session binding,
-client examples and compatibility rules.
+Legacy `/mcp` remains equivalent to `/mcp/full` during 2.x. See [Tool Surface Profiles](docs/tool-surface-profiles.md).
 
-The Node server must never be exposed directly to the public internet. See
-[Security](SECURITY.md) and the
-[HTTP delivery ADR](docs/adr/ADR-HTTP-External-Artifact-Delivery.md).
-
-## Quick start from source
+## Quick start
 
 Requirements:
 
 - Node.js `>=22.7.5`;
-- Obsidian Desktop only when using live Desktop features;
+- Obsidian Desktop only for live features;
 - capability-specific plugins listed below.
 
 ```bash
@@ -95,9 +79,12 @@ npm run build
 node dist/stdio-proxy.js --tool-profile standard
 ```
 
-For a package install, the explicit proxy binary is
-`optimike-obsidian-mcp-proxy`. The legacy
-`optimike-obsidian-mcp` binary still starts the backend directly.
+Package binaries:
+
+```text
+optimike-obsidian-mcp
+optimike-obsidian-mcp-proxy
+```
 
 Minimal Codex configuration:
 
@@ -117,111 +104,64 @@ OBSIDIAN_BASE_URL = "http://127.0.0.1:27123"
 OBSIDIAN_API_KEY = "<local-rest-api-key>"
 ```
 
-Keep real paths, API keys and external-root configurations outside the
-repository and outside distributable vault content.
+Keep real paths, API keys, journals and external-root configuration outside the repository and distributable vault content.
 
 ## Optional Obsidian integrations
 
 Enable only the surfaces you use:
 
-- [Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api):
-  live note, metadata and tag operations;
-- bundled **Bases Bridge (REST)**: live `.base` queries plus opt-in typed CAS for governed source-preserving formula `plan → apply → status → recover`; legacy whole-file config writes are default-off compatibility paths ([P2 contract](docs/governed-base-formula-p2.md));
-- bundled **Optimike Atomic Write Bridge**: independent default-off SHA-256 CAS gates for Markdown and JSON Canvas, backing governed note, Frontmatter and Canvas `plan → apply → status → recover`; Bridge 0.3.0 added bounded date-property protection/settlement and 0.4.0 adds typed Canvas read/CAS with graph validation; opaque `planRef`, lost response → `status`, exact-plan recovery ≠ undo ([note contract](docs/governed-note-replacement.md), [P1 contract](docs/governed-frontmatter-p1.md), [Canvas P3 contract](docs/governed-canvas-p3.md));
-- **Smart Connections**: semantic index under `.smart-env`;
-- **Operon Developer API V1** and the bundled **Optimike Operon Bridge**: governed live
-  task operations through the official Developer API V1;
-- Kairélys compatibility remains available as a bounded legacy/rollback path,
-  not as the production owner;
-- **Obsidian Tasks**: canonical Tasks parsing and configuration.
+- [Local REST API](https://github.com/coddingtonbear/obsidian-local-rest-api) for live note, metadata and tag operations;
+- bundled **Bases Bridge** for live Bases and governed formula CAS;
+- bundled **Optimike Atomic Write Bridge** for governed Note, Frontmatter and Canvas `plan → apply → status → recover`;
+- **Smart Connections** for the local semantic index;
+- **Operon Developer API V1** and bundled **Optimike Operon Bridge** for governed task operations;
+- **Obsidian Tasks** for Tasks-compatible Markdown parsing.
 
-Operon apply requires two explicit opt-ins:
+Operon mutations require the Bridge mutation setting plus:
 
 ```text
-Optimike Operon Bridge setting: Allow task mutations
 OPERON_MUTATIONS_ENABLED=true
 ```
 
-Stale Operon snapshots remain read-only. Atomic Markdown and Canvas writes have separate default-off bridge settings and do not require Operon's Developer API grant.
+Stale Operon snapshots remain read-only. No Operon route falls back to raw Markdown or private APIs. Full compatibility, certified/provisional versions, recovery semantics and current API gaps live in the [Operon MCP contract](docs/operon-mcp-contract.md) and [CLI / Developer API audit](docs/operon-cli-audit.md).
 
-The MCP exposes a curated agent surface rather than every Operon CLI function.
-Native diagnostics, finder/resolve, bounded relationships/context and timer
-state are available as read-only tools. Dedicated relationship and recurrence
-writes use official sealed preview/apply plans; destructive and operator
-commands stay in the CLI. Agents use MCP because it adds bounded schemas,
-least-privilege capability checks, dry-run, revision locking, durable
-idempotency, postflight verification and exact-plan recovery. A generic CLI
-passthrough would bypass those guarantees. See the
-[Operon MCP contract](docs/operon-mcp-contract.md) and
-[Operon CLI / Developer API audit](docs/operon-cli-audit.md).
-Transition apply is available through the Bridge. Elevated or destructive plans
-still require fresh confirmation in the owning Obsidian vault window and fail
-closed after 45 seconds when no confirmation can be presented.
+## Governed operations
 
-Compatibility note: the adapter negotiates Operon Developer API V1 with
-`contractVersion: 1` and `runtimeApi: 1`. Versions in the explicit certified
-set report `certified`; unknown non-denied versions exposing the accessor report
-`compatible-provisional`. Live use still requires `developerApi`, `ok`,
-`index.ready`, and the exact capability. Missing capabilities fail closed only
-for affected tools; known regressions remain denied.
-Operon `3.2.0` remains the earlier certified pilot baseline. Modified-time frontmatter settlement and
-multi-window consent were merged upstream before the current release. Saved-filter execution is available
-through the additive task-workflow Developer API after an exact grant, but the
-official API does not expose the saved-filter catalog: callers must supply an
-exact `filterSetId` obtained from Operon's UI/configuration or an operator
-workflow. Adoption remains unavailable on the official Developer API. Operon
-`3.3.2` with Operon CLI `1.1.2` is the current complete live-pilot baseline and
-remains admitted as `compatible-provisional` by the contract-first policy
-rather than a product-version allowlist. Operon `3.3.2` restores the Developer
-API Settings controls, rejects implicit File Task renames, and fixes unscoped
-Project Serial transition settlement. The production acceptance proved a
-non-terminal transition and exact restoration with 30 tasks, no pending
-recovery, and `P0/P1/P2 = 0/0/0`. Adoption is the only tracked official API gap
-([Operon #140](https://github.com/hasanyilmaz/operon/issues/140)). No MCP route
-falls back to Markdown or private APIs.
+Governed Note, Frontmatter, Base formula and Canvas families are exposed atomically:
+
+```text
+plan → apply → status → recover
+```
+
+After timeout or transport loss, call `status` before `recover`; never create a blind replacement mutation. Durable plans are not bound to the profile that created them.
 
 ## External document roots
 
-External roots are disabled by default. Their ordinary reads and handoffs form
-a default-deny authorization broker, not an external index, sync engine or
-backup system.
+External roots are disabled by default. They are an authorization broker, not an index, sync engine or backup system.
 
-The same `external_handoff` tool selects a transport-aware delivery:
+`external_handoff` is transport-aware:
 
 - local stdio returns a verified short-lived `local_path`;
-- authenticated direct HTTP may return an opt-in, identity-bound, single-use
-  `http_ticket`;
-- neither delivery mode discloses the physical source path or authorizes a
-  mutation.
+- authenticated direct HTTP may return an opt-in, identity-bound, single-use `http_ticket`;
+- neither delivery mode authorizes mutation or reveals the physical source path.
 
-One deliberately narrow mutation exists outside the handoff path: local stdio
-through `headless-filesystem` on a copied or dedicated vault can move or rename
-one regular file within the same opted-in root and repair exact ÉLYSIA
-references. It requires an inventory and durable plan, explicit write gates,
-hash/CAS preconditions, a journal and compensating rollback. It is not exposed
-over direct HTTP and does not add create, replace, delete, upload or sync.
+A separate local-stdio transaction can move one regular file within the same configured root and repair exact ÉLYSIA references. It requires inventory, a durable plan, explicit write gates, hash/CAS preconditions, journaling and rollback. It is not exposed over direct HTTP and does not add generic create, replace, delete, upload or sync.
 
-The MCP core does not embed PDF, Office or OCR engines. The calling client owns
-binary extraction and must verify size and SHA-256.
+The MCP core does not embed PDF, Office or OCR engines. The caller owns binary extraction and verifies size and SHA-256.
 
-Start with
-[External document roots — setup and operations](docs/external-roots-setup.md).
+See [External Roots Setup](docs/external-roots-setup.md).
 
 ## Semantic search
 
-`smart_semantic_search` is the canonical semantic-search tool. Modern profiles
-expose only that name. It searches a local Smart Connections index. Query
-embedding can remain local through Ollama or use OpenAI, depending on operator
-configuration. A configured OpenAI provider therefore makes this tool
-open-world even though the indexed vault data remains local.
+`smart_semantic_search` is the canonical semantic-search tool. It searches the local Smart Connections index. Query embedding can remain local through Ollama or use an OpenAI-compatible provider.
 
-See [Operations](OPERATIONS.md) for provider configuration and cache behavior.
+See [Operations](OPERATIONS.md) for providers and cache behavior.
 
 ## Verification
 
 ```bash
 npm run build
-npm run test:runtime && npm run test:governed-note-replace-mcp && npm run test:governed-note-replace-http
+npm run test:runtime
 npm run check:operon
 npm run test:external-roots
 npm run test:docs
@@ -229,27 +169,20 @@ npm run test:package
 npm run audit:production
 ```
 
-The runtime suites use disposable vaults and include Linux/Windows CI coverage.
-For production-like validation, keep the shared cache database outside the real
-synced vault.
+Runtime suites use disposable vaults and run in Linux/Windows CI.
 
 ## Documentation
 
-- Start here by audience and task: [Documentation hub](docs/README.md)
-- Tool exposure profiles and client examples: [Tool Surface Profiles](docs/tool-surface-profiles.md)
-- Runtime and maintenance: [OPERATIONS.md](OPERATIONS.md)
-- Security and deployment boundary: [SECURITY.md](SECURITY.md)
-- Current tools: [Tool Surface](docs/obsidian_mcp_tools_spec.md)
-- Runtime modes: [Runtime Capability Matrix](docs/runtime-capability-matrix.md)
-- Agent routing: [MCP Routing Guide](docs/mcp-routing-guide.md)
-- Operon tools and guarantees: [Operon MCP Contract](docs/operon-mcp-contract.md)
-- Operon surface and CLI routing: [Operon CLI / Developer API audit](docs/operon-cli-audit.md)
-- Headless deployment: [Headless Server Profile](docs/headless-server-profile.md)
-- Linux headless multi-client pilot: [Pilot and capability matrix](docs/headless-multiclient-pilot.md)
-- OSS gateway integration: [Gateway Compatibility](docs/gateway-compatibility.md)
-- External documents: [External Roots Setup](docs/external-roots-setup.md)
-- Architecture decisions and status: [ADR Index](docs/adr/README.md)
-- Public ÉLYSIA task profile: [profiles/elysia-tasks/README.fr.md](profiles/elysia-tasks/README.fr.md)
+- [Documentation hub](docs/README.md)
+- [Tool Surface Profiles](docs/tool-surface-profiles.md)
+- [Tool Surface](docs/obsidian_mcp_tools_spec.md)
+- [Runtime Capability Matrix](docs/runtime-capability-matrix.md)
+- [MCP Routing Guide](docs/mcp-routing-guide.md)
+- [Operon MCP Contract](docs/operon-mcp-contract.md)
+- [External Roots Setup](docs/external-roots-setup.md)
+- [Headless Server Profile](docs/headless-server-profile.md)
+- [Gateway Compatibility](docs/gateway-compatibility.md)
+- [ADR Index](docs/adr/README.md)
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Runtime answers what the backend can execute. It does not decide how many tools 
 | Tasks / Operon workflows | `tasks` | 31 |
 | Compatibility, admin and specialized surfaces | `full` | 72 |
 
-During the 2.x line, `full` preserves the complete compatibility surface. Modern profiles expose only `smart_semantic_search`; the legacy aliases `smart_search` and `smart-search` remain `full`-only until 3.0. `bases_upsert_config` is likewise a `full`-only whole-Base compatibility path; normal authoring uses bounded Base creation/row writes plus the governed formula family.
+During the 2.x line, `full` preserves the complete compatibility surface. Modern profiles expose only `smart_semantic_search`; the legacy aliases `smart_search` and `smart-search` remain `full`-only until 3.0. `bases_upsert_config` is likewise a `full`-only whole-Base compatibility path; legacy whole-file config writes are default-off, while normal authoring uses bounded Base creation/row writes plus the governed formula family.
 
 Select the profile before `tools/list`:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ explicitly governed access to configured documents outside the vault.
 | Area                    | What the MCP provides                                                                                     | Main dependency                                              |
 | ----------------------- | --------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
 | Notes                   | Read/search/update plus governed atomic note and source-preserving Frontmatter plans                      | Vault; Local REST API + Atomic Write Bridge for governed CAS |
-| Bases and Canvas        | Bases queries/formula plans plus governed Canvas graph plans and direct headless helpers                  | Bases Bridge; Atomic Write Bridge 0.4.0 for Canvas CAS        |
+| Bases and Canvas        | Bases queries/formula plans plus governed Canvas graph plans and direct headless helpers                  | Bases Bridge; Atomic Write Bridge 0.4.0 for Canvas CAS       |
 | Tasks                   | Obsidian Tasks-compatible list/query plus 23 governed Operon tools                                        | Operon Developer API V1 through the Bridge                   |
 | Semantic search         | Smart Connections index search with durable metadata cache                                                | `.smart-env` plus Ollama or OpenAI query embedding           |
 | Runtime                 | Shared SQLite cache, health, maintenance, degraded mode and exclusions                                    | Local filesystem                                             |
@@ -26,19 +26,54 @@ explicitly governed access to configured documents outside the vault.
 
 The current tool registry is documented in
 [Tool Surface](docs/obsidian_mcp_tools_spec.md). Availability varies by runtime
-mode; use the [Runtime Capability Matrix](docs/runtime-capability-matrix.md)
-before enabling writes.
+mode and by tool profile; use the [Runtime Capability Matrix](docs/runtime-capability-matrix.md)
+and [Tool Surface Profiles](docs/tool-surface-profiles.md) before enabling writes.
 
-## Choose a profile
+## Choose a runtime and transport
 
-| Need                                       | Recommended profile                                     | Posture                 |
-| ------------------------------------------ | ------------------------------------------------------- | ----------------------- |
-| Codex (verified) or a local stdio client   | `dist/stdio-proxy.js`                                   | Default local profile   |
-| Obsidian Desktop automation                | `live` or `hybrid` through the stdio proxy              | Trusted Desktop         |
-| CI, server or synchronized vault copy      | `headless-readonly`                                     | Safest headless profile |
-| Bounded writes on a copied/dedicated vault | `headless-guarded` then `headless-filesystem`           | Explicit opt-in         |
-| Direct HTTP on the same machine            | Authenticated loopback HTTP                             | Supported with limits   |
-| Remote HTTP                                | Reviewed TLS reverse proxy and private network controls | Pilot only              |
+| Need                                       | Recommended runtime / transport                            | Posture                 |
+| ------------------------------------------ | ---------------------------------------------------------- | ----------------------- |
+| Local stdio agent                          | `dist/stdio-proxy.js`                                      | Per-client proxy        |
+| Obsidian Desktop automation                | `live` or `hybrid` through the stdio proxy                 | Trusted Desktop         |
+| CI, server or synchronized vault copy      | `headless-readonly`                                        | Safest headless mode    |
+| Bounded writes on a copied/dedicated vault | `headless-guarded` then `headless-filesystem`              | Explicit opt-in         |
+| Direct HTTP on the same machine            | Authenticated loopback HTTP                                | Supported with limits   |
+| Remote HTTP                                | Reviewed TLS reverse proxy and private network controls    | Pilot only              |
+
+Runtime answers what the backend can safely do. It does not decide how many
+tools an agent should see.
+
+## Choose a tool surface
+
+| Need | Recommended tool profile | Full live/hybrid size |
+| --- | --- | ---: |
+| General vault work | `standard` | 19 tools |
+| Notes + tags + Bases/Canvas authoring | `authoring` | 31 tools |
+| Tasks / Operon workflows | `tasks` | 31 tools |
+| Compatibility, admin and specialized surfaces | `full` | 72 tools |
+
+Modern profiles expose only `smart_semantic_search` for semantic search.
+Historical compatibility aliases remain available only in `full` during the 2.x
+line and are planned for physical removal in 3.0.
+
+For stdio, select a profile before `tools/list`:
+
+```bash
+node dist/stdio-proxy.js --tool-profile standard
+```
+
+For HTTP, select it in the MCP URL:
+
+```text
+/mcp/standard
+/mcp/authoring
+/mcp/tasks
+/mcp/full
+```
+
+Legacy `/mcp` remains equivalent to `/mcp/full` during 2.x. See
+[Tool Surface Profiles](docs/tool-surface-profiles.md) for session binding,
+client examples and compatibility rules.
 
 The Node server must never be exposed directly to the public internet. See
 [Security](SECURITY.md) and the
@@ -57,7 +92,7 @@ git clone https://github.com/optimikelabs/optimike-obsidian-mcp.git
 cd optimike-obsidian-mcp
 npm install
 npm run build
-node dist/stdio-proxy.js
+node dist/stdio-proxy.js --tool-profile standard
 ```
 
 For a package install, the explicit proxy binary is
@@ -69,7 +104,11 @@ Minimal Codex configuration:
 ```toml
 [mcp_servers.optimike-obsidian-mcp-stdio]
 command = "node"
-args = ["/path/to/optimike-obsidian-mcp/dist/stdio-proxy.js"]
+args = [
+  "/path/to/optimike-obsidian-mcp/dist/stdio-proxy.js",
+  "--tool-profile",
+  "standard"
+]
 
 [mcp_servers.optimike-obsidian-mcp-stdio.env]
 OBSIDIAN_VAULT = "/path/to/vault"
@@ -170,7 +209,8 @@ Start with
 
 ## Semantic search
 
-`smart_semantic_search` searches a local Smart Connections index. Query
+`smart_semantic_search` is the canonical semantic-search tool. Modern profiles
+expose only that name. It searches a local Smart Connections index. Query
 embedding can remain local through Ollama or use OpenAI, depending on operator
 configuration. A configured OpenAI provider therefore makes this tool
 open-world even though the indexed vault data remains local.
@@ -196,6 +236,7 @@ synced vault.
 ## Documentation
 
 - Start here by audience and task: [Documentation hub](docs/README.md)
+- Tool exposure profiles and client examples: [Tool Surface Profiles](docs/tool-surface-profiles.md)
 - Runtime and maintenance: [OPERATIONS.md](OPERATIONS.md)
 - Security and deployment boundary: [SECURITY.md](SECURITY.md)
 - Current tools: [Tool Surface](docs/obsidian_mcp_tools_spec.md)

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ Runtime answers what the backend can execute. It does not decide how many tools 
 | Need | Profile | Full live/hybrid size |
 | --- | --- | ---: |
 | General vault work | `standard` | 19 |
-| Notes, tags, Bases and Canvas authoring | `authoring` | 31 |
+| Notes, tags, Bases and Canvas authoring | `authoring` | 30 |
 | Tasks / Operon workflows | `tasks` | 31 |
 | Compatibility, admin and specialized surfaces | `full` | 72 |
 
-During the 2.x line, `full` preserves the complete compatibility surface. Modern profiles expose only `smart_semantic_search`; the legacy aliases `smart_search` and `smart-search` remain `full`-only until 3.0.
+During the 2.x line, `full` preserves the complete compatibility surface. Modern profiles expose only `smart_semantic_search`; the legacy aliases `smart_search` and `smart-search` remain `full`-only until 3.0. `bases_upsert_config` is likewise a `full`-only whole-Base compatibility path; normal authoring uses bounded Base creation/row writes plus the governed formula family.
 
 Select the profile before `tools/list`:
 

--- a/docs/README.fr.md
+++ b/docs/README.fr.md
@@ -11,11 +11,11 @@ question.
 
 | Je suis…                        | Commencer ici                                             | Puis utiliser                                                                                                                                           |
 | ------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Nouvel utilisateur local        | [Présentation](../README.fr.md)                           | [Exploitation](../OPERATIONS.fr.md)                                                                                                                     |
-| Opérateur Codex ou agent local  | [Exploitation](../OPERATIONS.fr.md)                       | [Routage agentique](mcp-routing-guide.fr.md)                                                                                                            |
-| Opérateur headless/serveur      | [Profil serveur headless](headless-server-profile.fr.md)  | [Matrice runtime](runtime-capability-matrix.fr.md), [Sécurité](../SECURITY.fr.md)                                                                       |
+| Nouvel utilisateur local        | [Présentation](../README.fr.md)                           | [Profils d’outils](tool-surface-profiles.fr.md), [Exploitation](../OPERATIONS.fr.md)                                                                    |
+| Opérateur Codex ou agent local  | [Profils d’outils](tool-surface-profiles.fr.md)           | [Exploitation](../OPERATIONS.fr.md), [Routage agentique](mcp-routing-guide.fr.md)                                                                       |
+| Opérateur headless/serveur      | [Profil serveur headless](headless-server-profile.fr.md)  | [Matrice runtime](runtime-capability-matrix.fr.md), [Profils d’outils](tool-surface-profiles.fr.md), [Sécurité](../SECURITY.fr.md)                       |
 | Intégrateur d’une gateway       | [Compatibilité gateways OSS](gateway-compatibility.fr.md) | [Sécurité HTTP](http-multiclient-security.fr.md), [Backpressure](http-concurrency-backpressure.fr.md)                                                   |
-| Intégrateur d’un client MCP     | [Surface des outils](obsidian_mcp_tools_spec.md)          | [Contrat Operon](operon-mcp-contract.fr.md), [Matrice runtime](runtime-capability-matrix.fr.md)                                                         |
+| Intégrateur d’un client MCP     | [Profils d’outils](tool-surface-profiles.fr.md)           | [Surface des outils](obsidian_mcp_tools_spec.md), [Matrice runtime](runtime-capability-matrix.fr.md)                                                    |
 | Opérateur de documents externes | [Configuration des racines](external-roots-setup.fr.md)   | [ADR racines externes](adr/ADR-External-Document-Roots.md), [ADR intégrité des références](adr/ADR-External-Reference-Integrity.fr.md)                  |
 | Opérateur Tasks/Operon          | [Contrat MCP Operon](operon-mcp-contract.fr.md)           | [Audit CLI/API](operon-cli-audit.fr.md), [Validation locale](operon-local-validation.md), [profil public ÉLYSIA](../profiles/elysia-tasks/README.fr.md) |
 | Contributeur ou relecteur       | [Décisions d’architecture](adr/README.md)                 | [Arbre du dépôt](tree.md), README des plugins                                                                                                           |
@@ -24,18 +24,19 @@ question.
 
 | Question                                                                      | Autorité                                                                                |
 | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| Quel profil serveur d’outils faut-il exposer à un client ?                    | [Profils de surface d’outils](tool-surface-profiles.fr.md)                              |
 | Quels outils existent ?                                                       | [Surface des outils](obsidian_mcp_tools_spec.md)                                        |
 | Quels outils sont disponibles dans chaque runtime ?                           | [Matrice des capacités](runtime-capability-matrix.fr.md)                                |
 | Comment lancer et maintenir le service ?                                      | [Exploitation](../OPERATIONS.fr.md)                                                     |
-| Quelle surface un agent doit-il utiliser ?                                    | [Guide de routage](mcp-routing-guide.fr.md)                                             |
+| Quel outil un agent doit-il choisir dans son profil ?                         | [Guide de routage](mcp-routing-guide.fr.md)                                             |
 | Comment fonctionner sans Obsidian Desktop ?                                   | [Profil serveur headless](headless-server-profile.fr.md)                                |
 | Comment fonctionnent lecture, handoff, move et réparation de liens externes ? | [Configuration des racines](external-roots-setup.fr.md)                                 |
 | Quelle frontière de sécurité HTTP est supportée ?                             | [Sécurité](../SECURITY.fr.md) et [ADR HTTP](adr/ADR-HTTP-External-Artifact-Delivery.md) |
 | Quel profil de gateway OSS a été prouvé de bout en bout ?                     | [Compatibilité gateways OSS](gateway-compatibility.fr.md)                               |
 | Comment les lectures et mutations Operon sont-elles gouvernées ?              | [Contrat MCP Operon](operon-mcp-contract.fr.md)                                         |
 | Comment fonctionne le remplacement atomique gouverné ?                        | [Contrat de remplacement gouverné](governed-note-replacement.fr.md)                     |
-| Comment muter sûrement les formules nommées d’une Base Obsidian ?              | [Formules Base gouvernées P2](governed-base-formula-p2.fr.md)                           |
-| Comment muter sûrement le graphe d'un JSON Canvas existant ?                   | [Canvas gouverné P3](governed-canvas-p3.fr.md)                                          |
+| Comment muter sûrement les formules nommées d’une Base Obsidian ?             | [Formules Base gouvernées P2](governed-base-formula-p2.fr.md)                           |
+| Comment muter sûrement le graphe d’un JSON Canvas existant ?                  | [Canvas gouverné P3](governed-canvas-p3.fr.md)                                          |
 | Pourquoi le MCP expose-t-il des fonctions Operon au lieu d’appeler la CLI ?   | [Audit CLI / Developer API](operon-cli-audit.fr.md)                                     |
 | Pourquoi une décision d’architecture a-t-elle été prise ?                     | [Index des ADR](adr/README.md)                                                          |
 | Qu’est-ce qui a changé ?                                                      | [Changelog](../CHANGELOG.md)                                                            |
@@ -57,11 +58,12 @@ Formules Base gouvernées source-preserving : [contrat P2](governed-base-formula
 - contrat Operon gouverné : [Contrat MCP Operon](operon-mcp-contract.fr.md) ;
 - frontière MCP et CLI : [Audit CLI / Developer API](operon-cli-audit.fr.md) ;
 - bridge Operon inclus : [README Operon Bridge](../plugins/obsidian-operon-bridge/README.md) ;
-- bridge Bases inclus : [README Bases Bridge](../plugins/obsidian-bases-bridge/README.md).
+- bridge Bases inclus : [README Bases Bridge](../plugins/obsidian-bases-bridge/README.md) ;
 - remplacement atomique gouverné : [contrat](governed-note-replacement.fr.md) et [README Atomic Write Bridge](../plugins/obsidian-atomic-write-bridge/README.md).
 
 ### Recherche et runtime
 
+- profils publics d’exposition : [Profils de surface d’outils](tool-surface-profiles.fr.md) ;
 - recherche sémantique et providers : [Exploitation](../OPERATIONS.fr.md) ;
 - modes runtime : [Matrice des capacités](runtime-capability-matrix.fr.md) ;
 - cache, santé et maintenance : [Exploitation](../OPERATIONS.fr.md).
@@ -69,17 +71,19 @@ Formules Base gouvernées source-preserving : [contrat P2](governed-base-formula
 ### Documents externes
 
 - configuration et parcours clients : [Configuration des racines](external-roots-setup.fr.md) ;
-- routage agentique : [Guide de routage](mcp-routing-guide.fr.md#routage-des-documents-externes) ;
+- routage agentique : [Guide de routage](mcp-routing-guide.fr.md#routage-documentaire-externe) ;
 - frontière de livraison HTTP : [ADR HTTP](adr/ADR-HTTP-External-Artifact-Delivery.md) ;
 - move local, réparation exacte des liens et rollback :
   [ADR intégrité des références](adr/ADR-External-Reference-Integrity.fr.md).
 
 ## Propriété documentaire
 
-- Les README présentent le produit, les profils et le premier démarrage réussi.
+- Les README présentent le produit et le premier démarrage réussi.
+- Les Profils de surface d’outils portent `standard`, `authoring`, `tasks`, `full`, leur sélection et la sémantique d’exposition client.
 - Les guides d’exploitation portent le runtime local et le dépannage.
 - La surface des outils porte les noms et la sémantique des outils.
-- La matrice runtime porte leur disponibilité par mode.
+- La matrice runtime porte la disponibilité backend par mode.
+- Le guide de routage porte la priorité canonique entre outils qui se chevauchent.
 - Les guides de configuration portent les exemples.
 - Les ADR portent décisions, statuts, frontières et options rejetées.
 - Le changelog porte les versions et changements non publiés.

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,11 +11,11 @@ French operator guides are linked alongside their English equivalents.
 
 | I am…                           | Start here                                            | Then use                                                                                                                                             |
 | ------------------------------- | ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
-| A new local user                | [Product overview](../README.md)                      | [Operations](../OPERATIONS.md)                                                                                                                       |
-| A Codex or local-agent operator | [Operations](../OPERATIONS.md)                        | [Agent routing](mcp-routing-guide.md)                                                                                                                |
-| A headless/server operator      | [Headless Server Profile](headless-server-profile.md) | [Runtime Matrix](runtime-capability-matrix.md), [Security](../SECURITY.md)                                                                           |
+| A new local user                | [Product overview](../README.md)                      | [Tool Surface Profiles](tool-surface-profiles.md), [Operations](../OPERATIONS.md)                                                                    |
+| A Codex or local-agent operator | [Tool Surface Profiles](tool-surface-profiles.md)     | [Operations](../OPERATIONS.md), [Agent routing](mcp-routing-guide.md)                                                                                 |
+| A headless/server operator      | [Headless Server Profile](headless-server-profile.md) | [Runtime Matrix](runtime-capability-matrix.md), [Tool Surface Profiles](tool-surface-profiles.md), [Security](../SECURITY.md)                          |
 | A gateway integrator            | [OSS Gateway Compatibility](gateway-compatibility.md) | [HTTP Security](http-multiclient-security.md), [Backpressure](http-concurrency-backpressure.md)                                                      |
-| An MCP client integrator        | [Tool Surface](obsidian_mcp_tools_spec.md)            | [Runtime Matrix](runtime-capability-matrix.md)                                                                                                       |
+| An MCP client integrator        | [Tool Surface Profiles](tool-surface-profiles.md)     | [Tool Surface](obsidian_mcp_tools_spec.md), [Runtime Matrix](runtime-capability-matrix.md)                                                            |
 | An external-document operator   | [External Roots Setup](external-roots-setup.md)       | [External Roots ADR](adr/ADR-External-Document-Roots.md), [Reference Integrity ADR](adr/ADR-External-Reference-Integrity.md)                         |
 | A Tasks/Operon operator         | [Operon MCP Contract](operon-mcp-contract.md)         | [CLI/API audit](operon-cli-audit.md), [Local Validation](operon-local-validation.md), [public ÉLYSIA profile](../profiles/elysia-tasks/README.fr.md) |
 | A contributor or reviewer       | [Architecture decisions](adr/README.md)               | [Repository tree](tree.md), plugin READMEs                                                                                                           |
@@ -24,10 +24,11 @@ French operator guides are linked alongside their English equivalents.
 
 | Question                                                         | Authority                                                                             |
 | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------- |
+| Which server tool profile should a client expose?                | [Tool Surface Profiles](tool-surface-profiles.md)                                     |
 | Which tools exist?                                               | [Tool Surface](obsidian_mcp_tools_spec.md)                                            |
 | Which tools are available in each runtime?                       | [Runtime Capability Matrix](runtime-capability-matrix.md)                             |
 | How do I run and maintain the service?                           | [Operations](../OPERATIONS.md)                                                        |
-| Which surface should an agent use?                               | [MCP Routing Guide](mcp-routing-guide.md)                                             |
+| Which tool should an agent choose inside its profile?            | [MCP Routing Guide](mcp-routing-guide.md)                                             |
 | How do I run without Obsidian Desktop?                           | [Headless Server Profile](headless-server-profile.md)                                 |
 | How do external reads, handoff, move and link repair work?       | [External Roots Setup](external-roots-setup.md)                                       |
 | What is the supported HTTP security boundary?                    | [Security](../SECURITY.md) and [HTTP ADR](adr/ADR-HTTP-External-Artifact-Delivery.md) |
@@ -62,6 +63,7 @@ Governed source-preserving Base formulas: [P2 contract](governed-base-formula-p2
 
 ### Search and runtime
 
+- public exposure profiles: [Tool Surface Profiles](tool-surface-profiles.md);
 - semantic search and providers: [Operations](../OPERATIONS.md#semantic-search-what-is-persisted-and-what-is-not);
 - runtime modes: [Runtime Capability Matrix](runtime-capability-matrix.md);
 - cache, health and maintenance: [Operations](../OPERATIONS.md).
@@ -76,10 +78,12 @@ Governed source-preserving Base formulas: [P2 contract](governed-base-formula-p2
 
 ## Documentation ownership
 
-- README files explain the product, profiles and first successful run.
+- README files explain the product and first successful run.
+- Tool Surface Profiles owns `standard`, `authoring`, `tasks`, `full`, profile selection and client-facing exposure semantics.
 - Operations guides own local runtime and troubleshooting.
 - The tool surface owns tool names and semantics.
-- The runtime matrix owns mode availability.
+- The runtime matrix owns backend-mode availability.
+- The routing guide owns canonical precedence between overlapping tools.
 - Setup guides own configuration examples.
 - ADRs own decisions, status, boundaries and rejected alternatives.
 - The changelog records releases and unreleased changes.

--- a/docs/mcp-routing-guide.fr.md
+++ b/docs/mcp-routing-guide.fr.md
@@ -2,43 +2,56 @@
 
 Version anglaise : [mcp-routing-guide.md](mcp-routing-guide.md)
 
-Docs liées : [README](../README.fr.md),
-[Guide d’exploitation](../OPERATIONS.fr.md),
-[Matrice des capacités runtime](runtime-capability-matrix.fr.md),
+Docs liées : [README](../README.fr.md), [Profils de surface d’outils](tool-surface-profiles.fr.md),
+[Guide d’exploitation](../OPERATIONS.fr.md), [Matrice des capacités runtime](runtime-capability-matrix.fr.md),
 [Profil serveur headless](headless-server-profile.fr.md) et
 [Racines documentaires externes](external-roots-setup.fr.md)
 
 ![Parcours de décision pour router le travail agentique dans Optimike Obsidian MCP](assets/readme/routing-guide.fr.svg)
 
-Ce guide aide les agents à choisir la bonne couche pour travailler avec Obsidian.
+Ce guide aide les agents à choisir la bonne couche et l’outil canonique pour travailler avec Obsidian.
+
+## Choisir d’abord la surface exposée
+
+Runtime et profil d’outils sont deux décisions indépendantes :
+
+- le runtime (`live`, `hybrid`, `headless-*`) définit ce que le backend peut fournir en sécurité ;
+- le profil (`standard`, `authoring`, `tasks`, `full`) définit ce que le client voit avant `tools/list`.
+
+Pour une nouvelle intégration, préférer `standard` pour le travail général sur le
+coffre, `authoring` pour Bases/Canvas/tags et `tasks` pour Operon. `full` reste la
+surface de compatibilité et d’administration 2.x. Voir
+[Profils de surface d’outils](tool-surface-profiles.fr.md).
 
 ## Décision par défaut
 
 | Besoin                                                                     | Utiliser                                                        | Pourquoi                                                                          |
 | -------------------------------------------------------------------------- | --------------------------------------------------------------- | --------------------------------------------------------------------------------- |
-| Lire, lister, rechercher, Tasks, recherche sémantique                      | Optimike MCP                                                    | Surface stable entre live, hybrid et headless.                                    |
-| Lire un document explicitement configuré hors du coffre                    | Outils external-roots du MCP                                    | Confinement default-deny avec chemins logiques portables.                         |
-| Déplacer un fichier externe sans casser silencieusement ses liens ÉLYSIA   | Workflow de move externe en stdio local                         | Inventaire, plan durable, réparations CAS exactes, reçu et rollback.              |
-| Comportement Obsidian complet, commandes, active file, Bases via plugin    | Optimike MCP en `live` ou `hybrid` avec Obsidian Desktop ouvert | C'est le seul mode avec sémantique Desktop/plugin.                                |
-| Serveur backend sûr au-dessus d'un vault synchronisé                       | Optimike MCP en `headless-readonly` d'abord                     | Pas besoin de Desktop et aucun risque d'écriture.                                 |
-| Écritures Markdown/frontmatter/tags/admin bornées sur copie ou vault dédié | Optimike MCP en `headless-filesystem`                           | Sécurité de chemins, dry-run par défaut et préconditions.                         |
-| Édition fichier directe ponctuelle hors contrat MCP                        | Outils filesystem                                               | Utile pour du travail local type repo, mais l'agent porte tous les garde-fous.    |
-| Actions ou diagnostics app-native Obsidian                                 | Obsidian CLI                                                    | Utile comme plan de contrôle Desktop/app, pas comme headless strict.              |
-| Savoir écrire la syntaxe Markdown, Bases ou Canvas Obsidian                | Skills ou docs de format Obsidian                               | Les skills enseignent les conventions ; elles n'exécutent pas les opérations MCP. |
+| Lire, lister, rechercher, recherche sémantique                             | Profil `standard`                                               | Petite surface généraliste avec routage canonique lecture/écriture.               |
+| Workflows Operon ou Markdown Tasks                                         | Profil `tasks`                                                  | Contrat Operon complet + outils Markdown compatibles Tasks.                       |
+| Authoring Bases, tags ou Canvas                                            | Profil `authoring`                                              | Ajoute les surfaces d’authoring sans toute l’administration.                      |
+| Lire un document explicitement configuré hors du coffre                    | `full` + outils external-roots                                  | Les racines externes sont spécialisées et default-deny.                           |
+| Déplacer un fichier externe sans casser silencieusement ses liens ÉLYSIA   | `full` en stdio local sur copie ou coffre dédié                 | Inventaire, plan durable, réparations CAS exactes, reçu et rollback.              |
+| Comportement Obsidian complet, commandes, active file, Bases via plugin    | `live` ou `hybrid` avec Obsidian Desktop ouvert                 | Seul runtime avec sémantique Desktop/plugin.                                      |
+| Serveur backend sûr au-dessus d’un coffre synchronisé                      | `headless-readonly` d’abord                                     | Pas besoin de Desktop et aucun risque d’écriture.                                 |
+| Écritures Markdown/frontmatter/tags/admin bornées sur copie ou coffre dédié| `headless-filesystem`                                           | Sécurité de chemins, dry-run par défaut et préconditions.                         |
+| Édition fichier directe ponctuelle hors contrat MCP                        | Outils filesystem                                               | L’agent porte alors tous les garde-fous.                                           |
+| Actions ou diagnostics app-native Obsidian                                 | Obsidian CLI                                                    | Plan de contrôle Desktop/app, pas headless strict.                                |
+| Savoir écrire Markdown, Bases ou Canvas Obsidian                           | Skills ou docs de format Obsidian                               | Les skills enseignent les conventions sans exécuter les opérations MCP.           |
 
-## Outils directs, legacy et gouvernés
+## Outils directs, de compatibilité et gouvernés
 
 Quand plusieurs outils touchent le même domaine, ils ne sont pas
 interchangeables. Appliquer cette priorité :
 
-| Intention                                          | Outil préféré                                                                     | Limite de la voie directe ou legacy                                                                                            |
+| Intention                                          | Outil préféré                                                                     | Limite de la voie directe ou de compatibilité                                                                                  |
 | -------------------------------------------------- | --------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| Similarité sémantique                              | `smart_semantic_search`                                                           | `smart_search` et `smart-search` sont des alias de compatibilité de la même implémentation.                                    |
+| Similarité sémantique                              | `smart_semantic_search`                                                           | C’est le seul nom enseigné aux nouveaux agents et exposé dans les profils modernes.                                            |
 | Lecture de tâches gérées par Operon                | `operon_list_tasks`, `operon_query_tasks`                                         | `list_all_tasks` et `query_tasks` inspectent le Markdown compatible Obsidian Tasks.                                            |
-| Remplacement complet d'une note Markdown existante | `obsidian_note_replace_plan`, puis les outils apply/status/recover correspondants | L'overwrite de `obsidian_update_note` ne fournit ni reçu durable ni récupération du plan exact.                                |
-| Set/delete du frontmatter de premier niveau        | `obsidian_frontmatter_patch_plan`, puis son cycle associé                         | `obsidian_manage_frontmatter` reste utile pour la lecture, la compatibilité ou quand la projection gouvernée live est absente. |
-| Set/delete d'une formule Base nommée               | `bases_formula_patch_plan`, puis son cycle associé                                | `bases_upsert_config` est une voie de compatibilité whole-config désactivée par défaut.                                        |
-| Mutation du graphe d'un JSON Canvas existant       | `obsidian_canvas_patch_plan`, puis son cycle associé                              | `obsidian_manage_canvas` est un helper filesystem headless direct, sans recovery durable.                                      |
+| Remplacement complet d’une note Markdown existante | `obsidian_note_replace_plan`, puis apply/status/recover                            | L’overwrite de `obsidian_update_note` ne fournit ni reçu durable ni récupération du plan exact.                                |
+| Set/delete du Frontmatter de premier niveau        | `obsidian_frontmatter_patch_plan`, puis son cycle associé                         | `obsidian_manage_frontmatter` reste utile pour la lecture, la compatibilité ou quand la projection gouvernée live est absente. |
+| Set/delete d’une formule Base nommée               | `bases_formula_patch_plan`, puis son cycle associé                                | `bases_upsert_config` reste une voie whole-config de compatibilité.                                                            |
+| Mutation d’un graphe JSON Canvas existant          | `obsidian_canvas_patch_plan`, puis son cycle associé                              | `obsidian_manage_canvas` est un helper filesystem headless direct sans recovery durable.                                       |
 
 Les mutations directes append, prepend, search/replace et tags restent exposées
 quand le runtime actif les autorise. Elles ne produisent pas de reçu durable
@@ -50,93 +63,87 @@ Le serveur expose la même priorité concise via la ressource MCP
 `optimike://guides/tool-routing`. Un client peut la lister et la lire sans
 ajouter un nouvel outil de mutation appelable.
 
-## Nouveau en V2.2
+## Séquence gouvernée
 
-Utiliser `obsidian_validate_format` avant les écritures risquées ou le contenu généré :
+Pour chaque famille gouvernée :
 
-- `kind: markdown` vérifie frontmatter YAML, tags, wikilinks, embeds, callouts et code fences.
-- `kind: base` vérifie YAML `.base`, views, références de formules et formes courantes.
-- `kind: canvas` vérifie JSON Canvas, nodes, edges, IDs, géométrie et références d'edges.
-- `kind: auto` infère depuis l'extension de `filePath`.
+1. Appeler une seule fois le `*_plan` du domaine avec une clé d’idempotence contrôlée par l’appelant.
+2. Examiner le reçu et conserver son `planRef` opaque.
+3. Appeler le `*_apply` correspondant avec la même clé.
+4. Après timeout ou perte de transport, appeler `*_status` en premier.
+5. Appeler `*_recover` uniquement lorsque le reçu autorise la récupération de ce plan exact.
 
-Pour un Canvas existant en mode live/hybrid, préférer
+Un profil expose toujours la famille complète `plan → apply → status → recover`
+ou aucune de ses opérations. Le profil qui a créé le plan ne devient jamais son
+autorité de récupération.
+
+## Validation de format
+
+Utiliser `obsidian_validate_format` avant une écriture risquée ou du contenu généré :
+
+- `kind: markdown` vérifie frontmatter YAML, tags, wikilinks, embeds, callouts et code fences ;
+- `kind: base` vérifie YAML `.base`, views, références de formules et formes courantes ;
+- `kind: canvas` vérifie JSON Canvas, nodes, edges, IDs, géométrie et références d’edges ;
+- `kind: auto` infère depuis l’extension de `filePath`.
+
+Pour un Canvas existant en live/hybrid, préférer
 `obsidian_canvas_patch_plan → apply → status/recover`. Le compilateur gouverné
-borne les intentions sur les nœuds texte, la géométrie, la suppression de
-nœuds et les edges, préserve les valeurs inconnues, valide le graphe final et
-applique via le gate CAS Canvas séparé d'Atomic Write Bridge 0.4.0.
+borne les intentions, préserve les valeurs inconnues, valide le graphe final et
+applique via le gate CAS Canvas séparé d’Atomic Write Bridge 0.4.0.
 
 Utiliser `obsidian_manage_canvas` seulement comme helper direct en
-`headless-filesystem` :
-
-- `validate` lit et valide un `.canvas` existant.
-- `create` écrit un `.canvas` structurellement valide.
-- `add_text_node` ajoute un nœud texte.
-- `connect_nodes` ajoute une edge entre deux node IDs existants.
-
-Le dry-run est le défaut pour les opérations d'écriture.
+`headless-filesystem` pour valider, créer, ajouter un nœud texte ou connecter des
+nœuds. Le dry-run reste le défaut pour les opérations d’écriture.
 
 ## Routage documentaire externe
 
 Un lien Obsidian vers un fichier local n’autorise pas l’accès à ce fichier.
-Employer les outils external-roots uniquement lorsque l’opérateur a
-explicitement configuré un identifiant logique.
+Employer les outils external-roots uniquement lorsque l’opérateur a explicitement
+configuré un identifiant logique et choisi la surface spécialisée `full`.
 
 Workflow agent :
 
-1. Appeler `external_runtime_status` ou `external_roots_list` ; ne jamais déduire
-   une racine depuis un chemin physique trouvé dans une note.
-2. Employer `external_list` et `external_stat` avec l’identifiant et un chemin
-   relatif à la racine.
+1. Appeler `external_runtime_status` ou `external_roots_list` ; ne jamais déduire une racine depuis un chemin physique trouvé dans une note.
+2. Employer `external_list` et `external_stat` avec l’identifiant et un chemin relatif à la racine.
 3. Employer `external_read` uniquement pour du texte UTF-8 borné.
-4. Pour un PDF ou un document Office, demander explicitement
-   `external_handoff` :
+4. Pour un PDF ou un document Office, demander explicitement `external_handoff` :
    - le stdio local retourne un `local_path` temporaire vérifié ;
-   - le HTTP direct authentifié peut retourner un `http_ticket` opt-in, réclamé
-     une seule fois via `GET /external-handoff` avec la même identité bearer et
-     le header `X-External-Handoff-Ticket`.
-5. Conserver comme provenance l’identifiant logique, le chemin relatif, la
-   taille et le SHA-256. Ne jamais persister le chemin temporaire ni le ticket.
+   - le HTTP direct authentifié peut retourner un `http_ticket` opt-in, réclamé une seule fois avec la même identité bearer.
+5. Conserver comme provenance l’identifiant logique, le chemin relatif, la taille et le SHA-256. Ne jamais persister le chemin temporaire ni le ticket.
 
 Pour un move gouverné par ÉLYSIA :
 
-1. vérifier que le lien `file:///` cliquable possède l’identité canonique
-   adjacente `external-ref:<rootId>::<chemin-relatif-encode-en-pourcentage>` ;
+1. vérifier que le lien `file:///` cliquable possède l’identité canonique adjacente `external-ref:<rootId>::<chemin-relatif-encode>` ;
 2. employer `external_references_scan`, puis `external_move_plan` ;
-3. s’arrêter si `manualReview` n’est pas vide ; ne jamais réparer
-   automatiquement une occurrence legacy ou ambiguë ;
-4. examiner `external_move_status`, puis appeler `external_move_apply`
-   uniquement avec les gates write locaux explicites et la même clé
-   d’idempotence ;
-5. vérifier le fichier cible et les notes réparées ; employer
-   `external_move_rollback` seulement tant que ses préconditions persistées
-   tiennent encore.
+3. s’arrêter si `manualReview` n’est pas vide ; ne jamais réparer automatiquement une occurrence historique ou ambiguë ;
+4. examiner `external_move_status`, puis appeler `external_move_apply` uniquement avec les gates write locaux explicites et la même clé d’idempotence ;
+5. vérifier le fichier cible et les notes réparées ; employer `external_move_rollback` seulement tant que ses préconditions persistées tiennent encore.
 
 Cette transaction est réservée au stdio local. Elle accepte un fichier régulier,
-une cible absente dans un dossier parent existant, et un move sans écrasement
-dans la même racine et sur le même volume. Les éditions concurrentes de notes
-sont protégées par une précondition SHA-256 exacte en `headless-filesystem` sur
-une copie ou un coffre dédié. L’apply live via Local REST échoue fermé, car les
-remplacements de note complète n’imposent pas encore `If-Match`. Ne pas router
-create, replace, upload, delete, sync, dossier, cross-root ou cross-volume dans
-ce workflow.
+une cible absente dans un dossier parent existant et un move sans écrasement dans
+la même racine et sur le même volume. Les éditions concurrentes de notes sont
+protégées par une précondition SHA-256 exacte en `headless-filesystem` sur une
+copie ou un coffre dédié. L’apply live via Local REST échoue fermé tant que les
+remplacements de note complète n’imposent pas `If-Match`.
 
 Toute opération external-root en HTTP direct exige `external:read`. Le HTTP
-distant reste pilote derrière un proxy TLS et des contrôles réseau revus.
-Le HTTP direct refuse scan de références, plan/status de move, apply et
-rollback ; un ticket d’artefact autorise uniquement le téléchargement.
-
-Ne pas promettre l’extraction au seul motif que le handoff fonctionne :
-l’extraction dépend du client appelant. Ne pas copier silencieusement le contenu
-externe dans le coffre, le fusionner à la recherche du coffre ou traiter la
-racine configurée comme une sauvegarde.
+distant reste pilote derrière un proxy TLS et des contrôles réseau revus. Le
+HTTP direct refuse scan de références, plan/status de move, apply et rollback ;
+un ticket d’artefact autorise uniquement le téléchargement.
 
 ## Ce que le headless valide mais ne garantit pas
 
-La validation headless attrape les erreurs locales de format. Elle ne rend pas Obsidian, ne charge pas les plugins communautaires, n'évalue pas le comportement exact de l'UI Bases, n'exécute pas les formules, ne résout pas les backlinks via l'index interne Obsidian et ne confirme pas le layout visuel Canvas.
+La validation headless attrape les erreurs locales de format. Elle ne rend pas
+Obsidian, ne charge pas les plugins communautaires, n’évalue pas le comportement
+exact de l’UI Bases, n’exécute pas les formules, ne résout pas les backlinks via
+l’index interne Obsidian et ne confirme pas le layout visuel Canvas.
 
 ## Règle pratique pour agents
 
-1. Valider le contenu généré avec `obsidian_validate_format`.
-2. Si le comportement Desktop/plugin compte, utiliser `live` ou `hybrid` avec Obsidian ouvert.
-3. Sur backend, commencer par `headless-readonly`.
-4. Activer `headless-filesystem` seulement sur copie ou vault dédié avec rollback.
+1. Choisir le profil serveur le plus étroit qui contient le domaine nécessaire.
+2. Valider le contenu généré avec `obsidian_validate_format`.
+3. Si le comportement Desktop/plugin compte, utiliser `live` ou `hybrid` avec Obsidian ouvert.
+4. Sur backend, commencer par `headless-readonly`.
+5. Activer `headless-filesystem` seulement sur copie ou coffre dédié avec rollback.
+
+Il n’existe volontairement aucune surface publique générique `operation_*`.

--- a/docs/mcp-routing-guide.md
+++ b/docs/mcp-routing-guide.md
@@ -2,25 +2,38 @@
 
 French version: [mcp-routing-guide.fr.md](mcp-routing-guide.fr.md)
 
-Related docs: [README](../README.md), [Operations](../OPERATIONS.md),
-[Runtime Capability Matrix](runtime-capability-matrix.md),
+Related docs: [README](../README.md), [Tool Surface Profiles](tool-surface-profiles.md),
+[Operations](../OPERATIONS.md), [Runtime Capability Matrix](runtime-capability-matrix.md),
 [Headless Server Profile](headless-server-profile.md), and
 [External document roots](external-roots-setup.md)
 
 ![Decision path for routing agent work through Optimike Obsidian MCP](assets/readme/routing-guide.en.svg)
 
-This guide helps agents choose the right layer for Obsidian work.
+This guide helps agents choose the right layer and canonical tool for Obsidian work.
+
+## Choose the exposure surface first
+
+Runtime and tool profile are independent decisions:
+
+- the runtime (`live`, `hybrid`, `headless-*`) defines what the backend can safely provide;
+- the tool profile (`standard`, `authoring`, `tasks`, `full`) defines what the client sees before `tools/list`.
+
+For new integrations, prefer `standard` for general vault work, `authoring` for
+Bases/Canvas/tag authoring, and `tasks` for Operon workflows. `full` is the 2.x
+compatibility/admin surface. See [Tool Surface Profiles](tool-surface-profiles.md).
 
 ## Default Decision
 
 | Need                                                                         | Use                                                           | Why                                                                     |
 | ---------------------------------------------------------------------------- | ------------------------------------------------------------- | ----------------------------------------------------------------------- |
-| Read, list, search, tasks, semantic search                                   | Optimike MCP                                                  | Stable tool surface across live, hybrid, and headless modes.            |
-| Read an explicitly configured document outside the vault                     | Optimike MCP external-root tools                              | Default-deny confinement with portable logical paths.                   |
-| Move one external file without silently breaking ÉLYSIA links                | Local stdio on a copied or dedicated vault                    | Inventory, durable plan, exact hash repairs, receipt and rollback.      |
+| Read, list, search, semantic search                                          | `standard` profile                                            | Small general-purpose surface with canonical search/write routing.      |
+| Operon or Markdown Tasks workflows                                           | `tasks` profile                                               | Complete Operon contract plus Tasks-compatible Markdown tools.          |
+| Bases, tags or Canvas authoring                                               | `authoring` profile                                           | Adds the authoring-specific surfaces without the full admin set.        |
+| Read an explicitly configured document outside the vault                     | `full` + Optimike MCP external-root tools                     | External roots are specialized and default-deny.                        |
+| Move one external file without silently breaking ÉLYSIA links                | `full` over local stdio on a copied or dedicated vault        | Inventory, durable plan, exact hash repairs, receipt and rollback.      |
 | Full Obsidian behavior, commands, active file, plugin-backed Bases           | Optimike MCP in `live` or `hybrid` with Obsidian Desktop open | This is the only mode with Desktop/plugin-backed semantics.             |
-| Safe backend server over a synced vault                                      | Optimike MCP in `headless-readonly` first                     | No Desktop required and no write risk.                                  |
-| Bounded Markdown/frontmatter/tag/admin writes on a copied or dedicated vault | Optimike MCP in `headless-filesystem`                         | Path safety, dry-run defaults, and preconditions.                       |
+| Safe backend server over a synced vault                                      | `headless-readonly` first                                     | No Desktop required and no write risk.                                  |
+| Bounded Markdown/frontmatter/tag/admin writes on a copied or dedicated vault | `headless-filesystem`                                         | Path safety, dry-run defaults, and preconditions.                       |
 | Direct one-off file edits outside the MCP contract                           | Filesystem tools                                              | Useful for local repo-style work, but the agent owns all safety checks. |
 | App-native Obsidian actions or diagnostics                                   | Obsidian CLI                                                  | Useful as a Desktop/app control plane, not strict headless.             |
 | Knowing how to write Obsidian Markdown, Bases, or Canvas syntax              | Obsidian-format skills or docs                                | Skills teach format conventions; they do not execute MCP operations.    |
@@ -39,15 +52,15 @@ explicit vault-relative path first, then use the ordinary note tools. The
 optional upstream Periodic Notes API extension is a separate integration and is
 not assumed by Optimike MCP.
 
-## Direct, legacy and governed tools
+## Direct, compatibility and governed tools
 
 When multiple tools touch the same domain, they are not interchangeable. Use
 this precedence:
 
-| Intent                                            | Preferred tool                                                            | Direct or legacy boundary                                                                                              |
+| Intent                                            | Preferred tool                                                            | Direct or compatibility boundary                                                                                       |
 | ------------------------------------------------- | ------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
-| Semantic similarity                               | `smart_semantic_search`                                                   | `smart_search` and `smart-search` are compatibility aliases of the same implementation.                                |
-| Operon-managed task reads                         | `operon_list_tasks`, `operon_query_tasks`                                 | `list_all_tasks` and `query_tasks` inspect legacy Obsidian Tasks-compatible Markdown.                                  |
+| Semantic similarity                               | `smart_semantic_search`                                                   | This is the only semantic-search name taught to new agents and exposed by modern profiles.                             |
+| Operon-managed task reads                         | `operon_list_tasks`, `operon_query_tasks`                                 | `list_all_tasks` and `query_tasks` inspect Obsidian Tasks-compatible Markdown.                                         |
 | Complete replacement of an existing Markdown note | `obsidian_note_replace_plan` then its matching apply/status/recover tools | `obsidian_update_note` overwrite has no durable receipt or exact-plan recovery.                                        |
 | Top-level frontmatter set/delete                  | `obsidian_frontmatter_patch_plan` then its matching lifecycle             | `obsidian_manage_frontmatter` remains useful for reads, compatibility, or when the governed live projection is absent. |
 | Named Base formula set/delete                     | `bases_formula_patch_plan` then its matching lifecycle                    | `bases_upsert_config` is a default-off whole-config compatibility path.                                                |
@@ -63,7 +76,20 @@ The server exposes the same concise precedence as the MCP resource
 `optimike://guides/tool-routing`. Clients can list and read that resource without
 adding another callable mutation tool.
 
-## New In V2.2
+## Governed sequence
+
+For every governed family:
+
+1. Call the domain-specific `*_plan` tool once with a caller-owned idempotency key.
+2. Inspect the returned receipt and retain its opaque `planRef`.
+3. Call the matching `*_apply` tool with the same key.
+4. After timeout or transport loss, call `*_status` first.
+5. Call `*_recover` only when the receipt authorizes recovery of that exact plan.
+
+A profile always exposes the full `plan → apply → status → recover` family or
+none of it. The profile that created a plan is never recovery authority.
+
+## Format validation
 
 Use `obsidian_validate_format` before risky writes or generated content:
 
@@ -91,14 +117,13 @@ Dry-run is the default for write operations.
 
 An Obsidian link to a local file does not authorize access to that file. Use
 external-root tools only when the operator has explicitly configured a logical
-root ID.
+root ID and selected the specialized `full` surface.
 
 Agent workflow:
 
 1. Call `external_runtime_status` or `external_roots_list`; never infer a root
    from a physical path found in a note.
-2. Use `external_list` and `external_stat` with a root ID and root-relative
-   path.
+2. Use `external_list` and `external_stat` with a root ID and root-relative path.
 3. Use `external_read` only for bounded UTF-8 text.
 4. For PDF or Office content, request `external_handoff` explicitly:
    - local stdio returns a verified temporary `local_path`;
@@ -113,8 +138,7 @@ For an ÉLYSIA-managed move:
 1. ensure the clickable `file:///` link has an adjacent canonical identity:
    `external-ref:<rootId>::<percent-encoded-relative-path>`;
 2. use `external_references_scan`, then `external_move_plan`;
-3. stop when `manualReview` is non-empty; never repair a legacy or ambiguous
-   occurrence automatically;
+3. stop when `manualReview` is non-empty; never repair a historical or ambiguous occurrence automatically;
 4. inspect `external_move_status`, then call `external_move_apply` only with
    explicit local write gates and the same idempotency key;
 5. verify both the target file and repaired notes; use
@@ -129,9 +153,9 @@ Do not route create, replace, upload, delete, sync, directory, cross-root or
 cross-volume operations through this workflow.
 
 Every direct HTTP external-root operation requires `external:read`. Remote HTTP
-remains pilot-only behind reviewed TLS proxy and network controls.
-Direct HTTP rejects external reference scan, move plan/status, apply and
-rollback; an artifact ticket authorizes download only.
+remains pilot-only behind reviewed TLS proxy and network controls. Direct HTTP
+rejects external reference scan, move plan/status, apply and rollback; an
+artifact ticket authorizes download only.
 
 Do not promise extraction merely because handoff succeeds: extraction depends
 on the calling client. Do not silently copy external content into the vault,
@@ -139,11 +163,17 @@ merge it into vault search, or treat the configured root as a backup.
 
 ## What Headless Can Validate But Not Guarantee
 
-Headless validation catches local format errors. It does not render Obsidian, load community plugins, evaluate exact Bases UI behavior, execute formulas, resolve backlinks through Obsidian's internal index, or confirm visual Canvas layout.
+Headless validation catches local format errors. It does not render Obsidian,
+load community plugins, evaluate exact Bases UI behavior, execute formulas,
+resolve backlinks through Obsidian's internal index, or confirm visual Canvas
+layout.
 
 ## Practical Rule For Agents
 
-1. Validate generated content with `obsidian_validate_format`.
-2. If Desktop/plugin behavior matters, use `live` or `hybrid` with Obsidian open.
-3. If running on a backend, start with `headless-readonly`.
-4. Enable `headless-filesystem` only on a copied or dedicated vault with rollback.
+1. Select the narrowest server profile that contains the required domain.
+2. Validate generated content with `obsidian_validate_format`.
+3. If Desktop/plugin behavior matters, use `live` or `hybrid` with Obsidian open.
+4. If running on a backend, start with `headless-readonly`.
+5. Enable `headless-filesystem` only on a copied or dedicated vault with rollback.
+
+There is intentionally no generic public `operation_*` surface.

--- a/docs/obsidian_mcp_tools_spec.md
+++ b/docs/obsidian_mcp_tools_spec.md
@@ -6,6 +6,7 @@ names and runtime-aware registration.
 
 Related docs:
 
+- Tool exposure profiles: [tool-surface-profiles.md](tool-surface-profiles.md)
 - Runtime modes: [runtime-capability-matrix.md](runtime-capability-matrix.md)
 - Operations: [../OPERATIONS.md](../OPERATIONS.md)
 - Governed atomic note replacement: [governed-note-replacement.md](governed-note-replacement.md)
@@ -14,12 +15,27 @@ Related docs:
 - External roots: [external-roots-setup.md](external-roots-setup.md)
 - Operon contract: [operon-mcp-contract.md](operon-mcp-contract.md)
 
+## Exposure profiles
+
+The canonical registry is larger than any one normal agent surface. Runtime
+registration and tool-profile exposure are separate filters:
+
+- `standard`, `authoring` and `tasks` expose curated modern surfaces before
+  `tools/list`;
+- `full` preserves every tool registered by the active runtime for 2.x
+  compatibility and administration;
+- a hidden tool remains protected by the same runtime/write/security checks;
+  visibility is not authorization.
+
+The current cross-runtime registry contains 76 unique names. Full live/hybrid
+registration currently contains 72 names. See
+[Tool Surface Profiles](tool-surface-profiles.md) for exact profile semantics.
+
 ## MCP Resources
 
 - `optimike://guides/tool-routing`: concise Markdown precedence for canonical,
-  governed, direct and legacy-compatible tool families. Clients can read it
-  when choosing between overlapping domains; it adds no callable mutation
-  capability.
+  governed, direct and compatibility tool families. Clients can read it when
+  choosing between overlapping domains; it adds no callable mutation capability.
 
 ## Runtime Rules
 
@@ -212,9 +228,15 @@ fail-closed; no private or Markdown fallback is introduced.
 
 ## Semantic Search
 
-- `smart_semantic_search`: semantic search over Smart Connections embeddings.
-- `smart_search`: alias for `smart_semantic_search`.
-- `smart-search`: alias for `smart_semantic_search`.
+- `smart_semantic_search`: **canonical** semantic search over Smart Connections
+  embeddings. This is the only semantic-search name exposed by `standard`,
+  `authoring` and `tasks`, and the only name new routing documentation teaches.
+- `smart_search`: deprecated 2.x compatibility alias, visible only in `full`.
+- `smart-search`: deprecated 2.x compatibility alias, visible only in `full`.
+
+The two compatibility aliases remain physically registered during 2.x to avoid
+silently breaking an existing public client. Their physical removal is reserved
+for 3.0 unless an explicit SemVer break is chosen later.
 
 Semantic query execution still needs a reachable query embedder provider. The
 semantic manifest/vector metadata are cached locally for faster warm refreshes.

--- a/docs/tool-surface-profiles.fr.md
+++ b/docs/tool-surface-profiles.fr.md
@@ -2,115 +2,84 @@
 
 Version anglaise : [tool-surface-profiles.md](tool-surface-profiles.md)
 
-Optimike Obsidian MCP sépare deux contrats qui répondent à deux problèmes
-différents :
+Optimike Obsidian MCP sépare deux contrats indépendants :
 
 - le **mode runtime** contrôle ce que le backend peut fournir en sécurité (`live`, `hybrid`, `headless-readonly`, `headless-guarded`, `headless-filesystem`) ;
-- le **profil d’outils** contrôle ce qu’un client MCP voit avant `tools/list`.
+- le **profil d’outils** contrôle ce qu’un client MCP peut découvrir et appeler avant `tools/list`.
 
-Les profils réduisent l’ambiguïté côté modèle et le volume des schémas exposés.
-Ils ne constituent pas une frontière d’autorisation. Les contrôles runtime,
-write-mode, bridge, scopes, confirmations et CAS restent autoritaires même si un
-outil est visible.
+Les profils réduisent le volume des schémas et l’ambiguïté de routage. Ils ne constituent pas une frontière d’autorisation : mode runtime, write policy, grants des Bridges, scopes, confirmations, CAS, idempotence et règles de récupération restent autoritaires.
 
 ## Profils publics
 
 | Profil | Usage visé | Surface complète live/hybrid |
 | --- | --- | ---: |
-| `standard` | Lecture/recherche générale du coffre + authoring note/frontmatter courant | 19 outils |
-| `authoring` | `standard` + tags, authoring/formules Bases et authoring Canvas | 31 outils |
-| `tasks` | Compatibilité Markdown Tasks + contrat MCP Operon complet | 31 outils |
+| `standard` | Lecture/recherche générale et travail courant gouverné Note/Frontmatter | 19 outils |
+| `authoring` | `standard` + tags, authoring Bases borné/formules et authoring Canvas | 30 outils |
+| `tasks` | Compatibilité Markdown Tasks + contrat MCP Operon live complet | 31 outils |
 | `full` | Surface compatibilité/admin 2.x du runtime actif | 72 outils |
 
-Ces nombres sont des projections du registre actuel et peuvent être plus faibles
-dans un runtime plus restreint. Par exemple, `standard` expose 9 outils en
-`headless-readonly`. `full` signifie « tous les outils enregistrés par le runtime
-actif », pas « toujours 72 outils ».
+Ces nombres sont des projections du registre actuel et peuvent être plus faibles dans les runtimes restreints. `full` signifie tous les outils structurellement enregistrés par le runtime actif, pas toujours 72 outils. Le registre canonique couvre 76 noms uniques entre tous les runtimes, dont quatre n’existent qu’en `headless-filesystem`.
 
-Le registre canonique couvre 76 noms uniques entre tous les runtimes, car quatre
-outils existent uniquement en `headless-filesystem` et ne font donc pas partie
-des 72 outils live/hybrid.
+## Noms réservés à la compatibilité
 
-## Nom de la recherche sémantique
+Les profils modernes excluent volontairement les voies de compatibilité qui ajouteraient une décision au modèle sans apporter une capacité normale distincte.
 
-Les profils modernes n’exposent qu’un seul nom public :
+La recherche sémantique utilise un seul nom canonique :
 
 ```text
 smart_semantic_search
 ```
 
-Les anciens alias `smart_search` et `smart-search` sont masqués dans `standard`,
-`authoring` et `tasks`. Ils restent visibles uniquement dans `full` pendant la
-branche 2.x pour ne pas casser silencieusement un client public existant. Leur
-suppression physique est réservée à la 3.0, sauf décision ultérieure d’assumer
-une rupture SemVer en mineure.
+Les anciens alias `smart_search` et `smart-search` restent physiquement enregistrés et visibles uniquement dans `full` pendant la branche 2.x. Leur suppression physique est réservée à la 3.0.
 
-Tout nouveau routage agentique ou intégration doit utiliser uniquement
-`smart_semantic_search`.
+`bases_upsert_config` est également réservé à `full` en 2.10. Il remplace une configuration Base complète et n’est pas un fallback de l’édition gouvernée des formules. `authoring` conserve `bases_create`, `bases_upsert_rows` et la famille gouvernée complète `bases_formula_patch_*`.
 
 ## Familles gouvernées
 
-Une famille gouvernée est exposée atomiquement. Lorsqu’un profil expose l’une de
-ces familles, les quatre opérations restent visibles ensemble :
+Une famille gouvernée est exposée atomiquement :
 
 ```text
 plan → apply → status → recover
 ```
 
-Cela vaut pour le remplacement gouverné de note, la projection Frontmatter, les
-formules Base et le patch de graphe Canvas.
+Cela vaut pour le remplacement de Note, la projection Frontmatter, les formules Bases et le patch de graphe Canvas.
 
-Un profil ne modifie jamais le contenu scellé du plan, son journal, sa clé
-d’idempotence, son binding backend ni son autorité de récupération. Un plan
-durable créé dans une session peut être inspecté ou récupéré depuis une autre
-session ou un autre profil qui expose la même famille, sous réserve des
-politiques runtime et d’écriture/sécurité habituelles.
+L’enregistrement des outils est incrémental dans la factory serveur. Tant que les quatre membres d’une famille ne sont pas enregistrés, toute la famille gouvernée reste masquée et le fallback direct légitime reste visible. À l’arrivée du quatrième membre, le quartet devient visible en une seule réconciliation et le fallback devenu secondaire est masqué. La compilation statique reste stricte et rejette une famille réellement incomplète.
+
+Un profil ne modifie jamais le contenu scellé du plan, les journaux, l’idempotence, le binding backend ni l’autorité de récupération. Un plan durable créé dans une session peut être inspecté ou récupéré depuis une autre session ou un autre profil exposant la même famille complète, sous réserve des politiques runtime et d’écriture/sécurité habituelles.
 
 ## Canonique et fallback direct
 
-Les profils modernes peuvent masquer un outil direct de compatibilité lorsque
-la famille gouvernée correspondante est réellement enregistrée. Ils conservent
-la voie directe lorsqu’aucun équivalent gouverné n’existe dans le runtime.
+Les profils modernes ne masquent une voie directe que lorsque la famille gouvernée correspondante est structurellement complète dans le runtime courant.
 
-Exemple actuel :
-
-- `live` / `hybrid` live : la famille complète `obsidian_frontmatter_patch_*`
-  est exposée et `obsidian_manage_frontmatter` est masqué ;
-- `headless-guarded` / `headless-filesystem` : la famille gouvernée Frontmatter
-  n’existe pas, donc `obsidian_manage_frontmatter` reste le fallback borné.
+- `live` / `hybrid` live : exposer `obsidian_frontmatter_patch_{plan,apply,status,recover}` et masquer `obsidian_manage_frontmatter` ;
+- `headless-guarded` / `headless-filesystem` : la famille Frontmatter gouvernée est absente, donc `obsidian_manage_frontmatter` reste le fallback borné ;
+- les helpers Canvas directs de `headless-filesystem` restent disponibles uniquement lorsque la famille Canvas live gouvernée est structurellement absente ;
+- `bases_upsert_config` n’est jamais un fallback de formule et reste réservé à `full`.
 
 `full` n’applique jamais cette suppression au profit de la voie canonique.
 
 ## Sélection en stdio
 
-Le comportement historique reste `full` lorsqu’aucun profil n’est indiqué.
-
-Via argument :
+Le défaut de compatibilité de la branche 2.x reste `full` lorsqu’aucun profil n’est indiqué.
 
 ```bash
 node dist/stdio-proxy.js --tool-profile standard
 ```
 
-ou via environnement :
+ou :
 
 ```bash
 MCP_TOOL_PROFILE=standard node dist/stdio-proxy.js
 ```
 
-`--tool-profile` gagne sur `MCP_TOOL_PROFILE`. Un profil inconnu ou un argument
-répété échoue fermé au lieu de retomber sur `full`.
+`--tool-profile` prévaut sur `MCP_TOOL_PROFILE`. Une valeur inconnue, vide ou répétée échoue fermé au lieu de retomber sur `full`.
 
-Le proxy stdio applique le profil **par client**. S’il doit lancer le backend
-HTTP partagé, il lance explicitement ce backend en `full`, puis filtre sa propre
-surface client. Un agent `standard` et un agent `tasks` peuvent donc partager le
-même backend sans modifier mutuellement leur liste d’outils.
-
-Un outil masqué est aussi refusé lorsqu’il est appelé directement ; le profilage
-n’est pas un simple filtrage cosmétique de `tools/list`.
+Le proxy stdio applique le profil par client. Lorsqu’il démarre le backend HTTP partagé, il le démarre explicitement en `full`, puis filtre `tools/list` et `tools/call` pour son client. Un outil local du proxy masqué n’est donc pas appelable en connaissant simplement son nom.
 
 ## Sélection en HTTP
 
-Le serveur HTTP expose des routes de profil explicites et immuables :
+Le serveur expose des routes de profil immuables :
 
 ```text
 /mcp              → full (alias de compatibilité 2.x)
@@ -120,112 +89,31 @@ Le serveur HTTP expose des routes de profil explicites et immuables :
 /mcp/full         → full
 ```
 
-Une session est liée à son identité vérifiée **et** à son profil d’outils. Un
-`sessionId` créé sur `/mcp/standard` ne peut pas être réutilisé sur `/mcp/full`,
-y compris pour les requêtes de session POST, GET ou DELETE. Un mismatch de
-profil échoue fermé avec la même posture générique « session invalide/expirée »
-qu’un mismatch d’identité.
+Une session est liée à son identité vérifiée et à son profil. Un `sessionId` créé sur `/mcp/standard` ne peut pas être réutilisé sur `/mcp/full`, y compris pour POST, GET ou DELETE. Un mismatch de profil utilise la même posture générique « session invalide/expirée » qu’un mismatch d’identité.
 
-Le profil est porté par un contexte de requête uniquement pendant la création du
-`McpServer` propre à la session. Il n’est jamais écrit dans un état global du
-processus ; plusieurs profils peuvent donc coexister simultanément sur le même
-backend HTTP.
+Le contexte de profil est limité à la requête pendant la création du `McpServer` de la session ; plusieurs profils peuvent coexister sur un même backend sans mutation d’un profil global de processus.
 
-## Filtrage supplémentaire côté client
+## Contrat serveur, optimisation client
 
-Les profils serveur sont le contrat portable. Un client peut ensuite réduire
-encore cette surface avec ses propres fonctions, mais il ne devient jamais la
-source de vérité.
+Le profil serveur est le contrat portable. Un client peut encore réduire ou différer cette surface, mais ne devient jamais la source de vérité d’Optimike.
 
-Mécanismes complémentaires possibles :
+Mécanismes clients optionnels :
 
 - Codex : `enabled_tools` / `disabled_tools` ;
 - Gemini CLI : `includeTools` / `excludeTools` ;
-- Claude Code : tool search / chargement différé des outils MCP ;
+- Claude Code : tool search / chargement MCP différé ;
 - Hermes Agent : filtres include/exclude ;
 - OpenClaw : `toolFilter.include` / `toolFilter.exclude`.
 
-Ces mécanismes diffèrent selon les harnesses et peuvent évoluer séparément.
-Choisir d’abord le profil Optimike adapté, puis n’utiliser le filtrage client que
-s’il apporte un gain local supplémentaire.
+Ces mécanismes peuvent évoluer indépendamment. Choisir d’abord un profil Optimike, puis utiliser le filtrage client uniquement comme optimisation supplémentaire.
 
-## Exemples clients
+## Frontière de migration
 
-### Codex — stdio
+La 2.10 reste compatible SemVer avec la branche 2.x :
 
-```toml
-[mcp_servers.optimike]
-command = "node"
-args = [
-  "/chemin/vers/optimike-obsidian-mcp/dist/stdio-proxy.js",
-  "--tool-profile",
-  "standard"
-]
+- profil stdio non indiqué → `full` ;
+- `/mcp` historique → `/mcp/full` ;
+- `smart_search` et `smart-search` restent disponibles dans `full` ;
+- les surfaces `full` du runtime actif restent compatibles avec la 2.9.
 
-[mcp_servers.optimike.env]
-OBSIDIAN_VAULT = "/chemin/vers/coffre"
-OBSIDIAN_RUNTIME_MODE = "live"
-OBSIDIAN_BASE_URL = "http://127.0.0.1:27123"
-OBSIDIAN_API_KEY = "<cle-local-rest-api>"
-```
-
-`enabled_tools` peut éventuellement réduire encore la surface déjà sélectionnée
-côté serveur.
-
-### Gemini CLI — stdio
-
-```json
-{
-  "mcpServers": {
-    "optimike": {
-      "command": "node",
-      "args": [
-        "/chemin/vers/optimike-obsidian-mcp/dist/stdio-proxy.js",
-        "--tool-profile",
-        "standard"
-      ],
-      "env": {
-        "OBSIDIAN_VAULT": "/chemin/vers/coffre",
-        "OBSIDIAN_RUNTIME_MODE": "live"
-      }
-    }
-  }
-}
-```
-
-`includeTools` / `excludeTools` restent des réductions optionnelles côté client.
-
-### Claude Code — stdio
-
-```bash
-claude mcp add optimike -- node \
-  /chemin/vers/optimike-obsidian-mcp/dist/stdio-proxy.js \
-  --tool-profile standard
-```
-
-Claude Code peut aussi différer le chargement de grandes surfaces MCP via son
-tool search. Le profil serveur reste utile : il définit la surface publique
-canonique avant toute stratégie propre au client.
-
-### Client HTTP générique
-
-Le profil vit directement dans l’URL MCP :
-
-```text
-http://127.0.0.1:3010/mcp/standard
-```
-
-Aucun header propriétaire n’est nécessaire.
-
-## Règle de compatibilité 2.x
-
-Pendant la branche 2.x :
-
-- aucun profil indiqué → `full` ;
-- `/mcp` historique → comportement `/mcp/full` ;
-- les alias de recherche sémantique restent accessibles uniquement dans `full` ;
-- les profils modernes sont opt-in et peuvent être recommandés pour les nouvelles installations ;
-- la visibilité ne relâche jamais les contrôles runtime/écriture/sécurité existants.
-
-Une future version majeure pourra faire de `standard` le défaut et retirer les
-alias dépréciés après une fenêtre de migration explicite.
+La 3.0 est la frontière de rupture prévue pour supprimer physiquement les alias sémantiques et faire de `standard` la surface moderne par défaut, après admission complète de la 2.10.

--- a/docs/tool-surface-profiles.fr.md
+++ b/docs/tool-surface-profiles.fr.md
@@ -1,0 +1,231 @@
+# Profils de surface d’outils
+
+Version anglaise : [tool-surface-profiles.md](tool-surface-profiles.md)
+
+Optimike Obsidian MCP sépare deux contrats qui répondent à deux problèmes
+différents :
+
+- le **mode runtime** contrôle ce que le backend peut fournir en sécurité (`live`, `hybrid`, `headless-readonly`, `headless-guarded`, `headless-filesystem`) ;
+- le **profil d’outils** contrôle ce qu’un client MCP voit avant `tools/list`.
+
+Les profils réduisent l’ambiguïté côté modèle et le volume des schémas exposés.
+Ils ne constituent pas une frontière d’autorisation. Les contrôles runtime,
+write-mode, bridge, scopes, confirmations et CAS restent autoritaires même si un
+outil est visible.
+
+## Profils publics
+
+| Profil | Usage visé | Surface complète live/hybrid |
+| --- | --- | ---: |
+| `standard` | Lecture/recherche générale du coffre + authoring note/frontmatter courant | 19 outils |
+| `authoring` | `standard` + tags, authoring/formules Bases et authoring Canvas | 31 outils |
+| `tasks` | Compatibilité Markdown Tasks + contrat MCP Operon complet | 31 outils |
+| `full` | Surface compatibilité/admin 2.x du runtime actif | 72 outils |
+
+Ces nombres sont des projections du registre actuel et peuvent être plus faibles
+dans un runtime plus restreint. Par exemple, `standard` expose 9 outils en
+`headless-readonly`. `full` signifie « tous les outils enregistrés par le runtime
+actif », pas « toujours 72 outils ».
+
+Le registre canonique couvre 76 noms uniques entre tous les runtimes, car quatre
+outils existent uniquement en `headless-filesystem` et ne font donc pas partie
+des 72 outils live/hybrid.
+
+## Nom de la recherche sémantique
+
+Les profils modernes n’exposent qu’un seul nom public :
+
+```text
+smart_semantic_search
+```
+
+Les anciens alias `smart_search` et `smart-search` sont masqués dans `standard`,
+`authoring` et `tasks`. Ils restent visibles uniquement dans `full` pendant la
+branche 2.x pour ne pas casser silencieusement un client public existant. Leur
+suppression physique est réservée à la 3.0, sauf décision ultérieure d’assumer
+une rupture SemVer en mineure.
+
+Tout nouveau routage agentique ou intégration doit utiliser uniquement
+`smart_semantic_search`.
+
+## Familles gouvernées
+
+Une famille gouvernée est exposée atomiquement. Lorsqu’un profil expose l’une de
+ces familles, les quatre opérations restent visibles ensemble :
+
+```text
+plan → apply → status → recover
+```
+
+Cela vaut pour le remplacement gouverné de note, la projection Frontmatter, les
+formules Base et le patch de graphe Canvas.
+
+Un profil ne modifie jamais le contenu scellé du plan, son journal, sa clé
+d’idempotence, son binding backend ni son autorité de récupération. Un plan
+durable créé dans une session peut être inspecté ou récupéré depuis une autre
+session ou un autre profil qui expose la même famille, sous réserve des
+politiques runtime et d’écriture/sécurité habituelles.
+
+## Canonique et fallback direct
+
+Les profils modernes peuvent masquer un outil direct de compatibilité lorsque
+la famille gouvernée correspondante est réellement enregistrée. Ils conservent
+la voie directe lorsqu’aucun équivalent gouverné n’existe dans le runtime.
+
+Exemple actuel :
+
+- `live` / `hybrid` live : la famille complète `obsidian_frontmatter_patch_*`
+  est exposée et `obsidian_manage_frontmatter` est masqué ;
+- `headless-guarded` / `headless-filesystem` : la famille gouvernée Frontmatter
+  n’existe pas, donc `obsidian_manage_frontmatter` reste le fallback borné.
+
+`full` n’applique jamais cette suppression au profit de la voie canonique.
+
+## Sélection en stdio
+
+Le comportement historique reste `full` lorsqu’aucun profil n’est indiqué.
+
+Via argument :
+
+```bash
+node dist/stdio-proxy.js --tool-profile standard
+```
+
+ou via environnement :
+
+```bash
+MCP_TOOL_PROFILE=standard node dist/stdio-proxy.js
+```
+
+`--tool-profile` gagne sur `MCP_TOOL_PROFILE`. Un profil inconnu ou un argument
+répété échoue fermé au lieu de retomber sur `full`.
+
+Le proxy stdio applique le profil **par client**. S’il doit lancer le backend
+HTTP partagé, il lance explicitement ce backend en `full`, puis filtre sa propre
+surface client. Un agent `standard` et un agent `tasks` peuvent donc partager le
+même backend sans modifier mutuellement leur liste d’outils.
+
+Un outil masqué est aussi refusé lorsqu’il est appelé directement ; le profilage
+n’est pas un simple filtrage cosmétique de `tools/list`.
+
+## Sélection en HTTP
+
+Le serveur HTTP expose des routes de profil explicites et immuables :
+
+```text
+/mcp              → full (alias de compatibilité 2.x)
+/mcp/standard     → standard
+/mcp/authoring    → authoring
+/mcp/tasks        → tasks
+/mcp/full         → full
+```
+
+Une session est liée à son identité vérifiée **et** à son profil d’outils. Un
+`sessionId` créé sur `/mcp/standard` ne peut pas être réutilisé sur `/mcp/full`,
+y compris pour les requêtes de session POST, GET ou DELETE. Un mismatch de
+profil échoue fermé avec la même posture générique « session invalide/expirée »
+qu’un mismatch d’identité.
+
+Le profil est porté par un contexte de requête uniquement pendant la création du
+`McpServer` propre à la session. Il n’est jamais écrit dans un état global du
+processus ; plusieurs profils peuvent donc coexister simultanément sur le même
+backend HTTP.
+
+## Filtrage supplémentaire côté client
+
+Les profils serveur sont le contrat portable. Un client peut ensuite réduire
+encore cette surface avec ses propres fonctions, mais il ne devient jamais la
+source de vérité.
+
+Mécanismes complémentaires possibles :
+
+- Codex : `enabled_tools` / `disabled_tools` ;
+- Gemini CLI : `includeTools` / `excludeTools` ;
+- Claude Code : tool search / chargement différé des outils MCP ;
+- Hermes Agent : filtres include/exclude ;
+- OpenClaw : `toolFilter.include` / `toolFilter.exclude`.
+
+Ces mécanismes diffèrent selon les harnesses et peuvent évoluer séparément.
+Choisir d’abord le profil Optimike adapté, puis n’utiliser le filtrage client que
+s’il apporte un gain local supplémentaire.
+
+## Exemples clients
+
+### Codex — stdio
+
+```toml
+[mcp_servers.optimike]
+command = "node"
+args = [
+  "/chemin/vers/optimike-obsidian-mcp/dist/stdio-proxy.js",
+  "--tool-profile",
+  "standard"
+]
+
+[mcp_servers.optimike.env]
+OBSIDIAN_VAULT = "/chemin/vers/coffre"
+OBSIDIAN_RUNTIME_MODE = "live"
+OBSIDIAN_BASE_URL = "http://127.0.0.1:27123"
+OBSIDIAN_API_KEY = "<cle-local-rest-api>"
+```
+
+`enabled_tools` peut éventuellement réduire encore la surface déjà sélectionnée
+côté serveur.
+
+### Gemini CLI — stdio
+
+```json
+{
+  "mcpServers": {
+    "optimike": {
+      "command": "node",
+      "args": [
+        "/chemin/vers/optimike-obsidian-mcp/dist/stdio-proxy.js",
+        "--tool-profile",
+        "standard"
+      ],
+      "env": {
+        "OBSIDIAN_VAULT": "/chemin/vers/coffre",
+        "OBSIDIAN_RUNTIME_MODE": "live"
+      }
+    }
+  }
+}
+```
+
+`includeTools` / `excludeTools` restent des réductions optionnelles côté client.
+
+### Claude Code — stdio
+
+```bash
+claude mcp add optimike -- node \
+  /chemin/vers/optimike-obsidian-mcp/dist/stdio-proxy.js \
+  --tool-profile standard
+```
+
+Claude Code peut aussi différer le chargement de grandes surfaces MCP via son
+tool search. Le profil serveur reste utile : il définit la surface publique
+canonique avant toute stratégie propre au client.
+
+### Client HTTP générique
+
+Le profil vit directement dans l’URL MCP :
+
+```text
+http://127.0.0.1:3010/mcp/standard
+```
+
+Aucun header propriétaire n’est nécessaire.
+
+## Règle de compatibilité 2.x
+
+Pendant la branche 2.x :
+
+- aucun profil indiqué → `full` ;
+- `/mcp` historique → comportement `/mcp/full` ;
+- les alias de recherche sémantique restent accessibles uniquement dans `full` ;
+- les profils modernes sont opt-in et peuvent être recommandés pour les nouvelles installations ;
+- la visibilité ne relâche jamais les contrôles runtime/écriture/sécurité existants.
+
+Une future version majeure pourra faire de `standard` le défaut et retirer les
+alias dépréciés après une fenêtre de migration explicite.

--- a/docs/tool-surface-profiles.md
+++ b/docs/tool-surface-profiles.md
@@ -1,0 +1,225 @@
+# Tool Surface Profiles
+
+French version: [tool-surface-profiles.fr.md](tool-surface-profiles.fr.md)
+
+Optimike Obsidian MCP separates two contracts that solve different problems:
+
+- the **runtime mode** controls what the backend can safely provide (`live`, `hybrid`, `headless-readonly`, `headless-guarded`, `headless-filesystem`);
+- the **tool profile** controls what a connected MCP client sees before `tools/list`.
+
+Tool profiles reduce model-facing ambiguity and schema volume. They are not an
+authorization boundary. Runtime, write-mode, bridge, scope, confirmation and CAS
+checks remain authoritative even when a tool is visible.
+
+## Public profiles
+
+| Profile | Intended use | Full live/hybrid surface |
+| --- | --- | ---: |
+| `standard` | General vault reading/search plus common note/frontmatter authoring | 19 tools |
+| `authoring` | `standard` plus tags, Bases authoring/formulas and Canvas authoring | 31 tools |
+| `tasks` | Markdown Tasks compatibility plus the complete Operon MCP contract | 31 tools |
+| `full` | 2.x compatibility/admin surface for the active runtime | 72 tools |
+
+Counts are projections of the current registry and may be lower in a more
+restricted runtime. For example, `standard` exposes 9 tools in
+`headless-readonly`. `full` means "all tools registered by the active runtime",
+not "always 72 tools".
+
+The canonical registry covers 76 unique cross-runtime names because four tools
+exist only in `headless-filesystem` and therefore are not part of the 72-tool
+live/hybrid surface.
+
+## Semantic search naming
+
+Modern profiles expose one public semantic-search name:
+
+```text
+smart_semantic_search
+```
+
+The historical aliases `smart_search` and `smart-search` are hidden from
+`standard`, `authoring` and `tasks`. They remain visible only in `full` during
+the 2.x line for compatibility with existing public clients. Physical removal
+of the aliases is reserved for 3.0 unless a breaking minor is explicitly chosen
+later.
+
+Agent routing and new integrations must use `smart_semantic_search` only.
+
+## Governed families
+
+A governed family is exposed atomically. If a profile exposes one of these
+families, all four lifecycle tools remain present together:
+
+```text
+plan → apply → status → recover
+```
+
+This applies to governed note replacement, Frontmatter projection, Base formula
+patching and Canvas graph patching.
+
+A profile never changes the sealed plan content, journal, idempotency key,
+backend binding or recovery authority. A durable plan created in one session may
+be inspected/recovered from another session or profile that exposes the same
+family, subject to the normal runtime and write/security policies.
+
+## Canonical versus direct fallback
+
+Modern profiles may hide a direct compatibility tool when the corresponding
+governed family is actually registered. They keep the direct tool when the
+runtime has no governed equivalent.
+
+Current example:
+
+- `live` / live-capable `hybrid`: expose the complete
+  `obsidian_frontmatter_patch_*` family and hide `obsidian_manage_frontmatter`;
+- `headless-guarded` / `headless-filesystem`: the governed Frontmatter family is
+  unavailable, so `obsidian_manage_frontmatter` remains the bounded fallback.
+
+`full` never applies this canonical-preference suppression.
+
+## Stdio selection
+
+The historical behavior stays `full` when no profile is specified.
+
+Use either:
+
+```bash
+node dist/stdio-proxy.js --tool-profile standard
+```
+
+or:
+
+```bash
+MCP_TOOL_PROFILE=standard node dist/stdio-proxy.js
+```
+
+`--tool-profile` takes precedence over `MCP_TOOL_PROFILE`. Unknown or repeated
+CLI profile values fail closed instead of falling back to `full`.
+
+The stdio proxy applies the profile **per client**. If it needs to start the
+shared HTTP backend, that backend is explicitly started as `full`; the proxy
+then filters its own client surface. This allows, for example, a `standard`
+agent and a `tasks` agent to share one backend without changing each other's
+tool list.
+
+Hidden proxy tools are also rejected when called directly; filtering is not
+only cosmetic `tools/list` rewriting.
+
+## HTTP selection
+
+The HTTP server exposes explicit immutable profile routes:
+
+```text
+/mcp              → full (2.x compatibility alias)
+/mcp/standard     → standard
+/mcp/authoring    → authoring
+/mcp/tasks        → tasks
+/mcp/full         → full
+```
+
+A session is bound to both its verified identity and its tool profile. A
+`sessionId` created on `/mcp/standard` cannot be reused on `/mcp/full`, including
+for POST, GET or DELETE session traffic. Profile mismatch fails closed with the
+same generic invalid/expired-session posture as an identity mismatch.
+
+The profile is request-scoped while the per-session `McpServer` instance is
+created. It is never written to process-global state, so several profiles can
+coexist concurrently on one HTTP backend.
+
+## Client-assisted filtering
+
+Server profiles are the portable contract. A client may reduce that surface
+again using its own feature, but the client never becomes the source of truth.
+
+Examples of optional client-side mechanisms:
+
+- Codex: `enabled_tools` / `disabled_tools`;
+- Gemini CLI: `includeTools` / `excludeTools`;
+- Claude Code: tool search / deferred MCP tool loading;
+- Hermes Agent: include/exclude filters;
+- OpenClaw: `toolFilter.include` / `toolFilter.exclude`.
+
+These mechanisms differ between harnesses and can change independently. Prefer
+selecting the appropriate Optimike server profile first, then use client-side
+filtering only when it provides an additional local benefit.
+
+## Client examples
+
+### Codex — stdio
+
+```toml
+[mcp_servers.optimike]
+command = "node"
+args = [
+  "/path/to/optimike-obsidian-mcp/dist/stdio-proxy.js",
+  "--tool-profile",
+  "standard"
+]
+
+[mcp_servers.optimike.env]
+OBSIDIAN_VAULT = "/path/to/vault"
+OBSIDIAN_RUNTIME_MODE = "live"
+OBSIDIAN_BASE_URL = "http://127.0.0.1:27123"
+OBSIDIAN_API_KEY = "<local-rest-api-key>"
+```
+
+Codex `enabled_tools` can optionally narrow the already-selected server profile
+further.
+
+### Gemini CLI — stdio
+
+```json
+{
+  "mcpServers": {
+    "optimike": {
+      "command": "node",
+      "args": [
+        "/path/to/optimike-obsidian-mcp/dist/stdio-proxy.js",
+        "--tool-profile",
+        "standard"
+      ],
+      "env": {
+        "OBSIDIAN_VAULT": "/path/to/vault",
+        "OBSIDIAN_RUNTIME_MODE": "live"
+      }
+    }
+  }
+}
+```
+
+Gemini `includeTools` / `excludeTools` remain optional client-side reductions.
+
+### Claude Code — stdio
+
+```bash
+claude mcp add optimike -- node \
+  /path/to/optimike-obsidian-mcp/dist/stdio-proxy.js \
+  --tool-profile standard
+```
+
+Claude Code may additionally defer large MCP tool surfaces through its tool
+search behavior. The server profile is still useful because it defines the
+canonical public surface before any client-specific loading strategy.
+
+### Generic HTTP client
+
+Use the profile in the MCP URL itself:
+
+```text
+http://127.0.0.1:3010/mcp/standard
+```
+
+No proprietary request header is required.
+
+## Compatibility rule for 2.x
+
+During the 2.x line:
+
+- no profile specified → `full`;
+- legacy `/mcp` → `/mcp/full` behavior;
+- semantic-search aliases remain available in `full` only;
+- modern profiles are opt-in and may be recommended for new installations;
+- visibility never weakens existing runtime/write/security checks.
+
+A future major release may make `standard` the default and remove deprecated
+alias names after an explicit migration window.

--- a/docs/tool-surface-profiles.md
+++ b/docs/tool-surface-profiles.md
@@ -2,86 +2,66 @@
 
 French version: [tool-surface-profiles.fr.md](tool-surface-profiles.fr.md)
 
-Optimike Obsidian MCP separates two contracts that solve different problems:
+Optimike Obsidian MCP separates two independent contracts:
 
 - the **runtime mode** controls what the backend can safely provide (`live`, `hybrid`, `headless-readonly`, `headless-guarded`, `headless-filesystem`);
-- the **tool profile** controls what a connected MCP client sees before `tools/list`.
+- the **tool profile** controls what one MCP client can discover and call before `tools/list`.
 
-Tool profiles reduce model-facing ambiguity and schema volume. They are not an
-authorization boundary. Runtime, write-mode, bridge, scope, confirmation and CAS
-checks remain authoritative even when a tool is visible.
+Profiles reduce schema volume and routing ambiguity. They are not an authorization boundary: runtime mode, write policy, bridge grants, scopes, confirmations, CAS, idempotency and recovery rules remain authoritative.
 
 ## Public profiles
 
 | Profile | Intended use | Full live/hybrid surface |
 | --- | --- | ---: |
-| `standard` | General vault reading/search plus common note/frontmatter authoring | 19 tools |
-| `authoring` | `standard` plus tags, Bases authoring/formulas and Canvas authoring | 31 tools |
-| `tasks` | Markdown Tasks compatibility plus the complete Operon MCP contract | 31 tools |
+| `standard` | General vault reading/search and common governed note/Frontmatter work | 19 tools |
+| `authoring` | `standard` plus tags, bounded Bases authoring/formulas and Canvas authoring | 30 tools |
+| `tasks` | Markdown Tasks compatibility plus the complete live Operon MCP contract | 31 tools |
 | `full` | 2.x compatibility/admin surface for the active runtime | 72 tools |
 
-Counts are projections of the current registry and may be lower in a more
-restricted runtime. For example, `standard` exposes 9 tools in
-`headless-readonly`. `full` means "all tools registered by the active runtime",
-not "always 72 tools".
+Counts are projections of the current registry and may be lower in restricted runtimes. `full` means all tools structurally registered by the active runtime, not always 72 tools. The canonical registry covers 76 unique names across all runtimes because four names exist only in `headless-filesystem`.
 
-The canonical registry covers 76 unique cross-runtime names because four tools
-exist only in `headless-filesystem` and therefore are not part of the 72-tool
-live/hybrid surface.
+## Compatibility-only names
 
-## Semantic search naming
+Modern profiles intentionally exclude compatibility choices that would add ambiguity without adding a distinct normal-use capability.
 
-Modern profiles expose one public semantic-search name:
+Semantic search uses one canonical name:
 
 ```text
 smart_semantic_search
 ```
 
-The historical aliases `smart_search` and `smart-search` are hidden from
-`standard`, `authoring` and `tasks`. They remain visible only in `full` during
-the 2.x line for compatibility with existing public clients. Physical removal
-of the aliases is reserved for 3.0 unless a breaking minor is explicitly chosen
-later.
+The historical `smart_search` and `smart-search` aliases remain physically registered and visible only in `full` during the 2.x line. Their physical removal is reserved for 3.0.
 
-Agent routing and new integrations must use `smart_semantic_search` only.
+`bases_upsert_config` is also `full`-only in 2.10. It replaces a whole Base configuration and is not a fallback for governed formula editing. `authoring` keeps `bases_create`, `bases_upsert_rows` and the complete governed `bases_formula_patch_*` family.
 
 ## Governed families
 
-A governed family is exposed atomically. If a profile exposes one of these
-families, all four lifecycle tools remain present together:
+A governed family is exposed atomically:
 
 ```text
 plan → apply → status → recover
 ```
 
-This applies to governed note replacement, Frontmatter projection, Base formula
-patching and Canvas graph patching.
+This applies to governed Note replacement, Frontmatter projection, Base formula patching and Canvas graph patching.
 
-A profile never changes the sealed plan content, journal, idempotency key,
-backend binding or recovery authority. A durable plan created in one session may
-be inspected/recovered from another session or profile that exposes the same
-family, subject to the normal runtime and write/security policies.
+Registration is incremental inside the server factory. Until all four members of a governed family have registered, the whole governed family remains hidden and any legitimate direct fallback stays visible. When the fourth member arrives, the quartet becomes visible in one reconciliation and the superseded direct fallback is hidden. Static profile compilation remains strict and rejects an actually incomplete family.
+
+A profile never changes sealed plan content, journals, idempotency, backend binding or recovery authority. A durable plan created in one session can be inspected or recovered from another session or profile exposing the same complete family, subject to the normal runtime and write/security policies.
 
 ## Canonical versus direct fallback
 
-Modern profiles may hide a direct compatibility tool when the corresponding
-governed family is actually registered. They keep the direct tool when the
-runtime has no governed equivalent.
+Modern profiles hide a direct tool only when the corresponding governed family is structurally complete in the current runtime.
 
-Current example:
+- `live` / live-capable `hybrid`: expose `obsidian_frontmatter_patch_{plan,apply,status,recover}` and hide `obsidian_manage_frontmatter`;
+- `headless-guarded` / `headless-filesystem`: the governed Frontmatter family is absent, so `obsidian_manage_frontmatter` remains the bounded fallback;
+- `headless-filesystem` Canvas direct helpers remain available only where the governed live Canvas family is structurally absent;
+- `bases_upsert_config` is never a formula fallback and remains `full`-only.
 
-- `live` / live-capable `hybrid`: expose the complete
-  `obsidian_frontmatter_patch_*` family and hide `obsidian_manage_frontmatter`;
-- `headless-guarded` / `headless-filesystem`: the governed Frontmatter family is
-  unavailable, so `obsidian_manage_frontmatter` remains the bounded fallback.
-
-`full` never applies this canonical-preference suppression.
+`full` never applies canonical-preference suppression.
 
 ## Stdio selection
 
-The historical behavior stays `full` when no profile is specified.
-
-Use either:
+The 2.x compatibility default is `full` when no profile is specified.
 
 ```bash
 node dist/stdio-proxy.js --tool-profile standard
@@ -93,21 +73,13 @@ or:
 MCP_TOOL_PROFILE=standard node dist/stdio-proxy.js
 ```
 
-`--tool-profile` takes precedence over `MCP_TOOL_PROFILE`. Unknown or repeated
-CLI profile values fail closed instead of falling back to `full`.
+`--tool-profile` takes precedence over `MCP_TOOL_PROFILE`. Unknown, empty or repeated CLI values fail closed rather than falling back to `full`.
 
-The stdio proxy applies the profile **per client**. If it needs to start the
-shared HTTP backend, that backend is explicitly started as `full`; the proxy
-then filters its own client surface. This allows, for example, a `standard`
-agent and a `tasks` agent to share one backend without changing each other's
-tool list.
-
-Hidden proxy tools are also rejected when called directly; filtering is not
-only cosmetic `tools/list` rewriting.
+The stdio proxy applies the profile per client. When it starts the shared HTTP backend, it explicitly starts that backend as `full`, then filters both `tools/list` and `tools/call` for its client. A hidden local proxy tool is therefore also uncallable by name.
 
 ## HTTP selection
 
-The HTTP server exposes explicit immutable profile routes:
+The server exposes immutable profile routes:
 
 ```text
 /mcp              → full (2.x compatibility alias)
@@ -117,109 +89,31 @@ The HTTP server exposes explicit immutable profile routes:
 /mcp/full         → full
 ```
 
-A session is bound to both its verified identity and its tool profile. A
-`sessionId` created on `/mcp/standard` cannot be reused on `/mcp/full`, including
-for POST, GET or DELETE session traffic. Profile mismatch fails closed with the
-same generic invalid/expired-session posture as an identity mismatch.
+A session is bound to both verified identity and tool profile. A `sessionId` created on `/mcp/standard` cannot be reused on `/mcp/full`, including POST, GET or DELETE session traffic. Profile mismatch uses the same generic invalid/expired-session posture as an identity mismatch.
 
-The profile is request-scoped while the per-session `McpServer` instance is
-created. It is never written to process-global state, so several profiles can
-coexist concurrently on one HTTP backend.
+The profile context is request-scoped only while that session's `McpServer` instance is created; several profiles can coexist on one shared backend without process-global profile mutation.
 
-## Client-assisted filtering
+## Server-owned, client-assisted
 
-Server profiles are the portable contract. A client may reduce that surface
-again using its own feature, but the client never becomes the source of truth.
+The server profile is the portable contract. A client can reduce or defer that surface further, but never becomes Optimike's source of truth.
 
-Examples of optional client-side mechanisms:
+Optional client mechanisms include:
 
 - Codex: `enabled_tools` / `disabled_tools`;
 - Gemini CLI: `includeTools` / `excludeTools`;
-- Claude Code: tool search / deferred MCP tool loading;
+- Claude Code: tool search / deferred MCP loading;
 - Hermes Agent: include/exclude filters;
 - OpenClaw: `toolFilter.include` / `toolFilter.exclude`.
 
-These mechanisms differ between harnesses and can change independently. Prefer
-selecting the appropriate Optimike server profile first, then use client-side
-filtering only when it provides an additional local benefit.
+These client features can evolve independently. Select an Optimike profile first; use client filtering only as an additional optimization.
 
-## Client examples
+## Migration boundary
 
-### Codex — stdio
+2.10 remains SemVer-compatible with 2.x:
 
-```toml
-[mcp_servers.optimike]
-command = "node"
-args = [
-  "/path/to/optimike-obsidian-mcp/dist/stdio-proxy.js",
-  "--tool-profile",
-  "standard"
-]
+- unspecified stdio profile → `full`;
+- legacy `/mcp` → `/mcp/full`;
+- `smart_search` and `smart-search` remain available in `full`;
+- full active-runtime surfaces remain compatible with 2.9.
 
-[mcp_servers.optimike.env]
-OBSIDIAN_VAULT = "/path/to/vault"
-OBSIDIAN_RUNTIME_MODE = "live"
-OBSIDIAN_BASE_URL = "http://127.0.0.1:27123"
-OBSIDIAN_API_KEY = "<local-rest-api-key>"
-```
-
-Codex `enabled_tools` can optionally narrow the already-selected server profile
-further.
-
-### Gemini CLI — stdio
-
-```json
-{
-  "mcpServers": {
-    "optimike": {
-      "command": "node",
-      "args": [
-        "/path/to/optimike-obsidian-mcp/dist/stdio-proxy.js",
-        "--tool-profile",
-        "standard"
-      ],
-      "env": {
-        "OBSIDIAN_VAULT": "/path/to/vault",
-        "OBSIDIAN_RUNTIME_MODE": "live"
-      }
-    }
-  }
-}
-```
-
-Gemini `includeTools` / `excludeTools` remain optional client-side reductions.
-
-### Claude Code — stdio
-
-```bash
-claude mcp add optimike -- node \
-  /path/to/optimike-obsidian-mcp/dist/stdio-proxy.js \
-  --tool-profile standard
-```
-
-Claude Code may additionally defer large MCP tool surfaces through its tool
-search behavior. The server profile is still useful because it defines the
-canonical public surface before any client-specific loading strategy.
-
-### Generic HTTP client
-
-Use the profile in the MCP URL itself:
-
-```text
-http://127.0.0.1:3010/mcp/standard
-```
-
-No proprietary request header is required.
-
-## Compatibility rule for 2.x
-
-During the 2.x line:
-
-- no profile specified → `full`;
-- legacy `/mcp` → `/mcp/full` behavior;
-- semantic-search aliases remain available in `full` only;
-- modern profiles are opt-in and may be recommended for new installations;
-- visibility never weakens existing runtime/write/security checks.
-
-A future major release may make `standard` the default and remove deprecated
-alias names after an explicit migration window.
+3.0 is the planned breaking boundary for physical semantic-alias removal and for making the modern default surface `standard` after 2.10 has passed its release gates.

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,0 +1,80 @@
+# Tool-routing evaluations
+
+`tool-routing-corpus.json` is the initial discriminating corpus for measuring the
+impact of tool-surface profiles. It is intentionally harness-neutral: the same
+cases can be executed through Codex, Gemini CLI, Claude Code, Hermes Agent,
+OpenClaw or another MCP client.
+
+The corpus does **not** contain fabricated model scores. CI validates the cases,
+tool names and profile contracts only. Real model runs are recorded separately
+as JSONL traces and scored with `scripts/score-tool-routing-evals.mjs`.
+
+## Initial experiment
+
+Start with the 31 cases in the corpus. For stochastic harnesses, use three runs
+per case when practical.
+
+Compare at minimum:
+
+```text
+full vs recommended profile
+```
+
+For general authoring cases that means `full` vs `standard` or `authoring`; for
+Operon cases it means `full` vs `tasks`.
+
+Only expand toward 50-100 prompts if the initial sample shows a material signal
+or an uncovered ambiguity.
+
+## Result format
+
+Write one JSON object per run:
+
+```json
+{"id":"semantic-canonical","harness":"codex","surface":"standard","toolsCalled":["smart_semantic_search"],"success":true,"latencyMs":842,"inputTokens":2100}
+```
+
+Required fields:
+
+- `id`: case ID from the corpus;
+- `toolsCalled`: ordered MCP tool names used during the run;
+- `success`: whether the requested task completed successfully.
+
+Recommended fields:
+
+- `harness`: client/harness name and optionally model/version;
+- `surface`: `full`, `standard`, `authoring`, or `tasks`;
+- `latencyMs`;
+- `inputTokens`.
+
+Then run:
+
+```bash
+node scripts/score-tool-routing-evals.mjs results.jsonl
+```
+
+The scorer reports:
+
+- first-tool accuracy;
+- success rate;
+- forbidden-tool rate;
+- mean tool-call count;
+- mean unnecessary calls;
+- p50/p95 latency when supplied;
+- mean input tokens when supplied.
+
+`forbiddenTools` encode routing mistakes relevant to each case, such as choosing
+a semantic-search compatibility alias, calling apply before status after an
+uncertain outcome, or using a direct path when the case explicitly asks for the
+governed guarantee.
+
+## Interpretation
+
+The 15-25 tool target for a normal surface is a hypothesis, not a pass/fail
+criterion. Evaluate the tradeoff against routing accuracy, coverage, latency and
+token cost. A smaller surface that hides a required capability is a regression.
+
+Do not compare clients only by raw latency: clients differ in tool discovery,
+deferred loading, model choice and transport behavior. The load-bearing signal
+is whether the profile improves tool choice without reducing successful task
+coverage.

--- a/evals/tool-routing-corpus.json
+++ b/evals/tool-routing-corpus.json
@@ -1,0 +1,201 @@
+[
+  {
+    "id": "semantic-canonical",
+    "prompt": "Find notes semantically related to antifragility even if they do not contain that exact word.",
+    "recommendedProfile": "standard",
+    "acceptableFirstTools": ["smart_semantic_search"],
+    "forbiddenTools": ["smart_search", "smart-search"]
+  },
+  {
+    "id": "read-exact-note",
+    "prompt": "Read Atlas/Antifragility.md and summarize only what is written there.",
+    "recommendedProfile": "standard",
+    "acceptableFirstTools": ["obsidian_read_note"]
+  },
+  {
+    "id": "list-folder",
+    "prompt": "List the notes under Efforts/Projets without modifying anything.",
+    "recommendedProfile": "standard",
+    "acceptableFirstTools": ["obsidian_list_notes"]
+  },
+  {
+    "id": "exact-text-search",
+    "prompt": "Find every note containing the exact phrase North Star.",
+    "recommendedProfile": "standard",
+    "acceptableFirstTools": ["obsidian_global_search"]
+  },
+  {
+    "id": "validate-markdown",
+    "prompt": "Validate this generated Obsidian Markdown before I write it.",
+    "recommendedProfile": "standard",
+    "acceptableFirstTools": ["obsidian_validate_format"]
+  },
+  {
+    "id": "runtime-status",
+    "prompt": "Tell me whether the Optimike MCP runtime is healthy and whether the cache is degraded.",
+    "recommendedProfile": "standard",
+    "acceptableFirstTools": ["obsidian_runtime_status"],
+    "forbiddenTools": ["obsidian_runtime_maintenance"]
+  },
+  {
+    "id": "append-note-direct",
+    "prompt": "Append this one paragraph to an existing note without replacing the rest of the file.",
+    "recommendedProfile": "standard",
+    "acceptableFirstTools": ["obsidian_update_note"],
+    "forbiddenTools": ["obsidian_note_replace_plan"]
+  },
+  {
+    "id": "search-replace-direct",
+    "prompt": "Replace one exact typo occurrence in a note and leave everything else byte-for-byte alone.",
+    "recommendedProfile": "standard",
+    "acceptableFirstTools": ["obsidian_search_replace"]
+  },
+  {
+    "id": "replace-complete-note",
+    "prompt": "Replace the complete contents of an existing Markdown note with this final version using the safest durable path.",
+    "recommendedProfile": "standard",
+    "acceptableFirstTools": ["obsidian_note_replace_plan"],
+    "forbiddenTools": ["obsidian_update_note"]
+  },
+  {
+    "id": "lost-response-note-status",
+    "prompt": "The note replacement apply timed out after dispatch. Check what happened without issuing another mutation.",
+    "recommendedProfile": "standard",
+    "acceptableFirstTools": ["obsidian_note_replace_status"],
+    "forbiddenTools": ["obsidian_note_replace_apply", "obsidian_update_note"]
+  },
+  {
+    "id": "recover-note-plan",
+    "prompt": "The durable receipt says the same note replacement plan is recoverable. Resume that exact plan.",
+    "recommendedProfile": "standard",
+    "acceptableFirstTools": ["obsidian_note_replace_recover"]
+  },
+  {
+    "id": "frontmatter-live-governed",
+    "prompt": "Set statut: actif on this existing note while preserving the original Markdown source as much as possible.",
+    "recommendedProfile": "standard",
+    "acceptableFirstTools": ["obsidian_frontmatter_patch_plan"],
+    "forbiddenTools": ["obsidian_manage_frontmatter"]
+  },
+  {
+    "id": "frontmatter-status",
+    "prompt": "A governed frontmatter apply returned no response. Inspect the durable state first.",
+    "recommendedProfile": "standard",
+    "acceptableFirstTools": ["obsidian_frontmatter_patch_status"]
+  },
+  {
+    "id": "bases-list",
+    "prompt": "List the Bases available in this vault.",
+    "recommendedProfile": "standard",
+    "acceptableFirstTools": ["bases_list"]
+  },
+  {
+    "id": "bases-schema",
+    "prompt": "Inspect the schema of Projects.base before changing anything.",
+    "recommendedProfile": "standard",
+    "acceptableFirstTools": ["bases_get_schema"]
+  },
+  {
+    "id": "bases-query",
+    "prompt": "Query Projects.base for active projects without modifying the Base.",
+    "recommendedProfile": "standard",
+    "acceptableFirstTools": ["bases_query"]
+  },
+  {
+    "id": "bases-formula-governed",
+    "prompt": "Change the named priority_label formula in an existing Base using the recoverable governed path.",
+    "recommendedProfile": "authoring",
+    "acceptableFirstTools": ["bases_formula_patch_plan"],
+    "forbiddenTools": ["bases_upsert_config"]
+  },
+  {
+    "id": "canvas-existing-governed",
+    "prompt": "Move an existing Canvas node and connect it to another node using the recoverable live path.",
+    "recommendedProfile": "authoring",
+    "acceptableFirstTools": ["obsidian_canvas_patch_plan"],
+    "forbiddenTools": ["obsidian_manage_canvas"]
+  },
+  {
+    "id": "tags-authoring",
+    "prompt": "Add one Obsidian tag to this note using the MCP tag operation.",
+    "recommendedProfile": "authoring",
+    "acceptableFirstTools": ["obsidian_manage_tags"]
+  },
+  {
+    "id": "markdown-tasks-query",
+    "prompt": "Find unchecked legacy Obsidian Tasks-compatible Markdown checkboxes in the daily notes.",
+    "recommendedProfile": "tasks",
+    "acceptableFirstTools": ["query_tasks", "list_all_tasks"],
+    "forbiddenTools": ["operon_query_tasks"]
+  },
+  {
+    "id": "operon-list",
+    "prompt": "List my Operon-managed tasks with their stable task identities.",
+    "recommendedProfile": "tasks",
+    "acceptableFirstTools": ["operon_list_tasks", "operon_query_tasks"],
+    "forbiddenTools": ["list_all_tasks"]
+  },
+  {
+    "id": "operon-find-ranked",
+    "prompt": "Find the most relevant Operon project tasks for Nexus, ranked rather than broad text-matched.",
+    "recommendedProfile": "tasks",
+    "acceptableFirstTools": ["operon_find_tasks"]
+  },
+  {
+    "id": "operon-resolve-before-write",
+    "prompt": "I only know the note name and a fuzzy task phrase. Resolve the exact Operon task before changing it.",
+    "recommendedProfile": "tasks",
+    "acceptableFirstTools": ["operon_resolve_task"]
+  },
+  {
+    "id": "operon-context",
+    "prompt": "Build the bounded Operon project context for this exact task before planning the work.",
+    "recommendedProfile": "tasks",
+    "acceptableFirstTools": ["operon_build_context"]
+  },
+  {
+    "id": "operon-create",
+    "prompt": "Create a new Operon task in the target project with dry-run first.",
+    "recommendedProfile": "tasks",
+    "acceptableFirstTools": ["operon_create_task"]
+  },
+  {
+    "id": "operon-transition",
+    "prompt": "Transition this exact Operon task to the configured done status using its revision guard.",
+    "recommendedProfile": "tasks",
+    "acceptableFirstTools": ["operon_transition_task"]
+  },
+  {
+    "id": "operon-recovery-status",
+    "prompt": "An Operon mutation outcome is uncertain. List the pending durable recovery references before doing anything else.",
+    "recommendedProfile": "tasks",
+    "acceptableFirstTools": ["operon_list_pending_recoveries"],
+    "forbiddenTools": ["operon_recover_mutation"]
+  },
+  {
+    "id": "operon-recover",
+    "prompt": "Recover this exact uncertain Operon mutation using the provided recoveryRef and original idempotency key.",
+    "recommendedProfile": "tasks",
+    "acceptableFirstTools": ["operon_recover_mutation"]
+  },
+  {
+    "id": "external-read-full",
+    "prompt": "Read the configured external text file by logical root ID and relative path.",
+    "recommendedProfile": "full",
+    "acceptableFirstTools": ["external_read", "external_stat"]
+  },
+  {
+    "id": "external-move-full",
+    "prompt": "Move this configured external file while preserving exact ElySIA references; inventory and plan before applying.",
+    "recommendedProfile": "full",
+    "acceptableFirstTools": ["external_references_scan", "external_move_plan"],
+    "forbiddenTools": ["external_move_apply"]
+  },
+  {
+    "id": "no-tool-explanation",
+    "prompt": "Explain the difference between a governed plan and a direct write without inspecting my vault.",
+    "recommendedProfile": "standard",
+    "acceptableFirstTools": [],
+    "expectNoTool": true
+  }
+]

--- a/evals/tool-routing-corpus.json
+++ b/evals/tool-routing-corpus.json
@@ -55,6 +55,7 @@
     "prompt": "Replace the complete contents of an existing Markdown note with this final version using the safest durable path.",
     "recommendedProfile": "standard",
     "acceptableFirstTools": ["obsidian_note_replace_plan"],
+    "minimumToolCalls": 2,
     "forbiddenTools": ["obsidian_update_note"]
   },
   {
@@ -75,6 +76,7 @@
     "prompt": "Set statut: actif on this existing note while preserving the original Markdown source as much as possible.",
     "recommendedProfile": "standard",
     "acceptableFirstTools": ["obsidian_frontmatter_patch_plan"],
+    "minimumToolCalls": 2,
     "forbiddenTools": ["obsidian_manage_frontmatter"]
   },
   {
@@ -106,6 +108,7 @@
     "prompt": "Change the named priority_label formula in an existing Base using the recoverable governed path.",
     "recommendedProfile": "authoring",
     "acceptableFirstTools": ["bases_formula_patch_plan"],
+    "minimumToolCalls": 2,
     "forbiddenTools": ["bases_upsert_config"]
   },
   {
@@ -113,6 +116,7 @@
     "prompt": "Move an existing Canvas node and connect it to another node using the recoverable live path.",
     "recommendedProfile": "authoring",
     "acceptableFirstTools": ["obsidian_canvas_patch_plan"],
+    "minimumToolCalls": 2,
     "forbiddenTools": ["obsidian_manage_canvas"]
   },
   {
@@ -157,7 +161,8 @@
     "id": "operon-create",
     "prompt": "Create a new Operon task in the target project with dry-run first.",
     "recommendedProfile": "tasks",
-    "acceptableFirstTools": ["operon_create_task"]
+    "acceptableFirstTools": ["operon_create_task"],
+    "minimumToolCalls": 2
   },
   {
     "id": "operon-transition",
@@ -189,7 +194,7 @@
     "prompt": "Move this configured external file while preserving exact ElySIA references; inventory and plan before applying.",
     "recommendedProfile": "full",
     "acceptableFirstTools": ["external_references_scan", "external_move_plan"],
-    "forbiddenTools": ["external_move_apply"]
+    "minimumToolCalls": 3
   },
   {
     "id": "no-tool-explanation",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,8 @@
     "SECURITY.fr.md",
     "docs/README.md",
     "docs/README.fr.md",
+    "docs/tool-surface-profiles.md",
+    "docs/tool-surface-profiles.fr.md",
     "docs/obsidian_mcp_tools_spec.md",
     "docs/governed-note-replacement.fr.md",
     "docs/governed-note-replacement.md",

--- a/scripts/modified-time-canary-helpers.mjs
+++ b/scripts/modified-time-canary-helpers.mjs
@@ -2,6 +2,28 @@ const LOCAL_DATETIME =
   /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/u;
 const PLUGIN_FRESHNESS_MARGIN_MS = 5_200;
 
+export function supportsModifiedTimeSettlementBridgeVersion(value) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/u.exec(value ?? "");
+  if (!match) return false;
+  const [, major, minor] = match.map(Number);
+  return major > 0 || (major === 0 && minor >= 3);
+}
+
+export function assertAtomicNoteCanaryDateIsolation(status) {
+  const integrations =
+    status?.settlement?.modifiedTimeFrontmatter?.integrations ?? [];
+  if (!Array.isArray(integrations) || integrations.length === 0) return;
+  const active = integrations
+    .map(
+      (integration) =>
+        `${integration?.pluginId ?? "unknown"}:${integration?.propertyName ?? "unknown"}`,
+    )
+    .join(", ");
+  throw new Error(
+    `The byte-exact atomic-note canary requires active modified-time integrations to be disabled before mutation (${active}). Run smoke:modified-time-settlement-live separately with the integration enabled.`,
+  );
+}
+
 export function isSafeModifiedTimePropertyName(value) {
   return (
     typeof value === "string" &&

--- a/scripts/modified-time-canary-helpers.mjs
+++ b/scripts/modified-time-canary-helpers.mjs
@@ -10,17 +10,40 @@ export function supportsModifiedTimeSettlementBridgeVersion(value) {
 }
 
 export function assertAtomicNoteCanaryDateIsolation(status) {
-  const integrations =
+  const settlementIntegrations =
     status?.settlement?.modifiedTimeFrontmatter?.integrations ?? [];
-  if (!Array.isArray(integrations) || integrations.length === 0) return;
-  const active = integrations
-    .map(
-      (integration) =>
+  const protection = status?.protection?.frontmatterDateProperties;
+  const protectionIntegrations = protection?.integrations ?? [];
+  const unsupportedIntegrations = protection?.unsupportedIntegrations ?? [];
+  const active = new Set();
+
+  if (Array.isArray(settlementIntegrations)) {
+    for (const integration of settlementIntegrations) {
+      active.add(
         `${integration?.pluginId ?? "unknown"}:${integration?.propertyName ?? "unknown"}`,
-    )
-    .join(", ");
+      );
+    }
+  }
+  if (Array.isArray(protectionIntegrations)) {
+    for (const integration of protectionIntegrations) {
+      if (integration?.modifiedPropertyName) {
+        active.add(
+          `${integration?.pluginId ?? "unknown"}:${integration.modifiedPropertyName}`,
+        );
+      }
+    }
+  }
+  if (Array.isArray(unsupportedIntegrations)) {
+    for (const integration of unsupportedIntegrations) {
+      if (integration?.activeRoles?.includes("modified")) {
+        active.add(`${integration?.pluginId ?? "unknown"}:modified(unsupported)`);
+      }
+    }
+  }
+
+  if (active.size === 0) return;
   throw new Error(
-    `The byte-exact atomic-note canary requires active modified-time integrations to be disabled before mutation (${active}). Run smoke:modified-time-settlement-live separately with the integration enabled.`,
+    `The byte-exact atomic-note canary requires active modified-time integrations to be disabled before mutation (${[...active].join(", ")}). Run smoke:modified-time-settlement-live separately with the integration enabled.`,
   );
 }
 

--- a/scripts/score-tool-routing-evals.mjs
+++ b/scripts/score-tool-routing-evals.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+
+function usage() {
+  console.error(
+    "Usage: node scripts/score-tool-routing-evals.mjs <results.jsonl> [corpus.json]",
+  );
+  process.exit(2);
+}
+
+const resultsPath = process.argv[2];
+if (!resultsPath) usage();
+const corpusPath = process.argv[3] ?? new URL(
+  "../evals/tool-routing-corpus.json",
+  import.meta.url,
+);
+
+const corpus = JSON.parse(fs.readFileSync(corpusPath, "utf8"));
+const cases = new Map(corpus.map((item) => [item.id, item]));
+const lines = fs
+  .readFileSync(resultsPath, "utf8")
+  .split(/\r?\n/u)
+  .map((line) => line.trim())
+  .filter(Boolean);
+
+if (lines.length === 0) {
+  throw new Error("Routing eval results file is empty.");
+}
+
+const rows = lines.map((line, index) => {
+  let parsed;
+  try {
+    parsed = JSON.parse(line);
+  } catch (error) {
+    throw new Error(`Invalid JSONL at line ${index + 1}: ${error.message}`);
+  }
+  const testCase = cases.get(parsed.id);
+  if (!testCase) throw new Error(`Unknown eval id at line ${index + 1}: ${parsed.id}`);
+  if (!Array.isArray(parsed.toolsCalled)) {
+    throw new Error(`toolsCalled must be an array for ${parsed.id}`);
+  }
+
+  const firstTool = parsed.toolsCalled[0] ?? null;
+  const expectNoTool = testCase.expectNoTool === true;
+  const firstCorrect = expectNoTool
+    ? firstTool === null
+    : testCase.acceptableFirstTools.includes(firstTool);
+  const forbidden = new Set(testCase.forbiddenTools ?? []);
+  const forbiddenCalls = parsed.toolsCalled.filter((name) => forbidden.has(name));
+  const unnecessaryCalls = Math.max(
+    0,
+    parsed.toolsCalled.length - (expectNoTool ? 0 : 1),
+  );
+
+  return {
+    ...parsed,
+    harness: parsed.harness ?? "unknown",
+    surface: parsed.surface ?? "unknown",
+    success: parsed.success === true,
+    firstTool,
+    firstCorrect,
+    forbiddenCalls,
+    unnecessaryCalls,
+  };
+});
+
+function mean(values) {
+  return values.length
+    ? values.reduce((sum, value) => sum + value, 0) / values.length
+    : null;
+}
+
+function percentile(values, percentileValue) {
+  if (!values.length) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil((percentileValue / 100) * sorted.length) - 1),
+  );
+  return sorted[index];
+}
+
+const groups = new Map();
+for (const row of rows) {
+  const key = `${row.harness}::${row.surface}`;
+  const group = groups.get(key) ?? [];
+  group.push(row);
+  groups.set(key, group);
+}
+
+const summaries = [];
+for (const [key, group] of groups) {
+  const [harness, surface] = key.split("::");
+  const latencies = group
+    .map((row) => row.latencyMs)
+    .filter((value) => Number.isFinite(value));
+  const inputTokens = group
+    .map((row) => row.inputTokens)
+    .filter((value) => Number.isFinite(value));
+  const forbiddenCount = group.filter((row) => row.forbiddenCalls.length > 0).length;
+
+  summaries.push({
+    harness,
+    surface,
+    runs: group.length,
+    firstToolAccuracy: group.filter((row) => row.firstCorrect).length / group.length,
+    successRate: group.filter((row) => row.success).length / group.length,
+    forbiddenToolRate: forbiddenCount / group.length,
+    meanToolCalls: mean(group.map((row) => row.toolsCalled.length)),
+    meanUnnecessaryCalls: mean(group.map((row) => row.unnecessaryCalls)),
+    latencyMsP50: percentile(latencies, 50),
+    latencyMsP95: percentile(latencies, 95),
+    meanInputTokens: mean(inputTokens),
+  });
+}
+
+summaries.sort((a, b) =>
+  `${a.harness}::${a.surface}`.localeCompare(`${b.harness}::${b.surface}`),
+);
+
+console.log(JSON.stringify({
+  corpusCases: corpus.length,
+  evaluatedRuns: rows.length,
+  summaries,
+  failures: rows
+    .filter((row) => !row.firstCorrect || row.forbiddenCalls.length > 0 || !row.success)
+    .map((row) => ({
+      id: row.id,
+      harness: row.harness,
+      surface: row.surface,
+      firstTool: row.firstTool,
+      forbiddenCalls: row.forbiddenCalls,
+      success: row.success,
+    })),
+}, null, 2));

--- a/scripts/score-tool-routing-evals.mjs
+++ b/scripts/score-tool-routing-evals.mjs
@@ -48,9 +48,10 @@ const rows = lines.map((line, index) => {
     : testCase.acceptableFirstTools.includes(firstTool);
   const forbidden = new Set(testCase.forbiddenTools ?? []);
   const forbiddenCalls = parsed.toolsCalled.filter((name) => forbidden.has(name));
+  const minimumToolCalls = testCase.minimumToolCalls ?? (expectNoTool ? 0 : 1);
   const unnecessaryCalls = Math.max(
     0,
-    parsed.toolsCalled.length - (expectNoTool ? 0 : 1),
+    parsed.toolsCalled.length - minimumToolCalls,
   );
 
   return {
@@ -61,6 +62,7 @@ const rows = lines.map((line, index) => {
     firstTool,
     firstCorrect,
     forbiddenCalls,
+    minimumToolCalls,
     unnecessaryCalls,
   };
 });

--- a/scripts/smoke-atomic-note-mcp-live.mjs
+++ b/scripts/smoke-atomic-note-mcp-live.mjs
@@ -13,6 +13,7 @@ import os from "node:os";
 import path from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { assertAtomicNoteCanaryDateIsolation } from "./modified-time-canary-helpers.mjs";
 
 const canaryPath = process.env.OBSIDIAN_ATOMIC_NOTE_CANARY_PATH?.trim();
 const confirmation = process.env.OBSIDIAN_ATOMIC_NOTE_CANARY_CONFIRM?.trim();
@@ -148,6 +149,7 @@ async function proveDirectBridgeCasConflict() {
     target: canaryPath,
   });
   const status = await rest.getAtomicWriteStatus(context);
+  assertAtomicNoteCanaryDateIsolation(status);
   const before = await rest.readAtomicWriteNote(
     { contractVersion: 1, path: canaryPath },
     context,

--- a/scripts/smoke-modified-time-settlement-live.mjs
+++ b/scripts/smoke-modified-time-settlement-live.mjs
@@ -19,6 +19,7 @@ import {
   isSafeModifiedTimePropertyName,
   modifiedTimeFrontmatterPropertyValue,
   nextRepresentableTimestampReadyAt,
+  supportsModifiedTimeSettlementBridgeVersion,
 } from "./modified-time-canary-helpers.mjs";
 
 const canaryPath = process.env.OBSIDIAN_MODIFIED_TIME_CANARY_PATH?.trim();
@@ -607,7 +608,11 @@ try {
   );
   const status = await atomicStatus();
   assert.equal(status.plugin.id, "obsidian-atomic-write-bridge");
-  assert.equal(status.plugin.version, "0.3.0");
+  assert.equal(
+    supportsModifiedTimeSettlementBridgeVersion(status.plugin.version),
+    true,
+    `Atomic Write Bridge ${status.plugin.version} does not support bounded modified-time settlement; version 0.3.0 or later is required.`,
+  );
   assert.equal(status.backend.writeEnabled, true);
   assert.match(status.backend.bindingFingerprint, /^[a-f0-9]{64}$/u);
   originalBindingFingerprint = status.backend.bindingFingerprint;

--- a/scripts/test-governed-note-doc-contract.mjs
+++ b/scripts/test-governed-note-doc-contract.mjs
@@ -264,6 +264,28 @@ assert.match(
 );
 assert.match(operations, /smoke:modified-time-settlement-live/);
 assert.match(operationsFr, /smoke:modified-time-settlement-live/);
+assert.match(operations, /byte-exact canary refuses before mutation/i);
+assert.match(
+  operationsFr,
+  /restauration octet pour octet refuse avant mutation/i,
+);
+assert.match(
+  operations,
+  /the two\s+gates deliberately prove separate contracts/i,
+);
+assert.match(
+  operationsFr,
+  /deux gates prouvent volontairement\s+deux contrats distincts/i,
+);
+assert.match(liveCanary, /assertAtomicNoteCanaryDateIsolation\(status\)/);
+assert.match(
+  modifiedTimeCanaryHelpers,
+  /requires active modified-time integrations to be disabled before mutation/,
+);
+assert.match(
+  modifiedTimeLiveCanary,
+  /supportsModifiedTimeSettlementBridgeVersion\(status\.plugin\.version\)/,
+);
 assert.match(modifiedTimeLiveCanary, /os\.tmpdir\(\)/);
 assert.match(modifiedTimeLiveCanary, /dropNextCasResponse/);
 assert.match(modifiedTimeLiveCanary, /dropNextReconciliationRead/);

--- a/scripts/test-http-tool-profiles.mjs
+++ b/scripts/test-http-tool-profiles.mjs
@@ -143,7 +143,9 @@ async function waitForHealth(baseUrl, child) {
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
     if (child.exitCode !== null) {
-      throw new Error(`backend exited early with ${child.exitCode}`);
+      throw new Error(
+        `backend exited early with ${child.exitCode}: ${child.stderrText}`,
+      );
     }
     try {
       const response = await fetch(new URL("/healthz", baseUrl));
@@ -151,7 +153,7 @@ async function waitForHealth(baseUrl, child) {
     } catch {}
     await sleep(100);
   }
-  throw new Error("backend did not become healthy");
+  throw new Error(`backend did not become healthy: ${child.stderrText}`);
 }
 
 function toolNames(payload) {
@@ -162,7 +164,7 @@ function toolNames(payload) {
 
 const vault = await createVault();
 const port = await unusedPort();
-const logDir = path.join(vault, "logs");
+const logDir = path.join(process.cwd(), ".tmp", `http-tool-profiles-${port}`);
 await mkdir(logDir, { recursive: true });
 const child = spawn(process.execPath, ["dist/index.js"], {
   cwd: process.cwd(),
@@ -196,7 +198,11 @@ const child = spawn(process.execPath, ["dist/index.js"], {
     // A process-wide env profile must not change the public /mcp legacy contract.
     MCP_TOOL_PROFILE: "tasks",
   },
-  stdio: "ignore",
+  stdio: ["ignore", "pipe", "pipe"],
+});
+child.stderrText = "";
+child.stderr?.on("data", (chunk) => {
+  child.stderrText += String(chunk);
 });
 
 try {
@@ -310,5 +316,6 @@ try {
     sleep(5_000),
   ]);
   if (child.exitCode === null) child.kill("SIGKILL");
+  await rm(logDir, { recursive: true, force: true });
   await rm(vault, { recursive: true, force: true });
 }

--- a/scripts/test-http-tool-profiles.mjs
+++ b/scripts/test-http-tool-profiles.mjs
@@ -236,7 +236,7 @@ try {
   const legacyNames = toolNames(legacyList);
 
   assert.equal(standardNames.length, 9);
-  assert.equal(tasksNames.length, 31);
+  assert.equal(tasksNames.length, 14);
   assert.equal(fullNames.length, 48);
   assert.deepEqual(legacyNames, fullNames, "/mcp must remain an alias of /mcp/full");
 
@@ -249,10 +249,32 @@ try {
   assert.ok(fullNames.includes("smart_search"));
   assert.ok(fullNames.includes("smart-search"));
 
-  assert.ok(!standardNames.includes("operon_create_task"));
-  assert.ok(tasksNames.includes("operon_create_task"));
-  assert.ok(tasksNames.includes("operon_list_pending_recoveries"));
-  assert.ok(tasksNames.includes("operon_recover_mutation"));
+  for (const snapshotSafe of [
+    "operon_status",
+    "operon_get_configuration",
+    "operon_list_tasks",
+    "operon_get_task",
+    "operon_query_tasks",
+    "operon_validate",
+  ]) {
+    assert.ok(tasksNames.includes(snapshotSafe), `headless tasks lost ${snapshotSafe}`);
+  }
+  for (const liveOnly of [
+    "operon_query_saved_filter",
+    "operon_get_diagnostics",
+    "operon_find_tasks",
+    "operon_resolve_task",
+    "operon_get_relationships",
+    "operon_build_context",
+    "operon_get_timer_state",
+    "operon_create_task",
+    "operon_update_task",
+    "operon_transition_task",
+    "operon_list_pending_recoveries",
+    "operon_recover_mutation",
+  ]) {
+    assert.ok(!tasksNames.includes(liveOnly), `headless tasks exposed ${liveOnly}`);
+  }
 
   const mismatchPost = await protocolRequest({
     baseUrl,
@@ -304,7 +326,7 @@ try {
   assert.match(await unknown.text(), /unknown_tool_profile/);
 
   console.log(
-    "PASS: HTTP profile endpoints coexist on one backend, /mcp stays full, semantic aliases are modern-profile-hidden, and sessions cannot cross profile routes",
+    "PASS: HTTP profile endpoints coexist, /mcp stays full, headless tasks are snapshot-safe, semantic aliases stay modern-profile-hidden, and sessions cannot cross profile routes",
   );
 } finally {
   if (child.exitCode === null) child.kill("SIGTERM");

--- a/scripts/test-http-tool-profiles.mjs
+++ b/scripts/test-http-tool-profiles.mjs
@@ -1,0 +1,314 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:net";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { SignJWT } from "jose";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+const jwtSecret =
+  "tool-profile-http-test-secret-must-be-at-least-32-characters";
+
+async function unusedPort() {
+  const server = createServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.ok(address && typeof address === "object");
+  const port = address.port;
+  await new Promise((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+  return port;
+}
+
+async function signToken(clientId) {
+  return new SignJWT({ cid: clientId, scp: ["vault:read"] })
+    .setProtectedHeader({ alg: "HS256" })
+    .setSubject(clientId)
+    .setIssuedAt()
+    .setExpirationTime("10m")
+    .sign(new TextEncoder().encode(jwtSecret));
+}
+
+function parseProtocolPayload(text, contentType, expectedId) {
+  if (contentType.includes("application/json")) return JSON.parse(text);
+  const candidates = [];
+  for (const block of text.split(/\r?\n\r?\n/u)) {
+    const data = block
+      .split(/\r?\n/u)
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trim())
+      .join("\n");
+    if (!data || data === "[DONE]") continue;
+    try {
+      candidates.push(JSON.parse(data));
+    } catch {}
+  }
+  return (
+    candidates.find((candidate) => candidate?.id === expectedId) ??
+    candidates[0] ??
+    null
+  );
+}
+
+async function protocolRequest({
+  baseUrl,
+  profilePath,
+  token,
+  body,
+  sessionId,
+  method = "POST",
+}) {
+  const response = await fetch(new URL(profilePath, baseUrl), {
+    method,
+    headers: {
+      Accept: "application/json, text/event-stream",
+      ...(method === "POST" ? { "Content-Type": "application/json" } : {}),
+      Authorization: `Bearer ${token}`,
+      ...(sessionId ? { "Mcp-Session-Id": sessionId } : {}),
+    },
+    body: method === "POST" ? JSON.stringify(body) : undefined,
+  });
+  const text = await response.text();
+  const payload = text
+    ? parseProtocolPayload(
+        text,
+        response.headers.get("content-type") ?? "",
+        body?.id,
+      )
+    : null;
+  return { response, payload, text };
+}
+
+async function initializeClient(baseUrl, profilePath, token, name, id) {
+  const initialized = await protocolRequest({
+    baseUrl,
+    profilePath,
+    token,
+    body: {
+      jsonrpc: "2.0",
+      id,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name, version: "0" },
+      },
+    },
+  });
+  assert.equal(initialized.response.status, 200, initialized.text);
+  const sessionId = initialized.response.headers.get("mcp-session-id");
+  assert.ok(sessionId, `${name} did not receive an MCP session id`);
+
+  const notification = await protocolRequest({
+    baseUrl,
+    profilePath,
+    token,
+    sessionId,
+    body: { jsonrpc: "2.0", method: "notifications/initialized" },
+  });
+  assert.ok(
+    [200, 202, 204].includes(notification.response.status),
+    `${name} initialization notification failed: ${notification.response.status} ${notification.text}`,
+  );
+  return { token, sessionId, profilePath, nextId: id + 100 };
+}
+
+async function call(client, baseUrl, method, params = {}) {
+  const id = client.nextId++;
+  const result = await protocolRequest({
+    baseUrl,
+    profilePath: client.profilePath,
+    token: client.token,
+    sessionId: client.sessionId,
+    body: { jsonrpc: "2.0", id, method, params },
+  });
+  assert.equal(result.response.status, 200, result.text);
+  assert.equal(result.payload?.error, undefined, result.text);
+  return result.payload;
+}
+
+async function createVault() {
+  const vault = await mkdtemp(path.join(os.tmpdir(), "optimike-http-profiles-"));
+  await mkdir(path.join(vault, ".obsidian", "optimike-mcp"), { recursive: true });
+  await writeFile(path.join(vault, "Root.md"), "# HTTP profile smoke\n", "utf8");
+  return vault;
+}
+
+async function waitForHealth(baseUrl, child) {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`backend exited early with ${child.exitCode}`);
+    }
+    try {
+      const response = await fetch(new URL("/healthz", baseUrl));
+      if (response.ok) return;
+    } catch {}
+    await sleep(100);
+  }
+  throw new Error("backend did not become healthy");
+}
+
+function toolNames(payload) {
+  return (payload?.result?.tools ?? [])
+    .map((tool) => tool.name)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+const vault = await createVault();
+const port = await unusedPort();
+const logDir = path.join(vault, "logs");
+await mkdir(logDir, { recursive: true });
+const child = spawn(process.execPath, ["dist/index.js"], {
+  cwd: process.cwd(),
+  env: {
+    ...process.env,
+    NODE_ENV: "test",
+    OBSIDIAN_RUNTIME_MODE: "headless-readonly",
+    OBSIDIAN_VAULT: vault,
+    OBSIDIAN_CACHE_SOURCE: "filesystem",
+    OBSIDIAN_SHARED_CACHE_DB_PATH: path.join(
+      vault,
+      ".obsidian",
+      "optimike-mcp",
+      "shared-cache.sqlite",
+    ),
+    OBSIDIAN_ENABLE_CACHE: "true",
+    SEMANTIC_SEARCH_PREWARM: "false",
+    MCP_WRITE_MODE: "readonly",
+    MCP_TRANSPORT_TYPE: "http",
+    MCP_HTTP_HOST: "127.0.0.1",
+    MCP_HTTP_PORT: String(port),
+    MCP_HTTP_PORT_RETRIES: "0",
+    MCP_LOG_LEVEL: "error",
+    LOGS_DIR: logDir,
+    MCP_AUTH_MODE: "jwt",
+    MCP_AUTH_SECRET_KEY: jwtSecret,
+    MCP_ALLOWED_ORIGINS: "",
+    MCP_HTTP_LOOPBACK_POLICY: "shared",
+    MCP_HTTP_PREAUTH_RATE_LIMIT_MAX: "1000",
+    MCP_HTTP_IDENTITY_RATE_LIMIT_MAX: "1000",
+    // A process-wide env profile must not change the public /mcp legacy contract.
+    MCP_TOOL_PROFILE: "tasks",
+  },
+  stdio: "ignore",
+});
+
+try {
+  const baseUrl = new URL(`http://127.0.0.1:${port}`);
+  await waitForHealth(baseUrl, child);
+
+  const [standardToken, tasksToken, fullToken, legacyToken] = await Promise.all([
+    signToken("profile-standard"),
+    signToken("profile-tasks"),
+    signToken("profile-full"),
+    signToken("profile-legacy"),
+  ]);
+
+  const [standard, tasks, full, legacy] = await Promise.all([
+    initializeClient(baseUrl, "/mcp/standard", standardToken, "standard", 1),
+    initializeClient(baseUrl, "/mcp/tasks", tasksToken, "tasks", 2),
+    initializeClient(baseUrl, "/mcp/full", fullToken, "full", 3),
+    initializeClient(baseUrl, "/mcp", legacyToken, "legacy", 4),
+  ]);
+
+  const [standardList, tasksList, fullList, legacyList] = await Promise.all([
+    call(standard, baseUrl, "tools/list"),
+    call(tasks, baseUrl, "tools/list"),
+    call(full, baseUrl, "tools/list"),
+    call(legacy, baseUrl, "tools/list"),
+  ]);
+
+  const standardNames = toolNames(standardList);
+  const tasksNames = toolNames(tasksList);
+  const fullNames = toolNames(fullList);
+  const legacyNames = toolNames(legacyList);
+
+  assert.equal(standardNames.length, 9);
+  assert.equal(tasksNames.length, 31);
+  assert.equal(fullNames.length, 48);
+  assert.deepEqual(legacyNames, fullNames, "/mcp must remain an alias of /mcp/full");
+
+  for (const modern of [standardNames, tasksNames]) {
+    assert.ok(modern.includes("smart_semantic_search"));
+    assert.ok(!modern.includes("smart_search"));
+    assert.ok(!modern.includes("smart-search"));
+  }
+  assert.ok(fullNames.includes("smart_semantic_search"));
+  assert.ok(fullNames.includes("smart_search"));
+  assert.ok(fullNames.includes("smart-search"));
+
+  assert.ok(!standardNames.includes("operon_create_task"));
+  assert.ok(tasksNames.includes("operon_create_task"));
+  assert.ok(tasksNames.includes("operon_list_pending_recoveries"));
+  assert.ok(tasksNames.includes("operon_recover_mutation"));
+
+  const mismatchPost = await protocolRequest({
+    baseUrl,
+    profilePath: "/mcp/full",
+    token: standard.token,
+    sessionId: standard.sessionId,
+    body: {
+      jsonrpc: "2.0",
+      id: 999,
+      method: "tools/list",
+      params: {},
+    },
+  });
+  assert.equal(mismatchPost.response.status, 404, mismatchPost.text);
+  assert.match(mismatchPost.text, /Invalid or expired session ID/);
+
+  const mismatchDelete = await protocolRequest({
+    baseUrl,
+    profilePath: "/mcp/full",
+    token: standard.token,
+    sessionId: standard.sessionId,
+    method: "DELETE",
+  });
+  assert.equal(mismatchDelete.response.status, 404, mismatchDelete.text);
+  assert.match(mismatchDelete.text, /Invalid or expired session ID/);
+
+  const sameSessionStillWorks = await call(standard, baseUrl, "tools/list");
+  assert.equal(toolNames(sameSessionStillWorks).length, 9);
+
+  const unknown = await fetch(new URL("/mcp/nope", baseUrl), {
+    method: "POST",
+    headers: {
+      Accept: "application/json, text/event-stream",
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${standardToken}`,
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1000,
+      method: "initialize",
+      params: {
+        protocolVersion: "2025-03-26",
+        capabilities: {},
+        clientInfo: { name: "unknown", version: "0" },
+      },
+    }),
+  });
+  assert.equal(unknown.status, 404);
+  assert.match(await unknown.text(), /unknown_tool_profile/);
+
+  console.log(
+    "PASS: HTTP profile endpoints coexist on one backend, /mcp stays full, semantic aliases are modern-profile-hidden, and sessions cannot cross profile routes",
+  );
+} finally {
+  if (child.exitCode === null) child.kill("SIGTERM");
+  await Promise.race([
+    new Promise((resolve) => {
+      if (child.exitCode !== null) return resolve();
+      child.once("exit", resolve);
+    }),
+    sleep(5_000),
+  ]);
+  if (child.exitCode === null) child.kill("SIGKILL");
+  await rm(vault, { recursive: true, force: true });
+}

--- a/scripts/test-modified-time-canary-helpers.mjs
+++ b/scripts/test-modified-time-canary-helpers.mjs
@@ -36,6 +36,66 @@ assert.throws(
     }),
   /requires active modified-time integrations to be disabled before mutation \(frontmatter-date-manager:modification\)/u,
 );
+assert.throws(
+  () =>
+    assertAtomicNoteCanaryDateIsolation({
+      settlement: { modifiedTimeFrontmatter: { integrations: [] } },
+      protection: {
+        frontmatterDateProperties: {
+          integrations: [
+            {
+              pluginId: "frontmatter-date-manager",
+              modifiedPropertyName: "last modified",
+            },
+          ],
+          unsupportedIntegrations: [],
+        },
+      },
+    }),
+  /frontmatter-date-manager:last modified/u,
+  "a protection-only modified role must block the byte-exact canary",
+);
+assert.throws(
+  () =>
+    assertAtomicNoteCanaryDateIsolation({
+      settlement: { modifiedTimeFrontmatter: { integrations: [] } },
+      protection: {
+        frontmatterDateProperties: {
+          integrations: [],
+          unsupportedIntegrations: [
+            {
+              pluginId: "frontmatter-date-manager",
+              activeRoles: ["created", "modified"],
+            },
+          ],
+        },
+      },
+    }),
+  /frontmatter-date-manager:modified\(unsupported\)/u,
+  "an unrepresentable active modified role must block before mutation",
+);
+assert.doesNotThrow(() =>
+  assertAtomicNoteCanaryDateIsolation({
+    settlement: { modifiedTimeFrontmatter: { integrations: [] } },
+    protection: {
+      frontmatterDateProperties: {
+        integrations: [
+          {
+            pluginId: "frontmatter-date-manager",
+            createdPropertyName: "creation",
+            viewedPropertyName: "viewed",
+          },
+        ],
+        unsupportedIntegrations: [
+          {
+            pluginId: "frontmatter-date-manager",
+            activeRoles: ["created", "viewed"],
+          },
+        ],
+      },
+    },
+  }),
+);
 
 assert.equal(isSafeModifiedTimePropertyName("modification"), true);
 assert.equal(isSafeModifiedTimePropertyName("last modified"), true);

--- a/scripts/test-modified-time-canary-helpers.mjs
+++ b/scripts/test-modified-time-canary-helpers.mjs
@@ -1,9 +1,41 @@
 import assert from "node:assert/strict";
 import {
+  assertAtomicNoteCanaryDateIsolation,
   isSafeModifiedTimePropertyName,
   modifiedTimeFrontmatterPropertyValue,
   nextRepresentableTimestampReadyAt,
+  supportsModifiedTimeSettlementBridgeVersion,
 } from "./modified-time-canary-helpers.mjs";
+
+assert.equal(supportsModifiedTimeSettlementBridgeVersion("0.3.0"), true);
+assert.equal(supportsModifiedTimeSettlementBridgeVersion("0.4.0"), true);
+assert.equal(supportsModifiedTimeSettlementBridgeVersion("1.0.0"), true);
+assert.equal(supportsModifiedTimeSettlementBridgeVersion("0.2.9"), false);
+assert.equal(
+  supportsModifiedTimeSettlementBridgeVersion("0.3.0-beta.1"),
+  false,
+);
+assert.equal(supportsModifiedTimeSettlementBridgeVersion("invalid"), false);
+
+assert.doesNotThrow(() =>
+  assertAtomicNoteCanaryDateIsolation({ settlement: undefined }),
+);
+assert.throws(
+  () =>
+    assertAtomicNoteCanaryDateIsolation({
+      settlement: {
+        modifiedTimeFrontmatter: {
+          integrations: [
+            {
+              pluginId: "frontmatter-date-manager",
+              propertyName: "modification",
+            },
+          ],
+        },
+      },
+    }),
+  /requires active modified-time integrations to be disabled before mutation \(frontmatter-date-manager:modification\)/u,
+);
 
 assert.equal(isSafeModifiedTimePropertyName("modification"), true);
 assert.equal(isSafeModifiedTimePropertyName("last modified"), true);

--- a/scripts/test-package-contents.mjs
+++ b/scripts/test-package-contents.mjs
@@ -28,6 +28,8 @@ const requiredFiles = [
   "SECURITY.fr.md",
   "docs/README.md",
   "docs/README.fr.md",
+  "docs/tool-surface-profiles.md",
+  "docs/tool-surface-profiles.fr.md",
   "docs/governed-note-replacement.md",
   "docs/governed-note-replacement.fr.md",
   "docs/governed-frontmatter-p1.md",
@@ -58,7 +60,7 @@ const requiredFiles = [
 const missing = requiredFiles.filter((file) => !files.has(file));
 if (missing.length > 0) {
   throw new Error(
-    `Package is missing installable Bridge artifacts: ${missing.join(", ")}`,
+    `Package is missing required runnable, documentation or Bridge artifacts: ${missing.join(", ")}`,
   );
 }
 

--- a/scripts/test-tool-profile-runtime.mjs
+++ b/scripts/test-tool-profile-runtime.mjs
@@ -83,7 +83,14 @@ try {
 
       let rejected = false;
       try {
-        await client.callTool({ name: "smart_search", arguments: { query: "x" } });
+        const hidden = await client.callTool({
+          name: "smart_search",
+          arguments: { query: "x" },
+        });
+        const text = hidden.content.map((item) => item.text ?? "").join("\n");
+        rejected =
+          hidden.isError === true &&
+          /disabled|not found|not exposed/iu.test(text);
       } catch (error) {
         rejected = /disabled|not found|not exposed/iu.test(
           error instanceof Error ? error.message : String(error),

--- a/scripts/test-tool-profile-runtime.mjs
+++ b/scripts/test-tool-profile-runtime.mjs
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+async function createVault() {
+  const root = await mkdtemp(path.join(os.tmpdir(), "optimike-profile-runtime-"));
+  await mkdir(path.join(root, ".obsidian", "optimike-mcp"), { recursive: true });
+  await writeFile(path.join(root, "Root.md"), "# profile runtime\n", "utf8");
+  return root;
+}
+
+function envFor(vault, extra = {}) {
+  return {
+    ...process.env,
+    OBSIDIAN_RUNTIME_MODE: "headless-readonly",
+    OBSIDIAN_VAULT: vault,
+    OBSIDIAN_CACHE_SOURCE: "filesystem",
+    OBSIDIAN_SHARED_CACHE_DB_PATH: path.join(
+      vault,
+      ".obsidian",
+      "optimike-mcp",
+      "shared-cache.sqlite",
+    ),
+    OBSIDIAN_ENABLE_CACHE: "true",
+    SEMANTIC_SEARCH_PREWARM: "false",
+    MCP_TRANSPORT_TYPE: "stdio",
+    MCP_LOG_LEVEL: "error",
+    MCP_WRITE_MODE: "readonly",
+    ...extra,
+  };
+}
+
+async function openClient({ vault, args = [], env = {} }) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["dist/index.js", ...args],
+    cwd: process.cwd(),
+    env: envFor(vault, env),
+  });
+  const client = new Client({ name: "tool-profile-runtime-test", version: "0" });
+  await client.connect(transport);
+  return { client, transport };
+}
+
+async function listedNames(client) {
+  const result = await client.listTools();
+  return result.tools.map((tool) => tool.name).sort((a, b) => a.localeCompare(b));
+}
+
+const vault = await createVault();
+try {
+  {
+    const { client } = await openClient({ vault });
+    try {
+      const names = await listedNames(client);
+      assert.equal(names.length, 48, "2.x default must remain full");
+      assert.ok(names.includes("smart_semantic_search"));
+      assert.ok(names.includes("smart_search"));
+      assert.ok(names.includes("smart-search"));
+      assert.ok(names.includes("external_read"));
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  }
+
+  {
+    const { client } = await openClient({
+      vault,
+      args: ["--tool-profile", "standard"],
+      env: { MCP_TOOL_PROFILE: "full" },
+    });
+    try {
+      const names = await listedNames(client);
+      assert.equal(names.length, 9, "CLI standard must override env full");
+      assert.ok(names.includes("smart_semantic_search"));
+      assert.ok(!names.includes("smart_search"));
+      assert.ok(!names.includes("smart-search"));
+      assert.ok(!names.includes("external_read"));
+      assert.ok(!names.includes("obsidian_runtime_maintenance"));
+
+      let rejected = false;
+      try {
+        await client.callTool({ name: "smart_search", arguments: { query: "x" } });
+      } catch (error) {
+        rejected = /disabled|not found|not exposed/iu.test(
+          error instanceof Error ? error.message : String(error),
+        );
+      }
+      assert.ok(rejected, "a hidden direct-server tool call must be rejected");
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  }
+
+  {
+    const previous = process.env.MCP_TOOL_PROFILE;
+    process.env.MCP_TOOL_PROFILE = "full";
+    const { applyToolProfileCliOverride } = await import(
+      "../dist/config/toolProfileCli.js"
+    );
+    applyToolProfileCliOverride(["--tool-profile=tasks"]);
+    assert.equal(process.env.MCP_TOOL_PROFILE, "tasks");
+    assert.throws(
+      () => applyToolProfileCliOverride(["--tool-profile", "nope"]),
+      /Unknown MCP tool profile/,
+    );
+    assert.throws(
+      () => applyToolProfileCliOverride(["--tool-profile"]),
+      /requires one of/,
+    );
+    if (previous === undefined) delete process.env.MCP_TOOL_PROFILE;
+    else process.env.MCP_TOOL_PROFILE = previous;
+  }
+
+  console.log("PASS: direct server profiles preserve full compatibility and hide semantic aliases in standard");
+} finally {
+  await rm(vault, { recursive: true, force: true });
+}

--- a/scripts/test-tool-profile-runtime.mjs
+++ b/scripts/test-tool-profile-runtime.mjs
@@ -3,7 +3,9 @@ import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { installToolProfileRegistrationGate } from "../dist/mcp-server/toolProfileRuntime.js";
 
 async function createVault() {
   const root = await mkdtemp(path.join(os.tmpdir(), "optimike-profile-runtime-"));
@@ -48,6 +50,69 @@ async function openClient({ vault, args = [], env = {} }) {
 async function listedNames(client) {
   const result = await client.listTools();
   return result.tools.map((tool) => tool.name).sort((a, b) => a.localeCompare(b));
+}
+
+function registerSyntheticTool(server, name) {
+  return server.tool(
+    name,
+    `synthetic ${name}`,
+    {},
+    {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+    async () => ({
+      content: [{ type: "text", text: "ok" }],
+      isError: false,
+    }),
+  );
+}
+
+// The registration gate is installed before production tools register. A
+// governed quartet therefore arrives one member at a time. Partial lifecycles
+// must stay hidden rather than throwing or exposing an incomplete contract.
+{
+  const server = new McpServer(
+    { name: "profile-registration-order-test", version: "0" },
+    { capabilities: { tools: { listChanged: true } } },
+  );
+  installToolProfileRegistrationGate(server, "standard");
+
+  const direct = registerSyntheticTool(server, "obsidian_manage_frontmatter");
+  assert.equal(direct.enabled, true);
+
+  const governedNames = [
+    "obsidian_frontmatter_patch_plan",
+    "obsidian_frontmatter_patch_apply",
+    "obsidian_frontmatter_patch_status",
+    "obsidian_frontmatter_patch_recover",
+  ];
+  const governedHandles = [];
+  for (const [index, name] of governedNames.entries()) {
+    governedHandles.push(registerSyntheticTool(server, name));
+    if (index < governedNames.length - 1) {
+      assert.equal(
+        direct.enabled,
+        true,
+        "direct fallback must remain available while governed registration is partial",
+      );
+      assert.ok(
+        governedHandles.every((handle) => handle.enabled === false),
+        "partial governed lifecycle must remain fully hidden",
+      );
+    }
+  }
+  assert.equal(
+    direct.enabled,
+    false,
+    "direct fallback must be hidden once the complete governed family exists",
+  );
+  assert.ok(
+    governedHandles.every((handle) => handle.enabled === true),
+    "complete governed lifecycle must become visible atomically",
+  );
 }
 
 const vault = await createVault();
@@ -122,7 +187,7 @@ try {
     else process.env.MCP_TOOL_PROFILE = previous;
   }
 
-  console.log("PASS: direct server profiles preserve full compatibility and hide semantic aliases in standard");
+  console.log("PASS: direct server profiles preserve full compatibility, governed registration is atomic, and semantic aliases stay hidden in standard");
 } finally {
   await rm(vault, { recursive: true, force: true });
 }

--- a/scripts/test-tool-profile-stdio-proxy.mjs
+++ b/scripts/test-tool-profile-stdio-proxy.mjs
@@ -1,0 +1,146 @@
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createServer } from "node:http";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+async function freePort() {
+  const server = createServer();
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  const port = address.port;
+  await new Promise((resolve) => server.close(resolve));
+  return port;
+}
+
+async function createVault() {
+  const root = await mkdtemp(path.join(os.tmpdir(), "optimike-profile-proxy-"));
+  await mkdir(path.join(root, ".obsidian", "optimike-mcp"), { recursive: true });
+  await writeFile(path.join(root, "Root.md"), "# profile proxy\n", "utf8");
+  return root;
+}
+
+function sharedEnv(vault, port, extra = {}) {
+  return {
+    ...process.env,
+    OBSIDIAN_RUNTIME_MODE: "headless-readonly",
+    OBSIDIAN_VAULT: vault,
+    OBSIDIAN_CACHE_SOURCE: "filesystem",
+    OBSIDIAN_SHARED_CACHE_DB_PATH: path.join(
+      vault,
+      ".obsidian",
+      "optimike-mcp",
+      "shared-cache.sqlite",
+    ),
+    OBSIDIAN_ENABLE_CACHE: "true",
+    SEMANTIC_SEARCH_PREWARM: "false",
+    MCP_HTTP_HOST: "127.0.0.1",
+    MCP_HTTP_PORT: String(port),
+    MCP_LOG_LEVEL: "error",
+    MCP_WRITE_MODE: "readonly",
+    ...extra,
+  };
+}
+
+async function waitForHealth(port, child) {
+  const deadline = Date.now() + 20_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) {
+      throw new Error(`backend exited early with ${child.exitCode}`);
+    }
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/healthz`);
+      if (response.ok) return;
+    } catch {}
+    await new Promise((resolve) => setTimeout(resolve, 150));
+  }
+  throw new Error("backend did not become healthy");
+}
+
+async function openProxy(vault, port, profile) {
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["dist/stdio-proxy.js", "--tool-profile", profile],
+    cwd: process.cwd(),
+    env: sharedEnv(vault, port, {
+      MCP_TRANSPORT_TYPE: "stdio",
+      // Deliberately conflicting env proves CLI precedence inside each proxy.
+      MCP_TOOL_PROFILE: profile === "standard" ? "full" : "standard",
+    }),
+  });
+  const client = new Client({
+    name: `tool-profile-proxy-${profile}`,
+    version: "0",
+  });
+  await client.connect(transport);
+  return client;
+}
+
+const vault = await createVault();
+const port = await freePort();
+const backend = spawn(process.execPath, ["dist/index.js"], {
+  cwd: process.cwd(),
+  env: sharedEnv(vault, port, {
+    MCP_TRANSPORT_TYPE: "http",
+    MCP_TOOL_PROFILE: "full",
+  }),
+  stdio: "ignore",
+});
+
+try {
+  await waitForHealth(port, backend);
+
+  const standard = await openProxy(vault, port, "standard");
+  try {
+    const result = await standard.listTools();
+    const names = result.tools.map((tool) => tool.name);
+    assert.equal(names.length, 9);
+    assert.ok(names.includes("smart_semantic_search"));
+    assert.ok(!names.includes("smart_search"));
+    assert.ok(!names.includes("smart-search"));
+    assert.ok(!names.includes("external_read"));
+
+    const hidden = await standard.callTool({
+      name: "external_read",
+      arguments: { rootId: "missing", relativePath: "x.txt" },
+    });
+    assert.equal(hidden.isError, true);
+    const hiddenText = hidden.content.map((item) => item.text ?? "").join("\n");
+    assert.match(hiddenText, /tool_not_exposed/);
+    assert.match(hiddenText, /standard/);
+  } finally {
+    await standard.close().catch(() => undefined);
+  }
+
+  const full = await openProxy(vault, port, "full");
+  try {
+    const result = await full.listTools();
+    const names = result.tools.map((tool) => tool.name);
+    assert.equal(names.length, 48);
+    assert.ok(names.includes("smart_semantic_search"));
+    assert.ok(names.includes("smart_search"));
+    assert.ok(names.includes("smart-search"));
+    assert.ok(names.includes("external_read"));
+  } finally {
+    await full.close().catch(() => undefined);
+  }
+
+  console.log("PASS: stdio proxy profiles are per-client while the shared backend remains full");
+} finally {
+  if (backend.exitCode === null) backend.kill("SIGTERM");
+  await new Promise((resolve) => {
+    if (backend.exitCode !== null) return resolve();
+    const timer = setTimeout(() => {
+      if (backend.exitCode === null) backend.kill("SIGKILL");
+      resolve();
+    }, 5_000);
+    backend.once("exit", () => {
+      clearTimeout(timer);
+      resolve();
+    });
+  });
+  await rm(vault, { recursive: true, force: true });
+}

--- a/scripts/test-tool-profiles.mjs
+++ b/scripts/test-tool-profiles.mjs
@@ -12,12 +12,12 @@ import { TOOL_REGISTRATION_MODES } from "../dist/mcp-server/toolSurfaceRegistry.
 const WITH_CACHE = ["vault-cache"];
 
 const EXPECTED_COUNTS = {
-  live: { standard: 19, authoring: 31, tasks: 31, full: 72 },
-  "hybrid-live": { standard: 19, authoring: 31, tasks: 31, full: 72 },
+  live: { standard: 19, authoring: 30, tasks: 31, full: 72 },
+  "hybrid-live": { standard: 19, authoring: 30, tasks: 31, full: 72 },
   "hybrid-degraded": { standard: 6, authoring: 6, tasks: 14, full: 45 },
   "headless-readonly": { standard: 9, authoring: 9, tasks: 14, full: 48 },
   "headless-guarded": { standard: 12, authoring: 12, tasks: 14, full: 51 },
-  "headless-filesystem": { standard: 12, authoring: 17, tasks: 14, full: 60 },
+  "headless-filesystem": { standard: 12, authoring: 16, tasks: 14, full: 60 },
 };
 
 assert.deepEqual(TOOL_PROFILE_IDS, ["standard", "authoring", "tasks", "full"]);
@@ -70,6 +70,10 @@ for (const profile of ["standard", "authoring", "tasks"]) {
       !names.includes("smart_search") && !names.includes("smart-search"),
       `${profile}/${registrationMode} must hide semantic-search compatibility aliases`,
     );
+    assert.ok(
+      !names.includes("bases_upsert_config"),
+      `${profile}/${registrationMode} must keep whole-Base config replacement full-only`,
+    );
     for (const hidden of [
       "obsidian_runtime_maintenance",
       "obsidian_admin_filesystem",
@@ -94,6 +98,12 @@ for (const registrationMode of TOOL_REGISTRATION_MODES) {
   assert.ok(full.includes("smart_semantic_search"));
   assert.ok(full.includes("smart_search"));
   assert.ok(full.includes("smart-search"));
+  if (registrationMode === "live" || registrationMode === "hybrid-live" || registrationMode === "headless-filesystem") {
+    assert.ok(
+      full.includes("bases_upsert_config"),
+      `${registrationMode}/full must preserve whole-Base compatibility`,
+    );
+  }
 }
 
 for (const profile of TOOL_PROFILE_IDS) {
@@ -143,6 +153,16 @@ for (const profile of ["standard", "authoring"]) {
   );
   assert.ok(!guarded.includes("obsidian_frontmatter_patch_plan"));
 }
+
+const authoringLive = compileToolProfileNames({
+  profile: "authoring",
+  registrationMode: "live",
+  availableStaticRequirements: WITH_CACHE,
+});
+assert.ok(authoringLive.includes("bases_create"));
+assert.ok(authoringLive.includes("bases_upsert_rows"));
+assert.ok(authoringLive.includes("bases_formula_patch_plan"));
+assert.ok(!authoringLive.includes("bases_upsert_config"));
 
 const tasksLive = compileToolProfileNames({
   profile: "tasks",
@@ -244,4 +264,4 @@ for (const absent of [
 }
 assert.equal(readonlyWithoutCache.length, 5);
 
-console.log("PASS: profiles are deterministic, semantic aliases stay full-only, and headless tasks expose only snapshot-safe Operon reads");
+console.log("PASS: profiles are deterministic, semantic aliases and whole-Base config stay full-only, governed families are atomic, and headless tasks expose only snapshot-safe Operon reads");

--- a/scripts/test-tool-profiles.mjs
+++ b/scripts/test-tool-profiles.mjs
@@ -1,0 +1,188 @@
+import assert from "node:assert/strict";
+import {
+  TOOL_PROFILE_IDS,
+  TOOL_PROFILES,
+  compileToolProfile,
+  compileToolProfileNames,
+  parseToolProfileId,
+} from "../dist/mcp-server/toolProfiles.js";
+import { TOOL_REGISTRATION_MODES } from "../dist/mcp-server/toolSurfaceRegistry.js";
+
+const WITH_CACHE = ["vault-cache"];
+
+const EXPECTED_COUNTS = {
+  live: { standard: 19, authoring: 31, tasks: 31, full: 72 },
+  "hybrid-live": { standard: 19, authoring: 31, tasks: 31, full: 72 },
+  "hybrid-degraded": { standard: 6, authoring: 6, tasks: 31, full: 45 },
+  "headless-readonly": { standard: 9, authoring: 9, tasks: 31, full: 48 },
+  "headless-guarded": { standard: 12, authoring: 12, tasks: 31, full: 51 },
+  "headless-filesystem": { standard: 12, authoring: 17, tasks: 31, full: 60 },
+};
+
+assert.deepEqual(TOOL_PROFILE_IDS, ["standard", "authoring", "tasks", "full"]);
+for (const profile of TOOL_PROFILE_IDS) {
+  assert.equal(TOOL_PROFILES[profile].id, profile);
+  assert.ok(TOOL_PROFILES[profile].groups.length > 0);
+}
+
+assert.equal(parseToolProfileId("standard"), "standard");
+assert.throws(() => parseToolProfileId("standrad"), /Unknown MCP tool profile/);
+assert.throws(() => parseToolProfileId(""), /Unknown MCP tool profile/);
+
+for (const registrationMode of TOOL_REGISTRATION_MODES) {
+  for (const profile of TOOL_PROFILE_IDS) {
+    const names = compileToolProfileNames({
+      profile,
+      registrationMode,
+      availableStaticRequirements: WITH_CACHE,
+    });
+    assert.equal(
+      names.length,
+      EXPECTED_COUNTS[registrationMode][profile],
+      `${profile}/${registrationMode} count drifted`,
+    );
+    assert.deepEqual(
+      names,
+      [...names].sort((left, right) => left.localeCompare(right)),
+      `${profile}/${registrationMode} must be deterministically sorted`,
+    );
+    assert.equal(
+      new Set(names).size,
+      names.length,
+      `${profile}/${registrationMode} must not contain duplicates`,
+    );
+  }
+}
+
+for (const profile of ["standard", "authoring", "tasks"]) {
+  for (const registrationMode of TOOL_REGISTRATION_MODES) {
+    const names = compileToolProfileNames({
+      profile,
+      registrationMode,
+      availableStaticRequirements: WITH_CACHE,
+    });
+    assert.ok(
+      names.includes("smart_semantic_search"),
+      `${profile}/${registrationMode} lost canonical semantic search`,
+    );
+    assert.ok(
+      !names.includes("smart_search") && !names.includes("smart-search"),
+      `${profile}/${registrationMode} must hide semantic-search compatibility aliases`,
+    );
+    for (const hidden of [
+      "obsidian_runtime_maintenance",
+      "obsidian_admin_filesystem",
+      "external_runtime_status",
+      "external_read",
+      "external_move_plan",
+    ]) {
+      assert.ok(
+        !names.includes(hidden),
+        `${profile}/${registrationMode} unexpectedly exposes ${hidden}`,
+      );
+    }
+  }
+}
+
+for (const registrationMode of TOOL_REGISTRATION_MODES) {
+  const full = compileToolProfileNames({
+    profile: "full",
+    registrationMode,
+    availableStaticRequirements: WITH_CACHE,
+  });
+  assert.ok(full.includes("smart_semantic_search"));
+  assert.ok(full.includes("smart_search"));
+  assert.ok(full.includes("smart-search"));
+}
+
+for (const profile of TOOL_PROFILE_IDS) {
+  for (const registrationMode of TOOL_REGISTRATION_MODES) {
+    const entries = compileToolProfile({
+      profile,
+      registrationMode,
+      availableStaticRequirements: WITH_CACHE,
+    });
+    const lifecycleFamilies = new Map();
+    for (const entry of entries) {
+      if (!entry.lifecycleRole) continue;
+      const roles = lifecycleFamilies.get(entry.family) ?? [];
+      roles.push(entry.lifecycleRole);
+      lifecycleFamilies.set(entry.family, roles);
+    }
+    for (const [family, roles] of lifecycleFamilies) {
+      assert.deepEqual(
+        roles.sort(),
+        ["apply", "plan", "recover", "status"],
+        `${profile}/${registrationMode} exposes a partial ${family} lifecycle`,
+      );
+    }
+  }
+}
+
+for (const profile of ["standard", "authoring"]) {
+  const live = compileToolProfileNames({
+    profile,
+    registrationMode: "live",
+    availableStaticRequirements: WITH_CACHE,
+  });
+  assert.ok(live.includes("obsidian_frontmatter_patch_plan"));
+  assert.ok(
+    !live.includes("obsidian_manage_frontmatter"),
+    `${profile}/live must prefer the governed frontmatter family`,
+  );
+
+  const guarded = compileToolProfileNames({
+    profile,
+    registrationMode: "headless-guarded",
+    availableStaticRequirements: WITH_CACHE,
+  });
+  assert.ok(
+    guarded.includes("obsidian_manage_frontmatter"),
+    `${profile}/headless-guarded must keep the direct frontmatter fallback`,
+  );
+  assert.ok(!guarded.includes("obsidian_frontmatter_patch_plan"));
+}
+
+const tasksLive = compileToolProfileNames({
+  profile: "tasks",
+  registrationMode: "live",
+  availableStaticRequirements: WITH_CACHE,
+});
+for (const required of [
+  "operon_list_tasks",
+  "operon_query_tasks",
+  "operon_create_task",
+  "operon_update_task",
+  "operon_transition_task",
+  "operon_list_pending_recoveries",
+  "operon_recover_mutation",
+  "list_all_tasks",
+  "query_tasks",
+]) {
+  assert.ok(tasksLive.includes(required), `tasks profile lost ${required}`);
+}
+
+const standardWithoutCache = compileToolProfileNames({
+  profile: "standard",
+  registrationMode: "live",
+  availableStaticRequirements: [],
+});
+assert.ok(!standardWithoutCache.includes("obsidian_global_search"));
+assert.equal(standardWithoutCache.length, 18);
+
+const readonlyWithoutCache = compileToolProfileNames({
+  profile: "standard",
+  registrationMode: "headless-readonly",
+  availableStaticRequirements: [],
+});
+for (const absent of [
+  "obsidian_global_search",
+  "bases_list",
+  "bases_get_schema",
+  "bases_query",
+]) {
+  assert.ok(!readonlyWithoutCache.includes(absent));
+}
+assert.equal(readonlyWithoutCache.length, 5);
+
+console.log("PASS: standard, authoring, tasks and full profiles are deterministic, portable and SemVer-safe for semantic aliases");

--- a/scripts/test-tool-profiles.mjs
+++ b/scripts/test-tool-profiles.mjs
@@ -5,6 +5,7 @@ import {
   compileToolProfile,
   compileToolProfileNames,
   parseToolProfileId,
+  selectAvailableToolProfileNames,
 } from "../dist/mcp-server/toolProfiles.js";
 import { TOOL_REGISTRATION_MODES } from "../dist/mcp-server/toolSurfaceRegistry.js";
 
@@ -13,10 +14,10 @@ const WITH_CACHE = ["vault-cache"];
 const EXPECTED_COUNTS = {
   live: { standard: 19, authoring: 31, tasks: 31, full: 72 },
   "hybrid-live": { standard: 19, authoring: 31, tasks: 31, full: 72 },
-  "hybrid-degraded": { standard: 6, authoring: 6, tasks: 31, full: 45 },
-  "headless-readonly": { standard: 9, authoring: 9, tasks: 31, full: 48 },
-  "headless-guarded": { standard: 12, authoring: 12, tasks: 31, full: 51 },
-  "headless-filesystem": { standard: 12, authoring: 17, tasks: 31, full: 60 },
+  "hybrid-degraded": { standard: 6, authoring: 6, tasks: 14, full: 45 },
+  "headless-readonly": { standard: 9, authoring: 9, tasks: 14, full: 48 },
+  "headless-guarded": { standard: 12, authoring: 12, tasks: 14, full: 51 },
+  "headless-filesystem": { standard: 12, authoring: 17, tasks: 14, full: 60 },
 };
 
 assert.deepEqual(TOOL_PROFILE_IDS, ["standard", "authoring", "tasks", "full"]);
@@ -159,8 +160,66 @@ for (const required of [
   "list_all_tasks",
   "query_tasks",
 ]) {
-  assert.ok(tasksLive.includes(required), `tasks profile lost ${required}`);
+  assert.ok(tasksLive.includes(required), `live tasks profile lost ${required}`);
 }
+
+const tasksSnapshot = compileToolProfileNames({
+  profile: "tasks",
+  registrationMode: "headless-readonly",
+  availableStaticRequirements: WITH_CACHE,
+});
+assert.equal(tasksSnapshot.length, 14);
+for (const required of [
+  "operon_status",
+  "operon_get_configuration",
+  "operon_list_tasks",
+  "operon_get_task",
+  "operon_query_tasks",
+  "operon_validate",
+  "list_all_tasks",
+  "query_tasks",
+]) {
+  assert.ok(tasksSnapshot.includes(required), `snapshot tasks profile lost ${required}`);
+}
+for (const liveOnly of [
+  "operon_query_saved_filter",
+  "operon_get_diagnostics",
+  "operon_find_tasks",
+  "operon_resolve_task",
+  "operon_get_relationships",
+  "operon_build_context",
+  "operon_get_timer_state",
+  "operon_create_task",
+  "operon_update_task",
+  "operon_transition_task",
+  "operon_list_pending_recoveries",
+  "operon_recover_mutation",
+]) {
+  assert.ok(
+    !tasksSnapshot.includes(liveOnly),
+    `snapshot tasks profile must hide live-only tool ${liveOnly}`,
+  );
+}
+
+const selectedSnapshotTasks = selectAvailableToolProfileNames({
+  profile: "tasks",
+  availableNames: compileToolProfileNames({
+    profile: "full",
+    registrationMode: "headless-readonly",
+    availableStaticRequirements: WITH_CACHE,
+  }),
+});
+assert.deepEqual(selectedSnapshotTasks, tasksSnapshot);
+
+const selectedLiveTasks = selectAvailableToolProfileNames({
+  profile: "tasks",
+  availableNames: compileToolProfileNames({
+    profile: "full",
+    registrationMode: "live",
+    availableStaticRequirements: WITH_CACHE,
+  }),
+});
+assert.deepEqual(selectedLiveTasks, tasksLive);
 
 const standardWithoutCache = compileToolProfileNames({
   profile: "standard",
@@ -185,4 +244,4 @@ for (const absent of [
 }
 assert.equal(readonlyWithoutCache.length, 5);
 
-console.log("PASS: standard, authoring, tasks and full profiles are deterministic, portable and SemVer-safe for semantic aliases");
+console.log("PASS: profiles are deterministic, semantic aliases stay full-only, and headless tasks expose only snapshot-safe Operon reads");

--- a/scripts/test-tool-routing-contract.mjs
+++ b/scripts/test-tool-routing-contract.mjs
@@ -40,9 +40,17 @@ assert.deepEqual(readResult, {
   ],
 });
 
+assert.ok(
+  TOOL_ROUTING_RESOURCE_TEXT.includes("smart_semantic_search"),
+  "routing resource must expose the canonical semantic-search name",
+);
+assert.ok(
+  !TOOL_ROUTING_RESOURCE_TEXT.includes("`smart_search`") &&
+    !TOOL_ROUTING_RESOURCE_TEXT.includes("`smart-search`"),
+  "canonical routing resource must not teach semantic-search compatibility aliases",
+);
+
 const routingPairs = [
-  ["smart_search", "smart_semantic_search"],
-  ["smart-search", "smart_semantic_search"],
   ["list_all_tasks", "operon_list_tasks"],
   ["query_tasks", "operon_query_tasks"],
   ["obsidian_update_note", "obsidian_note_replace_plan"],
@@ -70,6 +78,10 @@ for (const relativePath of [
   assert.ok(
     content.includes(TOOL_ROUTING_RESOURCE_URI),
     `${relativePath} does not advertise the routing resource`,
+  );
+  assert.ok(
+    content.includes("smart_semantic_search"),
+    `${relativePath} omits canonical semantic search`,
   );
   for (const [, preferredTool] of routingPairs) {
     assert.ok(

--- a/scripts/test-tool-routing-eval-corpus.mjs
+++ b/scripts/test-tool-routing-eval-corpus.mjs
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import {
+  TOOL_PROFILE_IDS,
+  compileToolProfileNames,
+} from "../dist/mcp-server/toolProfiles.js";
+import { getToolSurfaceEntry } from "../dist/mcp-server/toolSurfaceRegistry.js";
+
+const corpus = JSON.parse(
+  fs.readFileSync(new URL("../evals/tool-routing-corpus.json", import.meta.url), "utf8"),
+);
+
+assert.ok(Array.isArray(corpus));
+assert.ok(corpus.length >= 25 && corpus.length <= 40, "initial routing corpus must remain 25-40 cases");
+
+const ids = new Set();
+for (const testCase of corpus) {
+  assert.equal(typeof testCase.id, "string");
+  assert.ok(testCase.id.length > 0);
+  assert.ok(!ids.has(testCase.id), `duplicate eval id: ${testCase.id}`);
+  ids.add(testCase.id);
+
+  assert.equal(typeof testCase.prompt, "string");
+  assert.ok(testCase.prompt.length >= 12, `${testCase.id} prompt is too weak`);
+  assert.ok(
+    TOOL_PROFILE_IDS.includes(testCase.recommendedProfile),
+    `${testCase.id} uses unknown profile ${testCase.recommendedProfile}`,
+  );
+  assert.ok(Array.isArray(testCase.acceptableFirstTools));
+  assert.ok(Array.isArray(testCase.forbiddenTools ?? []));
+
+  if (testCase.expectNoTool) {
+    assert.equal(
+      testCase.acceptableFirstTools.length,
+      0,
+      `${testCase.id} no-tool case must not define acceptable first tools`,
+    );
+  } else {
+    assert.ok(
+      testCase.acceptableFirstTools.length > 0,
+      `${testCase.id} needs at least one acceptable first tool`,
+    );
+  }
+
+  for (const name of [
+    ...testCase.acceptableFirstTools,
+    ...(testCase.forbiddenTools ?? []),
+  ]) {
+    assert.ok(getToolSurfaceEntry(name), `${testCase.id} references unknown tool ${name}`);
+  }
+
+  const liveProfile = new Set(
+    compileToolProfileNames({
+      profile: testCase.recommendedProfile,
+      registrationMode: "live",
+      availableStaticRequirements: ["vault-cache"],
+    }),
+  );
+  for (const name of testCase.acceptableFirstTools) {
+    assert.ok(
+      liveProfile.has(name),
+      `${testCase.id} expects ${name}, but recommended live profile ${testCase.recommendedProfile} hides it`,
+    );
+  }
+}
+
+for (const testCase of corpus) {
+  if (testCase.recommendedProfile === "full") continue;
+  assert.ok(
+    !(testCase.acceptableFirstTools ?? []).includes("smart_search") &&
+      !(testCase.acceptableFirstTools ?? []).includes("smart-search"),
+    `${testCase.id} teaches a deprecated semantic alias`,
+  );
+}
+
+const semantic = corpus.find((item) => item.id === "semantic-canonical");
+assert.deepEqual(semantic?.acceptableFirstTools, ["smart_semantic_search"]);
+assert.ok(semantic?.forbiddenTools.includes("smart_search"));
+assert.ok(semantic?.forbiddenTools.includes("smart-search"));
+
+console.log(`PASS: ${corpus.length} routing eval cases are profile-valid and canonical`);

--- a/scripts/test-tool-routing-eval-corpus.mjs
+++ b/scripts/test-tool-routing-eval-corpus.mjs
@@ -28,12 +28,22 @@ for (const testCase of corpus) {
   );
   assert.ok(Array.isArray(testCase.acceptableFirstTools));
   assert.ok(Array.isArray(testCase.forbiddenTools ?? []));
+  assert.ok(
+    Number.isInteger(testCase.minimumToolCalls ?? (testCase.expectNoTool ? 0 : 1)) &&
+      (testCase.minimumToolCalls ?? (testCase.expectNoTool ? 0 : 1)) >= 0,
+    `${testCase.id} minimumToolCalls must be a non-negative integer`,
+  );
 
   if (testCase.expectNoTool) {
     assert.equal(
       testCase.acceptableFirstTools.length,
       0,
       `${testCase.id} no-tool case must not define acceptable first tools`,
+    );
+    assert.equal(
+      testCase.minimumToolCalls ?? 0,
+      0,
+      `${testCase.id} no-tool case cannot require tool calls`,
     );
   } else {
     assert.ok(

--- a/scripts/test-tool-routing-scorer.mjs
+++ b/scripts/test-tool-routing-scorer.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+const temp = mkdtempSync(path.join(os.tmpdir(), "optimike-routing-score-"));
+const resultsPath = path.join(temp, "results.jsonl");
+
+try {
+  writeFileSync(
+    resultsPath,
+    [
+      JSON.stringify({
+        id: "semantic-canonical",
+        harness: "fixture",
+        surface: "standard",
+        toolsCalled: ["smart_semantic_search"],
+        success: true,
+        latencyMs: 100,
+        inputTokens: 1000,
+      }),
+      JSON.stringify({
+        id: "semantic-canonical",
+        harness: "fixture",
+        surface: "full",
+        toolsCalled: ["smart_search", "smart_semantic_search"],
+        success: true,
+        latencyMs: 140,
+        inputTokens: 1400,
+      }),
+      JSON.stringify({
+        id: "no-tool-explanation",
+        harness: "fixture",
+        surface: "standard",
+        toolsCalled: [],
+        success: true,
+        latencyMs: 50,
+        inputTokens: 500,
+      }),
+    ].join("\n") + "\n",
+    "utf8",
+  );
+
+  const output = execFileSync(
+    process.execPath,
+    ["scripts/score-tool-routing-evals.mjs", resultsPath],
+    { cwd: process.cwd(), encoding: "utf8" },
+  );
+  const report = JSON.parse(output);
+  assert.equal(report.evaluatedRuns, 3);
+
+  const standard = report.summaries.find(
+    (item) => item.harness === "fixture" && item.surface === "standard",
+  );
+  assert.ok(standard);
+  assert.equal(standard.runs, 2);
+  assert.equal(standard.firstToolAccuracy, 1);
+  assert.equal(standard.forbiddenToolRate, 0);
+  assert.equal(standard.successRate, 1);
+
+  const full = report.summaries.find(
+    (item) => item.harness === "fixture" && item.surface === "full",
+  );
+  assert.ok(full);
+  assert.equal(full.firstToolAccuracy, 0);
+  assert.equal(full.forbiddenToolRate, 1);
+  assert.equal(report.failures.length, 1);
+  assert.equal(report.failures[0].firstTool, "smart_search");
+
+  console.log("PASS: routing eval scorer distinguishes canonical and forbidden tool choices");
+} finally {
+  rmSync(temp, { recursive: true, force: true });
+}

--- a/scripts/test-tool-routing-scorer.mjs
+++ b/scripts/test-tool-routing-scorer.mjs
@@ -38,6 +38,19 @@ try {
         latencyMs: 50,
         inputTokens: 500,
       }),
+      JSON.stringify({
+        id: "external-move-full",
+        harness: "fixture",
+        surface: "full",
+        toolsCalled: [
+          "external_references_scan",
+          "external_move_plan",
+          "external_move_apply",
+        ],
+        success: true,
+        latencyMs: 180,
+        inputTokens: 1600,
+      }),
     ].join("\n") + "\n",
     "utf8",
   );
@@ -48,7 +61,7 @@ try {
     { cwd: process.cwd(), encoding: "utf8" },
   );
   const report = JSON.parse(output);
-  assert.equal(report.evaluatedRuns, 3);
+  assert.equal(report.evaluatedRuns, 4);
 
   const standard = report.summaries.find(
     (item) => item.harness === "fixture" && item.surface === "standard",
@@ -63,8 +76,14 @@ try {
     (item) => item.harness === "fixture" && item.surface === "full",
   );
   assert.ok(full);
-  assert.equal(full.firstToolAccuracy, 0);
-  assert.equal(full.forbiddenToolRate, 1);
+  assert.equal(full.runs, 2);
+  assert.equal(full.firstToolAccuracy, 0.5);
+  assert.equal(full.forbiddenToolRate, 0.5);
+  assert.equal(
+    full.meanUnnecessaryCalls,
+    0.5,
+    "the three required external-move calls must not be scored as unnecessary",
+  );
   assert.equal(report.failures.length, 1);
   assert.equal(report.failures[0].firstTool, "smart_search");
 

--- a/scripts/test-tool-surface-profile-docs.mjs
+++ b/scripts/test-tool-surface-profile-docs.mjs
@@ -38,12 +38,21 @@ for (const relative of [
   assert.ok(content.includes("tool-surface-profiles"));
 }
 
-for (const relative of ["docs/README.md", "docs/README.fr.md"]) {
+for (const relative of ["README.md", "README.fr.md", "docs/README.md", "docs/README.fr.md"]) {
   const content = read(relative);
   assert.ok(
     content.includes("tool-surface-profiles"),
     `${relative} must route readers to the profile contract`,
   );
+  assert.ok(content.includes("smart_semantic_search"));
+}
+
+const englishReadme = read("README.md");
+const frenchReadme = read("README.fr.md");
+for (const content of [englishReadme, frenchReadme]) {
+  assert.ok(content.includes("--tool-profile standard"));
+  assert.ok(content.includes("/mcp/standard"));
+  assert.ok(content.includes("/mcp/full"));
 }
 
 const routingResource = read("src/mcp-server/resources/toolRoutingResource.ts");
@@ -51,4 +60,4 @@ assert.ok(routingResource.includes("smart_semantic_search"));
 assert.ok(!routingResource.includes("`smart_search`"));
 assert.ok(!routingResource.includes("`smart-search`"));
 
-console.log("PASS: profile docs own compatibility while routing docs teach only smart_semantic_search");
+console.log("PASS: README/profile docs own compatibility while routing docs teach only smart_semantic_search");

--- a/scripts/test-tool-surface-profile-docs.mjs
+++ b/scripts/test-tool-surface-profile-docs.mjs
@@ -38,18 +38,19 @@ for (const relative of [
   assert.ok(content.includes("tool-surface-profiles"));
 }
 
-for (const relative of ["README.md", "README.fr.md", "docs/README.md", "docs/README.fr.md"]) {
+for (const relative of ["docs/README.md", "docs/README.fr.md"]) {
   const content = read(relative);
   assert.ok(
     content.includes("tool-surface-profiles"),
     `${relative} must route readers to the profile contract`,
   );
-  assert.ok(content.includes("smart_semantic_search"));
 }
 
 const englishReadme = read("README.md");
 const frenchReadme = read("README.fr.md");
 for (const content of [englishReadme, frenchReadme]) {
+  assert.ok(content.includes("tool-surface-profiles"));
+  assert.ok(content.includes("smart_semantic_search"));
   assert.ok(content.includes("--tool-profile standard"));
   assert.ok(content.includes("/mcp/standard"));
   assert.ok(content.includes("/mcp/full"));

--- a/scripts/test-tool-surface-profile-docs.mjs
+++ b/scripts/test-tool-surface-profile-docs.mjs
@@ -55,6 +55,12 @@ for (const content of [englishReadme, frenchReadme]) {
   assert.ok(content.includes("/mcp/full"));
 }
 
+const toolSpec = read("docs/obsidian_mcp_tools_spec.md");
+assert.ok(toolSpec.includes("`smart_semantic_search`: **canonical**"));
+assert.ok(toolSpec.includes("`smart_search`: deprecated 2.x compatibility alias, visible only in `full`"));
+assert.ok(toolSpec.includes("`smart-search`: deprecated 2.x compatibility alias, visible only in `full`"));
+assert.ok(toolSpec.includes("physical removal is reserved\nfor 3.0"));
+
 const routingResource = read("src/mcp-server/resources/toolRoutingResource.ts");
 assert.ok(routingResource.includes("smart_semantic_search"));
 assert.ok(!routingResource.includes("`smart_search`"));

--- a/scripts/test-tool-surface-profile-docs.mjs
+++ b/scripts/test-tool-surface-profile-docs.mjs
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const read = (relative) => fs.readFileSync(path.join(root, relative), "utf8");
+
+for (const relative of [
+  "docs/tool-surface-profiles.md",
+  "docs/tool-surface-profiles.fr.md",
+]) {
+  const content = read(relative);
+  for (const profile of ["standard", "authoring", "tasks", "full"]) {
+    assert.ok(content.includes(`\`${profile}\``), `${relative} omits ${profile}`);
+  }
+  assert.ok(content.includes("smart_semantic_search"));
+  assert.ok(content.includes("smart_search"));
+  assert.ok(content.includes("smart-search"));
+  assert.ok(
+    /3\.0/u.test(content),
+    `${relative} must document the major-version alias-removal boundary`,
+  );
+  assert.ok(content.includes("/mcp/standard"));
+  assert.ok(content.includes("/mcp/tasks"));
+}
+
+for (const relative of [
+  "docs/mcp-routing-guide.md",
+  "docs/mcp-routing-guide.fr.md",
+]) {
+  const content = read(relative);
+  assert.ok(content.includes("smart_semantic_search"));
+  assert.ok(
+    !content.includes("`smart_search`") && !content.includes("`smart-search`"),
+    `${relative} must teach only the canonical semantic-search tool`,
+  );
+  assert.ok(content.includes("tool-surface-profiles"));
+}
+
+for (const relative of ["docs/README.md", "docs/README.fr.md"]) {
+  const content = read(relative);
+  assert.ok(
+    content.includes("tool-surface-profiles"),
+    `${relative} must route readers to the profile contract`,
+  );
+}
+
+const routingResource = read("src/mcp-server/resources/toolRoutingResource.ts");
+assert.ok(routingResource.includes("smart_semantic_search"));
+assert.ok(!routingResource.includes("`smart_search`"));
+assert.ok(!routingResource.includes("`smart-search`"));
+
+console.log("PASS: profile docs own compatibility while routing docs teach only smart_semantic_search");

--- a/scripts/test-tool-surface-profile-docs.mjs
+++ b/scripts/test-tool-surface-profile-docs.mjs
@@ -60,7 +60,11 @@ const toolSpec = read("docs/obsidian_mcp_tools_spec.md");
 assert.ok(toolSpec.includes("`smart_semantic_search`: **canonical**"));
 assert.ok(toolSpec.includes("`smart_search`: deprecated 2.x compatibility alias, visible only in `full`"));
 assert.ok(toolSpec.includes("`smart-search`: deprecated 2.x compatibility alias, visible only in `full`"));
-assert.ok(toolSpec.includes("physical removal is reserved\nfor 3.0"));
+assert.match(
+  toolSpec,
+  /physical removal is reserved\s+for 3\.0/u,
+  "tool surface spec must preserve the 3.0 physical-alias-removal boundary",
+);
 
 const routingResource = read("src/mcp-server/resources/toolRoutingResource.ts");
 assert.ok(routingResource.includes("smart_semantic_search"));

--- a/scripts/test-tool-surface-registry.mjs
+++ b/scripts/test-tool-surface-registry.mjs
@@ -1,0 +1,176 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  TOOL_GROUP_IDS,
+  TOOL_REGISTRATION_MODES,
+  TOOL_SURFACE_REGISTRY,
+  compileToolNames,
+  compileToolSurface,
+  getToolSurfaceEntry,
+} from "../dist/mcp-server/toolSurfaceRegistry.js";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+
+const EXPECTED_UNION_COUNT = 76;
+const EXPECTED_COUNTS_BY_MODE = {
+  live: 72,
+  "hybrid-live": 72,
+  "hybrid-degraded": 45,
+  "headless-readonly": 48,
+  "headless-guarded": 51,
+  "headless-filesystem": 60,
+};
+
+assert.equal(
+  TOOL_SURFACE_REGISTRY.length,
+  EXPECTED_UNION_COUNT,
+  "canonical registry must cover the union of all currently registered tool names",
+);
+
+const names = TOOL_SURFACE_REGISTRY.map((entry) => entry.name);
+assert.equal(new Set(names).size, names.length, "tool names must be unique");
+
+for (const mode of TOOL_REGISTRATION_MODES) {
+  const compiled = compileToolNames({ registrationMode: mode });
+  assert.equal(
+    compiled.length,
+    EXPECTED_COUNTS_BY_MODE[mode],
+    `unexpected full tool count for ${mode}`,
+  );
+  assert.deepEqual(
+    compiled,
+    [...compiled].sort((left, right) => left.localeCompare(right)),
+    `${mode} compilation must be deterministic and sorted`,
+  );
+  assert.equal(
+    new Set(compiled).size,
+    compiled.length,
+    `${mode} compilation must not contain duplicate tools`,
+  );
+}
+
+assert.equal(
+  compileToolNames({ registrationMode: "live" }).length,
+  72,
+  "72 is the current full live/hybrid surface, not the cross-runtime registry size",
+);
+
+for (const entry of TOOL_SURFACE_REGISTRY) {
+  assert.ok(TOOL_GROUP_IDS.includes(entry.group), `unknown group for ${entry.name}`);
+  assert.ok(
+    entry.registrationModes.length > 0,
+    `${entry.name} must be registered in at least one mode`,
+  );
+  if (entry.aliasOf) {
+    assert.equal(entry.surfaceClass, "legacy", `${entry.name} alias must be legacy`);
+    assert.equal(
+      entry.canonicalName,
+      entry.aliasOf,
+      `${entry.name} canonicalName must resolve to aliasOf`,
+    );
+    assert.ok(
+      getToolSurfaceEntry(entry.aliasOf),
+      `${entry.name} points to missing canonical tool ${entry.aliasOf}`,
+    );
+  } else {
+    assert.equal(
+      entry.canonicalName,
+      entry.name,
+      `${entry.name} must be self-canonical when it is not an alias`,
+    );
+  }
+}
+
+assert.equal(getToolSurfaceEntry("smart_search")?.aliasOf, "smart_semantic_search");
+assert.equal(getToolSurfaceEntry("smart-search")?.aliasOf, "smart_semantic_search");
+
+const expectedLifecycleRoles = ["apply", "plan", "recover", "status"];
+const governedFamilies = new Map();
+for (const entry of TOOL_SURFACE_REGISTRY) {
+  if (!entry.lifecycleRole) continue;
+  const items = governedFamilies.get(entry.family) ?? [];
+  items.push(entry);
+  governedFamilies.set(entry.family, items);
+}
+assert.equal(governedFamilies.size, 4, "exactly four governed lifecycle families are expected");
+
+for (const [family, entries] of governedFamilies) {
+  assert.deepEqual(
+    entries.map((entry) => entry.lifecycleRole).sort(),
+    expectedLifecycleRoles,
+    `${family} must expose plan/apply/status/recover as one atomic family`,
+  );
+  assert.equal(
+    new Set(entries.map((entry) => entry.group)).size,
+    1,
+    `${family} lifecycle must stay in one group`,
+  );
+  assert.equal(
+    new Set(entries.map((entry) => entry.registrationModes.join("|"))).size,
+    1,
+    `${family} lifecycle must share one registration boundary`,
+  );
+}
+
+const selected = compileToolSurface({
+  registrationMode: "live",
+  groups: ["semantic.canonical", "validation"],
+});
+assert.deepEqual(
+  selected.map((entry) => entry.name),
+  ["obsidian_validate_format", "smart_semantic_search"],
+  "group composition must expose only the requested canonical tools",
+);
+
+function collectSourceFiles(root) {
+  const result = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    const absolute = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      result.push(...collectSourceFiles(absolute));
+    } else if (entry.isFile() && entry.name.endsWith(".ts")) {
+      result.push(absolute);
+    }
+  }
+  return result;
+}
+
+const sourceFiles = collectSourceFiles(path.join(repoRoot, "src", "mcp-server"));
+const sourceCorpus = sourceFiles.map((file) => fs.readFileSync(file, "utf8")).join("\n");
+
+for (const entry of TOOL_SURFACE_REGISTRY) {
+  assert.ok(
+    sourceCorpus.includes(`\"${entry.name}\"`) || sourceCorpus.includes(`'${entry.name}'`),
+    `registry entry ${entry.name} is not present in MCP source`,
+  );
+}
+
+const sourceDeclaredTools = new Set();
+const literalPatterns = [
+  /server\.tool\(\s*["'`]([^"'`]+)["'`]/gu,
+  /const\s+toolName\s*=\s*["'`]([^"'`]+)["'`]/gu,
+  /register\(\s*["'`](smart(?:_|-)[^"'`]+)["'`]/gu,
+  /name:\s*["'`](external_[^"'`]+)["'`]/gu,
+];
+for (const sourceFile of sourceFiles) {
+  const source = fs.readFileSync(sourceFile, "utf8");
+  for (const pattern of literalPatterns) {
+    pattern.lastIndex = 0;
+    for (const match of source.matchAll(pattern)) {
+      sourceDeclaredTools.add(match[1]);
+    }
+  }
+}
+
+for (const name of sourceDeclaredTools) {
+  assert.ok(
+    getToolSurfaceEntry(name),
+    `MCP source declares ${name} but the canonical registry does not`,
+  );
+}
+
+console.log(
+  `PASS: canonical tool registry covers ${TOOL_SURFACE_REGISTRY.length} cross-runtime names; live=${EXPECTED_COUNTS_BY_MODE.live}, headless-filesystem=${EXPECTED_COUNTS_BY_MODE["headless-filesystem"]}`,
+);

--- a/scripts/test-tool-surface-registry.mjs
+++ b/scripts/test-tool-surface-registry.mjs
@@ -85,6 +85,11 @@ for (const entry of TOOL_SURFACE_REGISTRY) {
 
 assert.equal(getToolSurfaceEntry("smart_search")?.aliasOf, "smart_semantic_search");
 assert.equal(getToolSurfaceEntry("smart-search")?.aliasOf, "smart_semantic_search");
+assert.equal(
+  getToolSurfaceEntry("bases_upsert_config")?.group,
+  "bases.compat",
+  "whole-Base replacement must have its own compatibility group",
+);
 
 const expectedLifecycleRoles = ["apply", "plan", "recover", "status"];
 const governedFamilies = new Map();
@@ -180,5 +185,5 @@ for (const name of sourceDeclaredTools) {
 }
 
 console.log(
-  `PASS: canonical tool registry covers ${TOOL_SURFACE_REGISTRY.length} cross-runtime names; live=${EXPECTED_COUNTS_BY_MODE.live}, headless-filesystem=${EXPECTED_COUNTS_BY_MODE["headless-filesystem"]}`,
+  `PASS: canonical tool registry covers ${TOOL_SURFACE_REGISTRY.length} cross-runtime names; live=${EXPECTED_COUNTS_BY_MODE.live}, headless-filesystem=${EXPECTED_COUNTS_BY_MODE["headless-filesystem"]}; whole-Base compatibility is isolated`,
 );

--- a/scripts/test-tool-surface-registry.mjs
+++ b/scripts/test-tool-surface-registry.mjs
@@ -137,13 +137,21 @@ function collectSourceFiles(root) {
   return result;
 }
 
-const sourceFiles = collectSourceFiles(path.join(repoRoot, "src", "mcp-server"));
+const registrySource = path.join(
+  repoRoot,
+  "src",
+  "mcp-server",
+  "toolSurfaceRegistry.ts",
+);
+const sourceFiles = collectSourceFiles(path.join(repoRoot, "src", "mcp-server")).filter(
+  (file) => path.resolve(file) !== path.resolve(registrySource),
+);
 const sourceCorpus = sourceFiles.map((file) => fs.readFileSync(file, "utf8")).join("\n");
 
 for (const entry of TOOL_SURFACE_REGISTRY) {
   assert.ok(
     sourceCorpus.includes(`\"${entry.name}\"`) || sourceCorpus.includes(`'${entry.name}'`),
-    `registry entry ${entry.name} is not present in MCP source`,
+    `registry entry ${entry.name} is not present outside the registry itself`,
   );
 }
 

--- a/scripts/test-tool-surface-runtime-conformance.mjs
+++ b/scripts/test-tool-surface-runtime-conformance.mjs
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { compileToolNames } from "../dist/mcp-server/toolSurfaceRegistry.js";
+
+const MODES = [
+  "live",
+  "hybrid-live",
+  "hybrid-degraded",
+  "headless-readonly",
+  "headless-guarded",
+  "headless-filesystem",
+];
+
+async function createTempVault() {
+  const vaultRoot = await mkdtemp(path.join(os.tmpdir(), "optimike-tool-surface-"));
+  await mkdir(path.join(vaultRoot, ".obsidian", "optimike-mcp"), {
+    recursive: true,
+  });
+  await writeFile(path.join(vaultRoot, "Root.md"), "# Tool surface smoke\n", "utf8");
+  return vaultRoot;
+}
+
+async function createFakeRestServer() {
+  const server = createServer((request, response) => {
+    if (request.url === "/") {
+      response.setHeader("content-type", "application/json");
+      response.end(
+        JSON.stringify({
+          service: "Obsidian Local REST API",
+          authenticated: true,
+          versions: { obsidian: "surface-smoke", self: "surface-smoke" },
+        }),
+      );
+      return;
+    }
+    response.statusCode = 404;
+    response.end("not found");
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  return {
+    server,
+    url: `http://127.0.0.1:${address.port}`,
+  };
+}
+
+async function listToolsForMode(registrationMode) {
+  const vaultRoot = await createTempVault();
+  const needsRest = registrationMode === "live" || registrationMode === "hybrid-live";
+  const fakeRest = needsRest ? await createFakeRestServer() : undefined;
+  const runtimeMode = registrationMode.startsWith("hybrid")
+    ? "hybrid"
+    : registrationMode;
+  const apiKey = needsRest ? "surface-smoke-key" : "";
+  const writeMode =
+    registrationMode === "headless-readonly" ||
+    registrationMode === "hybrid-degraded"
+      ? "readonly"
+      : registrationMode === "headless-guarded" ||
+          registrationMode === "headless-filesystem"
+        ? "guarded"
+        : "full";
+
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["dist/index.js"],
+    cwd: process.cwd(),
+    env: {
+      ...process.env,
+      OBSIDIAN_RUNTIME_MODE: runtimeMode,
+      OBSIDIAN_VAULT: vaultRoot,
+      OBSIDIAN_CACHE_SOURCE: "filesystem",
+      OBSIDIAN_SHARED_CACHE_DB_PATH: path.join(
+        vaultRoot,
+        ".obsidian",
+        "optimike-mcp",
+        "shared-cache.sqlite",
+      ),
+      OBSIDIAN_ENABLE_CACHE: "true",
+      OBSIDIAN_API_KEY: apiKey,
+      OBSIDIAN_BASE_URL: fakeRest?.url ?? "http://127.0.0.1:9",
+      OBSIDIAN_STARTUP_BLOCKING: "true",
+      SEMANTIC_SEARCH_PREWARM: "false",
+      MCP_TRANSPORT_TYPE: "stdio",
+      MCP_LOG_LEVEL: "error",
+      MCP_WRITE_MODE: writeMode,
+    },
+  });
+  const client = new Client({
+    name: `optimike-tool-surface-${registrationMode}`,
+    version: "0",
+  });
+
+  try {
+    await client.connect(transport);
+    const tools = await client.listTools();
+    return tools.tools.map((tool) => tool.name).sort((a, b) => a.localeCompare(b));
+  } finally {
+    await client.close().catch(() => undefined);
+    await transport.close().catch(() => undefined);
+    if (fakeRest) {
+      await new Promise((resolve) => fakeRest.server.close(resolve));
+    }
+    await rm(vaultRoot, { recursive: true, force: true });
+  }
+}
+
+for (const registrationMode of MODES) {
+  const actual = await listToolsForMode(registrationMode);
+  const expected = [...compileToolNames({ registrationMode })];
+  assert.deepEqual(
+    actual,
+    expected,
+    `${registrationMode} tools/list diverges from the canonical registry`,
+  );
+  console.log(`PASS ${registrationMode}: ${actual.length} tools`);
+}
+
+console.log("PASS: runtime tools/list matches the canonical registry in every registration mode");

--- a/scripts/test-tool-surface-runtime-conformance.mjs
+++ b/scripts/test-tool-surface-runtime-conformance.mjs
@@ -102,7 +102,6 @@ async function listToolsForMode(registrationMode) {
     return tools.tools.map((tool) => tool.name).sort((a, b) => a.localeCompare(b));
   } finally {
     await client.close().catch(() => undefined);
-    await transport.close().catch(() => undefined);
     if (fakeRest) {
       await new Promise((resolve) => fakeRest.server.close(resolve));
     }

--- a/src/config/toolProfileCli.ts
+++ b/src/config/toolProfileCli.ts
@@ -1,0 +1,34 @@
+import { parseToolProfileId } from "../mcp-server/toolProfiles.js";
+
+export function applyToolProfileCliOverride(
+  argv: readonly string[] = process.argv.slice(2),
+): void {
+  const values: string[] = [];
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === "--tool-profile") {
+      const value = argv[index + 1];
+      if (!value || value.startsWith("--")) {
+        throw new Error(
+          "--tool-profile requires one of: standard, authoring, tasks, full.",
+        );
+      }
+      values.push(value);
+      index += 1;
+      continue;
+    }
+    if (arg.startsWith("--tool-profile=")) {
+      values.push(arg.slice("--tool-profile=".length));
+    }
+  }
+
+  if (values.length === 0) return;
+  if (values.length > 1) {
+    throw new Error("--tool-profile may be provided only once.");
+  }
+
+  process.env.MCP_TOOL_PROFILE = parseToolProfileId(values[0]);
+}
+
+applyToolProfileCliOverride();

--- a/src/mcp-server/resources/toolRoutingResource.ts
+++ b/src/mcp-server/resources/toolRoutingResource.ts
@@ -1,4 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import "../../config/toolProfileCli.js";
+import { installToolProfileRegistrationGate } from "../toolProfileRuntime.js";
 
 export const TOOL_ROUTING_RESOURCE_URI =
   "optimike://guides/tool-routing" as const;
@@ -6,13 +8,14 @@ export const TOOL_ROUTING_RESOURCE_URI =
 export const TOOL_ROUTING_RESOURCE_TEXT = `# Optimike MCP tool routing
 
 Use the narrowest tool that owns the required guarantee. Tool availability is
-runtime-dependent; never infer that an absent tool can be emulated safely.
+runtime- and profile-dependent; never infer that an absent tool can be emulated safely.
 
 ## Canonical priorities
 
 - Read, list and exact text search: use the dedicated read/search tools.
-- Semantic search: use \`smart_semantic_search\`. \`smart_search\` and
-  \`smart-search\` are legacy compatibility aliases of the same implementation.
+- Semantic search: use \`smart_semantic_search\`. It is the only semantic-search
+  name exposed by modern 2.10 profiles; compatibility aliases remain a \`full\`
+  2.x concern and are not part of canonical routing.
 - Operon-managed tasks: use \`operon_list_tasks\` or \`operon_query_tasks\`. Use
   \`list_all_tasks\` and \`query_tasks\` only for legacy Obsidian Tasks-compatible
   Markdown inspection.
@@ -28,8 +31,8 @@ runtime-dependent; never infer that an absent tool can be emulated safely.
   \`obsidian_frontmatter_patch_plan\`. Use \`obsidian_manage_frontmatter\` for
   direct reads, compatibility, or a runtime where the governed tool is absent.
 - Named Base formula set/delete: prefer \`bases_formula_patch_plan\`.
-  \`bases_upsert_config\` is a legacy whole-config compatibility path and must not
-  bypass the governed formula contract.
+  \`bases_upsert_config\` is a whole-config compatibility path and must not bypass
+  the governed formula contract.
 - Existing JSON Canvas graph mutation in live/hybrid mode: prefer
   \`obsidian_canvas_patch_plan\`, then its matching apply/status/recover tools.
   \`obsidian_manage_canvas\` is a direct headless-filesystem helper without a
@@ -52,13 +55,17 @@ There is intentionally no generic public \`operation_*\` surface.
 `;
 
 export function registerToolRoutingResource(server: McpServer): void {
+  // server.ts calls this bootstrap point before registering any MCP tools.
+  // Install the selected profile first so hidden tools never reach tools/list.
+  installToolProfileRegistrationGate(server);
+
   server.registerResource(
     "optimike-tool-routing",
     TOOL_ROUTING_RESOURCE_URI,
     {
       title: "Optimike MCP tool routing",
       description:
-        "Canonical precedence between direct, legacy and governed Optimike MCP tools.",
+        "Canonical precedence between direct, compatibility and governed Optimike MCP tools.",
       mimeType: "text/markdown",
     },
     async () => ({

--- a/src/mcp-server/toolProfileContext.ts
+++ b/src/mcp-server/toolProfileContext.ts
@@ -1,0 +1,15 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import type { ToolProfileId } from "./toolProfiles.js";
+
+const toolProfileContext = new AsyncLocalStorage<ToolProfileId>();
+
+export function currentToolProfileContext(): ToolProfileId | undefined {
+  return toolProfileContext.getStore();
+}
+
+export function withToolProfileContext<T>(
+  profile: ToolProfileId,
+  operation: () => Promise<T>,
+): Promise<T> {
+  return toolProfileContext.run(profile, operation);
+}

--- a/src/mcp-server/toolProfileRuntime.ts
+++ b/src/mcp-server/toolProfileRuntime.ts
@@ -1,0 +1,77 @@
+import type {
+  McpServer,
+  RegisteredTool,
+} from "@modelcontextprotocol/sdk/server/mcp.js";
+import {
+  parseToolProfileId,
+  selectAvailableToolProfileNames,
+  type ToolProfileId,
+} from "./toolProfiles.js";
+
+export function resolveToolProfile(
+  raw = process.env.MCP_TOOL_PROFILE?.trim() || "full",
+): ToolProfileId {
+  return parseToolProfileId(raw);
+}
+
+/**
+ * Installs a registration-time exposure gate on one McpServer instance.
+ *
+ * The SDK's public RegisteredTool handles are authoritative: disabling a tool
+ * removes it from tools/list and rejects direct callTool invocation. We keep
+ * every registered handle, recompute the selected profile from the concrete
+ * names currently present, and reconcile enabled state after each registration.
+ * This makes canonical/direct fallback resolution independent of registration
+ * order while preserving `full` as the unfiltered 2.x compatibility surface.
+ */
+export function installToolProfileRegistrationGate(
+  server: McpServer,
+  profile: ToolProfileId = resolveToolProfile(),
+): void {
+  if (profile === "full") return;
+
+  const handles = new Map<string, RegisteredTool>();
+  const originalTool = server.tool.bind(server) as (
+    name: string,
+    ...rest: unknown[]
+  ) => RegisteredTool;
+  const originalRegisterTool = server.registerTool.bind(server) as (
+    name: string,
+    ...rest: unknown[]
+  ) => RegisteredTool;
+
+  const reconcile = () => {
+    const allowed = new Set(
+      selectAvailableToolProfileNames({
+        profile,
+        availableNames: [...handles.keys()],
+      }),
+    );
+
+    for (const [name, handle] of handles) {
+      const shouldEnable = allowed.has(name);
+      if (handle.enabled !== shouldEnable) {
+        handle.update({ enabled: shouldEnable });
+      }
+    }
+  };
+
+  const remember = (name: string, handle: RegisteredTool): RegisteredTool => {
+    handles.set(name, handle);
+    reconcile();
+    return handle;
+  };
+
+  // The project still uses the v1 convenience `tool()` API extensively, while
+  // future registrations may migrate to `registerTool()`. Intercept both public
+  // entrypoints so the profile contract cannot drift during that migration.
+  (server as unknown as { tool: typeof server.tool }).tool = ((
+    name: string,
+    ...rest: unknown[]
+  ) => remember(name, originalTool(name, ...rest))) as typeof server.tool;
+
+  (server as unknown as { registerTool: typeof server.registerTool }).registerTool = ((
+    name: string,
+    ...rest: unknown[]
+  ) => remember(name, originalRegisterTool(name, ...rest))) as typeof server.registerTool;
+}

--- a/src/mcp-server/toolProfileRuntime.ts
+++ b/src/mcp-server/toolProfileRuntime.ts
@@ -2,16 +2,20 @@ import type {
   McpServer,
   RegisteredTool,
 } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { currentToolProfileContext } from "./toolProfileContext.js";
 import {
   parseToolProfileId,
   selectAvailableToolProfileNames,
   type ToolProfileId,
 } from "./toolProfiles.js";
 
-export function resolveToolProfile(
-  raw = process.env.MCP_TOOL_PROFILE?.trim() || "full",
-): ToolProfileId {
-  return parseToolProfileId(raw);
+export function resolveToolProfile(raw?: string): ToolProfileId {
+  const selected =
+    raw?.trim() ||
+    currentToolProfileContext() ||
+    process.env.MCP_TOOL_PROFILE?.trim() ||
+    "full";
+  return parseToolProfileId(selected);
 }
 
 /**
@@ -23,6 +27,9 @@ export function resolveToolProfile(
  * names currently present, and reconcile enabled state after each registration.
  * This makes canonical/direct fallback resolution independent of registration
  * order while preserving `full` as the unfiltered 2.x compatibility surface.
+ *
+ * HTTP session creation may provide a request-scoped profile through
+ * AsyncLocalStorage; stdio falls back to CLI/env selection.
  */
 export function installToolProfileRegistrationGate(
   server: McpServer,

--- a/src/mcp-server/toolProfiles.ts
+++ b/src/mcp-server/toolProfiles.ts
@@ -66,6 +66,13 @@ const OPERON_LIVE_ONLY_READ_TOOLS = new Set([
   "operon_list_pending_recoveries",
 ]);
 
+const GOVERNED_LIFECYCLE_ROLES = [
+  "plan",
+  "apply",
+  "status",
+  "recover",
+] as const;
+
 export const TOOL_PROFILES: Readonly<Record<ToolProfileId, ToolProfileDefinition>> = {
   standard: {
     id: "standard",
@@ -127,7 +134,9 @@ function suppressPreferredFallbacks(
   );
 }
 
-function assertGovernedFamiliesAtomic(entries: readonly ToolSurfaceEntry[]): void {
+function lifecycleRolesByFamily(
+  entries: readonly ToolSurfaceEntry[],
+): Map<string, Set<string>> {
   const lifecycleByFamily = new Map<string, Set<string>>();
   for (const entry of entries) {
     if (!entry.lifecycleRole) continue;
@@ -135,13 +144,34 @@ function assertGovernedFamiliesAtomic(entries: readonly ToolSurfaceEntry[]): voi
     roles.add(entry.lifecycleRole);
     lifecycleByFamily.set(entry.family, roles);
   }
+  return lifecycleByFamily;
+}
 
-  const complete = new Set(["plan", "apply", "status", "recover"]);
-  for (const [family, roles] of lifecycleByFamily) {
-    if (
-      roles.size !== complete.size ||
-      [...complete].some((role) => !roles.has(role))
-    ) {
+function lifecycleIsComplete(roles: ReadonlySet<string>): boolean {
+  return (
+    roles.size === GOVERNED_LIFECYCLE_ROLES.length &&
+    GOVERNED_LIFECYCLE_ROLES.every((role) => roles.has(role))
+  );
+}
+
+function hideIncompleteGovernedFamilies(
+  entries: readonly ToolSurfaceEntry[],
+): readonly ToolSurfaceEntry[] {
+  const lifecycleByFamily = lifecycleRolesByFamily(entries);
+  const completeFamilies = new Set(
+    [...lifecycleByFamily]
+      .filter(([, roles]) => lifecycleIsComplete(roles))
+      .map(([family]) => family),
+  );
+
+  return entries.filter(
+    (entry) => !entry.lifecycleRole || completeFamilies.has(entry.family),
+  );
+}
+
+function assertGovernedFamiliesAtomic(entries: readonly ToolSurfaceEntry[]): void {
+  for (const [family, roles] of lifecycleRolesByFamily(entries)) {
+    if (!lifecycleIsComplete(roles)) {
       throw new Error(
         `Tool profile exposes an incomplete governed lifecycle for ${family}: ${[...roles].sort().join(", ")}.`,
       );
@@ -169,15 +199,30 @@ function modernRuntimeAvailable(
   return true;
 }
 
+interface FinalizeProfileEntriesOptions {
+  tolerateIncompleteRegistration?: boolean;
+}
+
 function finalizeProfileEntries(
   definition: ToolProfileDefinition,
   entries: readonly ToolSurfaceEntry[],
   operonLive: boolean,
+  options: FinalizeProfileEntriesOptions = {},
 ): readonly ToolSurfaceEntry[] {
   let selected =
     definition.id === "full"
       ? entries
       : entries.filter((entry) => modernRuntimeAvailable(entry, operonLive));
+
+  // A concrete McpServer registers tools one at a time. During that transient
+  // construction phase a governed quartet is necessarily incomplete. Keep the
+  // whole family disabled until all four members exist, then expose it in one
+  // reconciliation. Static profile compilation remains strict and will still
+  // fail on an actually incomplete catalogue.
+  if (options.tolerateIncompleteRegistration) {
+    selected = hideIncompleteGovernedFamilies(selected);
+  }
+
   if (definition.preferCanonicalAlternatives) {
     selected = suppressPreferredFallbacks(selected);
   }
@@ -224,6 +269,10 @@ export interface SelectAvailableToolProfileInput {
  * service contract is statically live-only. Presence of the governed note
  * family is used as the concrete live/hybrid marker because it is registered
  * before Operon in live-capable server construction and is absent headlessly.
+ *
+ * Registration is incremental, so a governed quartet may be transiently
+ * incomplete while the server factory is still constructing the instance. In
+ * that case the entire family remains hidden until all four names are present.
  */
 export function selectAvailableToolProfileNames({
   profile,
@@ -242,7 +291,7 @@ export function selectAvailableToolProfileNames({
     .filter((entry) => groups.has(entry.group));
   const operonLive = uniqueNames.includes("obsidian_note_replace_plan");
 
-  return finalizeProfileEntries(definition, entries, operonLive).map(
-    (entry) => entry.name,
-  );
+  return finalizeProfileEntries(definition, entries, operonLive, {
+    tolerateIncompleteRegistration: true,
+  }).map((entry) => entry.name);
 }

--- a/src/mcp-server/toolProfiles.ts
+++ b/src/mcp-server/toolProfiles.ts
@@ -1,0 +1,164 @@
+import {
+  TOOL_GROUP_IDS,
+  compileToolSurface,
+  type ToolGroupId,
+  type ToolRegistrationMode,
+  type ToolStaticRequirement,
+  type ToolSurfaceEntry,
+} from "./toolSurfaceRegistry.js";
+
+export const TOOL_PROFILE_IDS = [
+  "standard",
+  "authoring",
+  "tasks",
+  "full",
+] as const;
+
+export type ToolProfileId = (typeof TOOL_PROFILE_IDS)[number];
+
+export interface ToolProfileDefinition {
+  id: ToolProfileId;
+  description: string;
+  groups: readonly ToolGroupId[];
+  preferCanonicalAlternatives: boolean;
+}
+
+const STANDARD_GROUPS = [
+  "notes.read",
+  "notes.direct.common",
+  "notes.governed",
+  "metadata.direct.frontmatter",
+  "metadata.governed",
+  "bases.read",
+  "semantic.canonical",
+  "runtime.status",
+  "validation",
+] as const satisfies readonly ToolGroupId[];
+
+const AUTHORING_GROUPS = [
+  ...STANDARD_GROUPS,
+  "metadata.direct.tags",
+  "bases.direct",
+  "bases.governed",
+  "canvas.direct",
+  "canvas.governed",
+] as const satisfies readonly ToolGroupId[];
+
+const TASK_GROUPS = [
+  "notes.read",
+  "tasks.markdown",
+  "tasks.operon.read",
+  "tasks.operon.write",
+  "semantic.canonical",
+  "runtime.status",
+  "validation",
+] as const satisfies readonly ToolGroupId[];
+
+export const TOOL_PROFILES: Readonly<Record<ToolProfileId, ToolProfileDefinition>> = {
+  standard: {
+    id: "standard",
+    description:
+      "General Obsidian work: read/search, canonical semantic search, bounded direct note edits, governed note/frontmatter lifecycles when available, Bases reads, format validation and runtime status.",
+    groups: STANDARD_GROUPS,
+    preferCanonicalAlternatives: true,
+  },
+  authoring: {
+    id: "authoring",
+    description:
+      "Content and structure authoring: standard plus tags, Bases writes/formulas and Canvas mutation surfaces appropriate to the active runtime.",
+    groups: AUTHORING_GROUPS,
+    preferCanonicalAlternatives: true,
+  },
+  tasks: {
+    id: "tasks",
+    description:
+      "Task-focused work: note context, Markdown Tasks compatibility, the complete Operon MCP contract, canonical semantic search, validation and runtime status.",
+    groups: TASK_GROUPS,
+    preferCanonicalAlternatives: true,
+  },
+  full: {
+    id: "full",
+    description:
+      "Compatibility surface: every tool registered by the active runtime, including legacy aliases, admin, maintenance and external-root capabilities.",
+    groups: TOOL_GROUP_IDS,
+    preferCanonicalAlternatives: false,
+  },
+};
+
+export function isToolProfileId(value: string): value is ToolProfileId {
+  return (TOOL_PROFILE_IDS as readonly string[]).includes(value);
+}
+
+export function parseToolProfileId(value: string): ToolProfileId {
+  if (!isToolProfileId(value)) {
+    throw new Error(
+      `Unknown MCP tool profile ${JSON.stringify(value)}. Expected one of: ${TOOL_PROFILE_IDS.join(", ")}.`,
+    );
+  }
+  return value;
+}
+
+export interface CompileToolProfileInput {
+  profile: ToolProfileId;
+  registrationMode: ToolRegistrationMode;
+  availableStaticRequirements?: readonly ToolStaticRequirement[];
+}
+
+function suppressPreferredFallbacks(
+  entries: readonly ToolSurfaceEntry[],
+): readonly ToolSurfaceEntry[] {
+  const availableFamilies = new Set(entries.map((entry) => entry.family));
+  return entries.filter(
+    (entry) =>
+      !entry.preferredAlternativeFamily ||
+      !availableFamilies.has(entry.preferredAlternativeFamily),
+  );
+}
+
+function assertGovernedFamiliesAtomic(entries: readonly ToolSurfaceEntry[]): void {
+  const lifecycleByFamily = new Map<string, Set<string>>();
+  for (const entry of entries) {
+    if (!entry.lifecycleRole) continue;
+    const roles = lifecycleByFamily.get(entry.family) ?? new Set<string>();
+    roles.add(entry.lifecycleRole);
+    lifecycleByFamily.set(entry.family, roles);
+  }
+
+  const complete = new Set(["plan", "apply", "status", "recover"]);
+  for (const [family, roles] of lifecycleByFamily) {
+    if (
+      roles.size !== complete.size ||
+      [...complete].some((role) => !roles.has(role))
+    ) {
+      throw new Error(
+        `Tool profile exposes an incomplete governed lifecycle for ${family}: ${[...roles].sort().join(", ")}.`,
+      );
+    }
+  }
+}
+
+export function compileToolProfile({
+  profile,
+  registrationMode,
+  availableStaticRequirements,
+}: CompileToolProfileInput): readonly ToolSurfaceEntry[] {
+  const definition = TOOL_PROFILES[profile];
+  let entries = compileToolSurface({
+    registrationMode,
+    groups: definition.groups,
+    availableStaticRequirements,
+  });
+
+  if (definition.preferCanonicalAlternatives) {
+    entries = suppressPreferredFallbacks(entries);
+  }
+
+  assertGovernedFamiliesAtomic(entries);
+  return [...entries].sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export function compileToolProfileNames(
+  input: CompileToolProfileInput,
+): readonly string[] {
+  return compileToolProfile(input).map((entry) => entry.name);
+}

--- a/src/mcp-server/toolProfiles.ts
+++ b/src/mcp-server/toolProfiles.ts
@@ -1,6 +1,7 @@
 import {
   TOOL_GROUP_IDS,
   compileToolSurface,
+  getToolSurfaceEntry,
   type ToolGroupId,
   type ToolRegistrationMode,
   type ToolStaticRequirement,
@@ -137,28 +138,66 @@ function assertGovernedFamiliesAtomic(entries: readonly ToolSurfaceEntry[]): voi
   }
 }
 
+function finalizeProfileEntries(
+  definition: ToolProfileDefinition,
+  entries: readonly ToolSurfaceEntry[],
+): readonly ToolSurfaceEntry[] {
+  const selected = definition.preferCanonicalAlternatives
+    ? suppressPreferredFallbacks(entries)
+    : entries;
+  assertGovernedFamiliesAtomic(selected);
+  return [...selected].sort((left, right) => left.name.localeCompare(right.name));
+}
+
 export function compileToolProfile({
   profile,
   registrationMode,
   availableStaticRequirements,
 }: CompileToolProfileInput): readonly ToolSurfaceEntry[] {
   const definition = TOOL_PROFILES[profile];
-  let entries = compileToolSurface({
+  const entries = compileToolSurface({
     registrationMode,
     groups: definition.groups,
     availableStaticRequirements,
   });
-
-  if (definition.preferCanonicalAlternatives) {
-    entries = suppressPreferredFallbacks(entries);
-  }
-
-  assertGovernedFamiliesAtomic(entries);
-  return [...entries].sort((left, right) => left.name.localeCompare(right.name));
+  return finalizeProfileEntries(definition, entries);
 }
 
 export function compileToolProfileNames(
   input: CompileToolProfileInput,
 ): readonly string[] {
   return compileToolProfile(input).map((entry) => entry.name);
+}
+
+export interface SelectAvailableToolProfileInput {
+  profile: ToolProfileId;
+  availableNames: readonly string[];
+}
+
+/**
+ * Select a profile from the tools that a concrete server/proxy actually has.
+ * This is the runtime authority used by P2/P3: it intersects the portable
+ * profile contract with real registration rather than predicting availability.
+ *
+ * `full` intentionally preserves unknown future names for 2.x compatibility.
+ * Modern profiles fail closed on unknown names by omitting them until the
+ * canonical registry classifies them.
+ */
+export function selectAvailableToolProfileNames({
+  profile,
+  availableNames,
+}: SelectAvailableToolProfileInput): readonly string[] {
+  const uniqueNames = [...new Set(availableNames)];
+  if (profile === "full") {
+    return uniqueNames.sort((left, right) => left.localeCompare(right));
+  }
+
+  const definition = TOOL_PROFILES[profile];
+  const groups = new Set<ToolGroupId>(definition.groups);
+  const entries = uniqueNames
+    .map((name) => getToolSurfaceEntry(name))
+    .filter((entry): entry is ToolSurfaceEntry => Boolean(entry))
+    .filter((entry) => groups.has(entry.group));
+
+  return finalizeProfileEntries(definition, entries).map((entry) => entry.name);
 }

--- a/src/mcp-server/toolProfiles.ts
+++ b/src/mcp-server/toolProfiles.ts
@@ -55,6 +55,17 @@ const TASK_GROUPS = [
   "validation",
 ] as const satisfies readonly ToolGroupId[];
 
+const OPERON_LIVE_ONLY_READ_TOOLS = new Set([
+  "operon_query_saved_filter",
+  "operon_get_diagnostics",
+  "operon_find_tasks",
+  "operon_resolve_task",
+  "operon_get_relationships",
+  "operon_build_context",
+  "operon_get_timer_state",
+  "operon_list_pending_recoveries",
+]);
+
 export const TOOL_PROFILES: Readonly<Record<ToolProfileId, ToolProfileDefinition>> = {
   standard: {
     id: "standard",
@@ -73,14 +84,14 @@ export const TOOL_PROFILES: Readonly<Record<ToolProfileId, ToolProfileDefinition
   tasks: {
     id: "tasks",
     description:
-      "Task-focused work: note context, Markdown Tasks compatibility, the complete Operon MCP contract, canonical semantic search, validation and runtime status.",
+      "Task-focused work: note context, Markdown Tasks compatibility, the complete Operon MCP contract when the Desktop Bridge is configured, and only the snapshot-safe Operon read subset in non-live runtimes.",
     groups: TASK_GROUPS,
     preferCanonicalAlternatives: true,
   },
   full: {
     id: "full",
     description:
-      "Compatibility surface: every tool registered by the active runtime, including legacy aliases, admin, maintenance and external-root capabilities.",
+      "Compatibility surface: every tool registered by the active runtime, including legacy aliases, unavailable fail-closed compatibility tools, admin, maintenance and external-root capabilities.",
     groups: TOOL_GROUP_IDS,
     preferCanonicalAlternatives: false,
   },
@@ -138,13 +149,38 @@ function assertGovernedFamiliesAtomic(entries: readonly ToolSurfaceEntry[]): voi
   }
 }
 
+function operonLiveForRegistrationMode(
+  registrationMode: ToolRegistrationMode,
+): boolean {
+  return registrationMode === "live" || registrationMode === "hybrid-live";
+}
+
+function modernRuntimeAvailable(
+  entry: ToolSurfaceEntry,
+  operonLive: boolean,
+): boolean {
+  if (entry.group === "tasks.operon.write") return operonLive;
+  if (
+    entry.group === "tasks.operon.read" &&
+    OPERON_LIVE_ONLY_READ_TOOLS.has(entry.name)
+  ) {
+    return operonLive;
+  }
+  return true;
+}
+
 function finalizeProfileEntries(
   definition: ToolProfileDefinition,
   entries: readonly ToolSurfaceEntry[],
+  operonLive: boolean,
 ): readonly ToolSurfaceEntry[] {
-  const selected = definition.preferCanonicalAlternatives
-    ? suppressPreferredFallbacks(entries)
-    : entries;
+  let selected =
+    definition.id === "full"
+      ? entries
+      : entries.filter((entry) => modernRuntimeAvailable(entry, operonLive));
+  if (definition.preferCanonicalAlternatives) {
+    selected = suppressPreferredFallbacks(selected);
+  }
   assertGovernedFamiliesAtomic(selected);
   return [...selected].sort((left, right) => left.name.localeCompare(right.name));
 }
@@ -160,7 +196,11 @@ export function compileToolProfile({
     groups: definition.groups,
     availableStaticRequirements,
   });
-  return finalizeProfileEntries(definition, entries);
+  return finalizeProfileEntries(
+    definition,
+    entries,
+    operonLiveForRegistrationMode(registrationMode),
+  );
 }
 
 export function compileToolProfileNames(
@@ -180,8 +220,10 @@ export interface SelectAvailableToolProfileInput {
  * profile contract with real registration rather than predicting availability.
  *
  * `full` intentionally preserves unknown future names for 2.x compatibility.
- * Modern profiles fail closed on unknown names by omitting them until the
- * canonical registry classifies them.
+ * Modern profiles fail closed on unknown names and hide Operon tools whose
+ * service contract is statically live-only. Presence of the governed note
+ * family is used as the concrete live/hybrid marker because it is registered
+ * before Operon in live-capable server construction and is absent headlessly.
  */
 export function selectAvailableToolProfileNames({
   profile,
@@ -198,6 +240,9 @@ export function selectAvailableToolProfileNames({
     .map((name) => getToolSurfaceEntry(name))
     .filter((entry): entry is ToolSurfaceEntry => Boolean(entry))
     .filter((entry) => groups.has(entry.group));
+  const operonLive = uniqueNames.includes("obsidian_note_replace_plan");
 
-  return finalizeProfileEntries(definition, entries).map((entry) => entry.name);
+  return finalizeProfileEntries(definition, entries, operonLive).map(
+    (entry) => entry.name,
+  );
 }

--- a/src/mcp-server/toolSurfaceRegistry.ts
+++ b/src/mcp-server/toolSurfaceRegistry.ts
@@ -18,12 +18,16 @@ export const TOOL_GROUP_IDS = [
   "canvas.governed",
   "external.move",
   "external.read",
-  "metadata.direct",
+  "metadata.direct.batch",
+  "metadata.direct.frontmatter",
+  "metadata.direct.tags",
   "metadata.governed",
-  "notes.direct",
+  "notes.direct.admin",
+  "notes.direct.common",
   "notes.governed",
   "notes.read",
-  "runtime",
+  "runtime.maintenance",
+  "runtime.status",
   "semantic.canonical",
   "semantic.legacy",
   "tasks.markdown",
@@ -46,6 +50,12 @@ export type ToolAnnotationClass =
   | "governed-mutation";
 
 export type GovernedLifecycleRole = "plan" | "apply" | "status" | "recover";
+export type ToolStaticRequirement = "vault-cache";
+
+export interface ToolAvailabilityRule {
+  modes: readonly ToolRegistrationMode[];
+  requires: readonly ToolStaticRequirement[];
+}
 
 export interface ToolSurfaceEntry {
   name: string;
@@ -57,6 +67,8 @@ export interface ToolSurfaceEntry {
   annotationClass: ToolAnnotationClass;
   lifecycleRole?: GovernedLifecycleRole;
   aliasOf?: string;
+  preferredAlternativeFamily?: string;
+  availabilityRules?: readonly ToolAvailabilityRule[];
 }
 
 const ALL_MODES = TOOL_REGISTRATION_MODES;
@@ -102,6 +114,8 @@ function defineTool(
     annotationClass?: ToolAnnotationClass;
     lifecycleRole?: GovernedLifecycleRole;
     aliasOf?: string;
+    preferredAlternativeFamily?: string;
+    availabilityRules?: readonly ToolAvailabilityRule[];
   } = {},
 ): ToolSurfaceEntry {
   return {
@@ -114,6 +128,12 @@ function defineTool(
     annotationClass: options.annotationClass ?? "read-only",
     ...(options.lifecycleRole ? { lifecycleRole: options.lifecycleRole } : {}),
     ...(options.aliasOf ? { aliasOf: options.aliasOf } : {}),
+    ...(options.preferredAlternativeFamily
+      ? { preferredAlternativeFamily: options.preferredAlternativeFamily }
+      : {}),
+    ...(options.availabilityRules
+      ? { availabilityRules: options.availabilityRules }
+      : {}),
   };
 }
 
@@ -172,33 +192,40 @@ const OPERON_MUTATION_TOOLS = [
 export const TOOL_SURFACE_REGISTRY: readonly ToolSurfaceEntry[] = [
   defineTool("obsidian_read_note", "notes.read", "notes-core", ALL_MODES),
   defineTool("obsidian_list_notes", "notes.read", "notes-core", ALL_MODES),
-  defineTool("obsidian_global_search", "notes.read", "notes-core", ALL_MODES),
+  defineTool("obsidian_global_search", "notes.read", "notes-core", ALL_MODES, {
+    availabilityRules: [
+      {
+        modes: ALL_MODES,
+        requires: ["vault-cache"],
+      },
+    ],
+  }),
 
   defineTool(
     "obsidian_update_note",
-    "notes.direct",
+    "notes.direct.common",
     "notes-core",
     GUARDED_NOTE_MODES,
     { surfaceClass: "direct", annotationClass: "destructive" },
   ),
   defineTool(
     "obsidian_search_replace",
-    "notes.direct",
+    "notes.direct.common",
     "notes-core",
     GUARDED_NOTE_MODES,
     { surfaceClass: "direct", annotationClass: "destructive" },
   ),
   defineTool(
     "obsidian_delete_note",
-    "notes.direct",
-    "notes-core",
+    "notes.direct.admin",
+    "notes-admin",
     LIVE_OR_FILESYSTEM_MODES,
     { surfaceClass: "direct", annotationClass: "destructive" },
   ),
   defineTool(
     "obsidian_move_note",
-    "notes.direct",
-    "notes-core",
+    "notes.direct.admin",
+    "notes-admin",
     FILESYSTEM_ONLY,
     { surfaceClass: "direct", annotationClass: "destructive" },
   ),
@@ -211,22 +238,26 @@ export const TOOL_SURFACE_REGISTRY: readonly ToolSurfaceEntry[] = [
 
   defineTool(
     "obsidian_manage_frontmatter",
-    "metadata.direct",
-    "frontmatter",
+    "metadata.direct.frontmatter",
+    "frontmatter-direct",
     GUARDED_NOTE_MODES,
-    { surfaceClass: "direct", annotationClass: "destructive" },
+    {
+      surfaceClass: "direct",
+      annotationClass: "destructive",
+      preferredAlternativeFamily: "frontmatter-patch",
+    },
   ),
   defineTool(
     "obsidian_manage_tags",
-    "metadata.direct",
+    "metadata.direct.tags",
     "tags",
     LIVE_OR_FILESYSTEM_MODES,
     { surfaceClass: "direct", annotationClass: "destructive" },
   ),
   defineTool(
     "obsidian_batch_frontmatter",
-    "metadata.direct",
-    "frontmatter",
+    "metadata.direct.batch",
+    "frontmatter-batch",
     FILESYSTEM_ONLY,
     { surfaceClass: "direct", annotationClass: "destructive" },
   ),
@@ -237,9 +268,30 @@ export const TOOL_SURFACE_REGISTRY: readonly ToolSurfaceEntry[] = [
     "frontmatter-patch",
   ),
 
-  defineTool("bases_list", "bases.read", "bases", BASE_READ_MODES),
-  defineTool("bases_get_schema", "bases.read", "bases", BASE_READ_MODES),
-  defineTool("bases_query", "bases.read", "bases", BASE_READ_MODES),
+  defineTool("bases_list", "bases.read", "bases", BASE_READ_MODES, {
+    availabilityRules: [
+      {
+        modes: ["headless-readonly"],
+        requires: ["vault-cache"],
+      },
+    ],
+  }),
+  defineTool("bases_get_schema", "bases.read", "bases", BASE_READ_MODES, {
+    availabilityRules: [
+      {
+        modes: ["headless-readonly"],
+        requires: ["vault-cache"],
+      },
+    ],
+  }),
+  defineTool("bases_query", "bases.read", "bases", BASE_READ_MODES, {
+    availabilityRules: [
+      {
+        modes: ["headless-readonly"],
+        requires: ["vault-cache"],
+      },
+    ],
+  }),
 
   defineTool(
     "bases_create",
@@ -274,7 +326,11 @@ export const TOOL_SURFACE_REGISTRY: readonly ToolSurfaceEntry[] = [
     "canvas.direct",
     "canvas",
     FILESYSTEM_ONLY,
-    { surfaceClass: "direct", annotationClass: "destructive" },
+    {
+      surfaceClass: "direct",
+      annotationClass: "destructive",
+      preferredAlternativeFamily: "canvas-patch",
+    },
   ),
 
   ...governedFamily(
@@ -342,10 +398,10 @@ export const TOOL_SURFACE_REGISTRY: readonly ToolSurfaceEntry[] = [
     },
   ),
 
-  defineTool("obsidian_runtime_status", "runtime", "runtime", ALL_MODES),
+  defineTool("obsidian_runtime_status", "runtime.status", "runtime", ALL_MODES),
   defineTool(
     "obsidian_runtime_maintenance",
-    "runtime",
+    "runtime.maintenance",
     "runtime",
     ALL_MODES,
     { annotationClass: "maintenance" },
@@ -440,17 +496,36 @@ export const TOOL_SURFACE_REGISTRY: readonly ToolSurfaceEntry[] = [
 export interface CompileToolSurfaceInput {
   registrationMode: ToolRegistrationMode;
   groups?: readonly ToolGroupId[];
+  availableStaticRequirements?: readonly ToolStaticRequirement[];
+}
+
+function staticRequirementsSatisfied(
+  entry: ToolSurfaceEntry,
+  registrationMode: ToolRegistrationMode,
+  availableStaticRequirements: readonly ToolStaticRequirement[] | undefined,
+): boolean {
+  if (!availableStaticRequirements) return true;
+  const available = new Set<ToolStaticRequirement>(availableStaticRequirements);
+  return (entry.availabilityRules ?? [])
+    .filter((rule) => rule.modes.includes(registrationMode))
+    .every((rule) => rule.requires.every((requirement) => available.has(requirement)));
 }
 
 export function compileToolSurface({
   registrationMode,
   groups = TOOL_GROUP_IDS,
+  availableStaticRequirements,
 }: CompileToolSurfaceInput): readonly ToolSurfaceEntry[] {
   const selectedGroups = new Set<ToolGroupId>(groups);
   return TOOL_SURFACE_REGISTRY.filter(
     (entry) =>
       selectedGroups.has(entry.group) &&
-      entry.registrationModes.includes(registrationMode),
+      entry.registrationModes.includes(registrationMode) &&
+      staticRequirementsSatisfied(
+        entry,
+        registrationMode,
+        availableStaticRequirements,
+      ),
   ).sort((left, right) => left.name.localeCompare(right.name));
 }
 

--- a/src/mcp-server/toolSurfaceRegistry.ts
+++ b/src/mcp-server/toolSurfaceRegistry.ts
@@ -1,0 +1,467 @@
+export const TOOL_REGISTRATION_MODES = [
+  "live",
+  "hybrid-live",
+  "hybrid-degraded",
+  "headless-readonly",
+  "headless-guarded",
+  "headless-filesystem",
+] as const;
+
+export type ToolRegistrationMode = (typeof TOOL_REGISTRATION_MODES)[number];
+
+export const TOOL_GROUP_IDS = [
+  "admin",
+  "bases.direct",
+  "bases.governed",
+  "bases.read",
+  "canvas.direct",
+  "canvas.governed",
+  "external.move",
+  "external.read",
+  "metadata.direct",
+  "metadata.governed",
+  "notes.direct",
+  "notes.governed",
+  "notes.read",
+  "runtime",
+  "semantic.canonical",
+  "semantic.legacy",
+  "tasks.markdown",
+  "tasks.operon.read",
+  "tasks.operon.write",
+  "validation",
+] as const;
+
+export type ToolGroupId = (typeof TOOL_GROUP_IDS)[number];
+
+export type ToolSurfaceClass = "canonical" | "direct" | "legacy";
+
+export type ToolAnnotationClass =
+  | "read-only"
+  | "read-only-open-world"
+  | "mutation"
+  | "destructive"
+  | "maintenance"
+  | "governed-plan"
+  | "governed-mutation";
+
+export type GovernedLifecycleRole = "plan" | "apply" | "status" | "recover";
+
+export interface ToolSurfaceEntry {
+  name: string;
+  canonicalName: string;
+  group: ToolGroupId;
+  family: string;
+  registrationModes: readonly ToolRegistrationMode[];
+  surfaceClass: ToolSurfaceClass;
+  annotationClass: ToolAnnotationClass;
+  lifecycleRole?: GovernedLifecycleRole;
+  aliasOf?: string;
+}
+
+const ALL_MODES = TOOL_REGISTRATION_MODES;
+
+const LIVE_MODES = [
+  "live",
+  "hybrid-live",
+] as const satisfies readonly ToolRegistrationMode[];
+
+const BASE_READ_MODES = [
+  "live",
+  "hybrid-live",
+  "headless-readonly",
+  "headless-guarded",
+  "headless-filesystem",
+] as const satisfies readonly ToolRegistrationMode[];
+
+const GUARDED_NOTE_MODES = [
+  "live",
+  "hybrid-live",
+  "headless-guarded",
+  "headless-filesystem",
+] as const satisfies readonly ToolRegistrationMode[];
+
+const LIVE_OR_FILESYSTEM_MODES = [
+  "live",
+  "hybrid-live",
+  "headless-filesystem",
+] as const satisfies readonly ToolRegistrationMode[];
+
+const FILESYSTEM_ONLY = [
+  "headless-filesystem",
+] as const satisfies readonly ToolRegistrationMode[];
+
+function defineTool(
+  name: string,
+  group: ToolGroupId,
+  family: string,
+  registrationModes: readonly ToolRegistrationMode[],
+  options: {
+    canonicalName?: string;
+    surfaceClass?: ToolSurfaceClass;
+    annotationClass?: ToolAnnotationClass;
+    lifecycleRole?: GovernedLifecycleRole;
+    aliasOf?: string;
+  } = {},
+): ToolSurfaceEntry {
+  return {
+    name,
+    canonicalName: options.canonicalName ?? options.aliasOf ?? name,
+    group,
+    family,
+    registrationModes,
+    surfaceClass: options.surfaceClass ?? "canonical",
+    annotationClass: options.annotationClass ?? "read-only",
+    ...(options.lifecycleRole ? { lifecycleRole: options.lifecycleRole } : {}),
+    ...(options.aliasOf ? { aliasOf: options.aliasOf } : {}),
+  };
+}
+
+function governedFamily(
+  prefix: string,
+  group: ToolGroupId,
+  family: string,
+): readonly ToolSurfaceEntry[] {
+  return [
+    defineTool(`${prefix}_plan`, group, family, LIVE_MODES, {
+      annotationClass: "governed-plan",
+      lifecycleRole: "plan",
+    }),
+    defineTool(`${prefix}_apply`, group, family, LIVE_MODES, {
+      annotationClass: "governed-mutation",
+      lifecycleRole: "apply",
+    }),
+    defineTool(`${prefix}_status`, group, family, LIVE_MODES, {
+      lifecycleRole: "status",
+    }),
+    defineTool(`${prefix}_recover`, group, family, LIVE_MODES, {
+      annotationClass: "governed-mutation",
+      lifecycleRole: "recover",
+    }),
+  ];
+}
+
+const OPERON_READ_TOOLS = [
+  "operon_status",
+  "operon_get_configuration",
+  "operon_list_tasks",
+  "operon_query_tasks",
+  "operon_query_saved_filter",
+  "operon_get_task",
+  "operon_validate",
+  "operon_get_diagnostics",
+  "operon_find_tasks",
+  "operon_resolve_task",
+  "operon_get_relationships",
+  "operon_build_context",
+  "operon_get_timer_state",
+  "operon_list_pending_recoveries",
+] as const;
+
+const OPERON_MUTATION_TOOLS = [
+  "operon_adopt_task",
+  "operon_create_task",
+  "operon_update_task",
+  "operon_transition_task",
+  "operon_relocate_task",
+  "operon_set_relationships",
+  "operon_update_recurrence",
+  "operon_recover_mutation",
+] as const;
+
+export const TOOL_SURFACE_REGISTRY: readonly ToolSurfaceEntry[] = [
+  defineTool("obsidian_read_note", "notes.read", "notes-core", ALL_MODES),
+  defineTool("obsidian_list_notes", "notes.read", "notes-core", ALL_MODES),
+  defineTool("obsidian_global_search", "notes.read", "notes-core", ALL_MODES),
+
+  defineTool(
+    "obsidian_update_note",
+    "notes.direct",
+    "notes-core",
+    GUARDED_NOTE_MODES,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+  defineTool(
+    "obsidian_search_replace",
+    "notes.direct",
+    "notes-core",
+    GUARDED_NOTE_MODES,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+  defineTool(
+    "obsidian_delete_note",
+    "notes.direct",
+    "notes-core",
+    LIVE_OR_FILESYSTEM_MODES,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+  defineTool(
+    "obsidian_move_note",
+    "notes.direct",
+    "notes-core",
+    FILESYSTEM_ONLY,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+
+  ...governedFamily(
+    "obsidian_note_replace",
+    "notes.governed",
+    "note-replace",
+  ),
+
+  defineTool(
+    "obsidian_manage_frontmatter",
+    "metadata.direct",
+    "frontmatter",
+    GUARDED_NOTE_MODES,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+  defineTool(
+    "obsidian_manage_tags",
+    "metadata.direct",
+    "tags",
+    LIVE_OR_FILESYSTEM_MODES,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+  defineTool(
+    "obsidian_batch_frontmatter",
+    "metadata.direct",
+    "frontmatter",
+    FILESYSTEM_ONLY,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+
+  ...governedFamily(
+    "obsidian_frontmatter_patch",
+    "metadata.governed",
+    "frontmatter-patch",
+  ),
+
+  defineTool("bases_list", "bases.read", "bases", BASE_READ_MODES),
+  defineTool("bases_get_schema", "bases.read", "bases", BASE_READ_MODES),
+  defineTool("bases_query", "bases.read", "bases", BASE_READ_MODES),
+
+  defineTool(
+    "bases_create",
+    "bases.direct",
+    "bases",
+    LIVE_OR_FILESYSTEM_MODES,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+  defineTool(
+    "bases_upsert_config",
+    "bases.direct",
+    "bases",
+    LIVE_OR_FILESYSTEM_MODES,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+  defineTool(
+    "bases_upsert_rows",
+    "bases.direct",
+    "bases",
+    LIVE_OR_FILESYSTEM_MODES,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+
+  ...governedFamily(
+    "bases_formula_patch",
+    "bases.governed",
+    "base-formula-patch",
+  ),
+
+  defineTool(
+    "obsidian_manage_canvas",
+    "canvas.direct",
+    "canvas",
+    FILESYSTEM_ONLY,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+
+  ...governedFamily(
+    "obsidian_canvas_patch",
+    "canvas.governed",
+    "canvas-patch",
+  ),
+
+  defineTool(
+    "list_all_tasks",
+    "tasks.markdown",
+    "markdown-tasks",
+    ALL_MODES,
+  ),
+  defineTool(
+    "query_tasks",
+    "tasks.markdown",
+    "markdown-tasks",
+    ALL_MODES,
+  ),
+
+  ...OPERON_READ_TOOLS.map((name) =>
+    defineTool(name, "tasks.operon.read", "operon", ALL_MODES),
+  ),
+  ...OPERON_MUTATION_TOOLS.map((name) =>
+    defineTool(name, "tasks.operon.write", "operon", ALL_MODES, {
+      annotationClass: "mutation",
+    }),
+  ),
+  defineTool(
+    "operon_convert_task",
+    "tasks.operon.write",
+    "operon",
+    ALL_MODES,
+    { annotationClass: "destructive" },
+  ),
+
+  defineTool(
+    "smart_semantic_search",
+    "semantic.canonical",
+    "semantic-search",
+    ALL_MODES,
+    { annotationClass: "read-only-open-world" },
+  ),
+  defineTool(
+    "smart_search",
+    "semantic.legacy",
+    "semantic-search",
+    ALL_MODES,
+    {
+      aliasOf: "smart_semantic_search",
+      surfaceClass: "legacy",
+      annotationClass: "read-only-open-world",
+    },
+  ),
+  defineTool(
+    "smart-search",
+    "semantic.legacy",
+    "semantic-search",
+    ALL_MODES,
+    {
+      aliasOf: "smart_semantic_search",
+      surfaceClass: "legacy",
+      annotationClass: "read-only-open-world",
+    },
+  ),
+
+  defineTool("obsidian_runtime_status", "runtime", "runtime", ALL_MODES),
+  defineTool(
+    "obsidian_runtime_maintenance",
+    "runtime",
+    "runtime",
+    ALL_MODES,
+    { annotationClass: "maintenance" },
+  ),
+
+  defineTool(
+    "obsidian_validate_format",
+    "validation",
+    "format-validation",
+    ALL_MODES,
+  ),
+
+  defineTool(
+    "obsidian_admin_filesystem",
+    "admin",
+    "filesystem-admin",
+    FILESYSTEM_ONLY,
+    { surfaceClass: "direct", annotationClass: "destructive" },
+  ),
+
+  defineTool(
+    "external_runtime_status",
+    "external.read",
+    "external-roots",
+    ALL_MODES,
+  ),
+  defineTool(
+    "external_roots_list",
+    "external.read",
+    "external-roots",
+    ALL_MODES,
+  ),
+  defineTool(
+    "external_list",
+    "external.read",
+    "external-roots",
+    ALL_MODES,
+  ),
+  defineTool(
+    "external_stat",
+    "external.read",
+    "external-roots",
+    ALL_MODES,
+  ),
+  defineTool(
+    "external_read",
+    "external.read",
+    "external-roots",
+    ALL_MODES,
+  ),
+  defineTool(
+    "external_handoff",
+    "external.read",
+    "external-roots",
+    ALL_MODES,
+  ),
+  defineTool(
+    "external_references_scan",
+    "external.read",
+    "external-roots",
+    ALL_MODES,
+  ),
+
+  defineTool(
+    "external_move_plan",
+    "external.move",
+    "external-move",
+    ALL_MODES,
+  ),
+  defineTool(
+    "external_move_status",
+    "external.move",
+    "external-move",
+    ALL_MODES,
+  ),
+  defineTool(
+    "external_move_apply",
+    "external.move",
+    "external-move",
+    ALL_MODES,
+    { annotationClass: "destructive" },
+  ),
+  defineTool(
+    "external_move_rollback",
+    "external.move",
+    "external-move",
+    ALL_MODES,
+    { annotationClass: "destructive" },
+  ),
+] as const;
+
+export interface CompileToolSurfaceInput {
+  registrationMode: ToolRegistrationMode;
+  groups?: readonly ToolGroupId[];
+}
+
+export function compileToolSurface({
+  registrationMode,
+  groups = TOOL_GROUP_IDS,
+}: CompileToolSurfaceInput): readonly ToolSurfaceEntry[] {
+  const selectedGroups = new Set<ToolGroupId>(groups);
+  return TOOL_SURFACE_REGISTRY.filter(
+    (entry) =>
+      selectedGroups.has(entry.group) &&
+      entry.registrationModes.includes(registrationMode),
+  ).sort((left, right) => left.name.localeCompare(right.name));
+}
+
+export function compileToolNames(
+  input: CompileToolSurfaceInput,
+): readonly string[] {
+  return compileToolSurface(input).map((entry) => entry.name);
+}
+
+export function getToolSurfaceEntry(
+  name: string,
+): ToolSurfaceEntry | undefined {
+  return TOOL_SURFACE_REGISTRY.find((entry) => entry.name === name);
+}

--- a/src/mcp-server/toolSurfaceRegistry.ts
+++ b/src/mcp-server/toolSurfaceRegistry.ts
@@ -11,6 +11,7 @@ export type ToolRegistrationMode = (typeof TOOL_REGISTRATION_MODES)[number];
 
 export const TOOL_GROUP_IDS = [
   "admin",
+  "bases.compat",
   "bases.direct",
   "bases.governed",
   "bases.read",
@@ -302,7 +303,7 @@ export const TOOL_SURFACE_REGISTRY: readonly ToolSurfaceEntry[] = [
   ),
   defineTool(
     "bases_upsert_config",
-    "bases.direct",
+    "bases.compat",
     "bases",
     LIVE_OR_FILESYSTEM_MODES,
     { surfaceClass: "direct", annotationClass: "destructive" },
@@ -508,7 +509,9 @@ function staticRequirementsSatisfied(
   const available = new Set<ToolStaticRequirement>(availableStaticRequirements);
   return (entry.availabilityRules ?? [])
     .filter((rule) => rule.modes.includes(registrationMode))
-    .every((rule) => rule.requires.every((requirement) => available.has(requirement)));
+    .every((rule) =>
+      rule.requires.every((requirement) => available.has(requirement)),
+    );
 }
 
 export function compileToolSurface({

--- a/src/mcp-server/transports/httpToolProfileRouting.ts
+++ b/src/mcp-server/transports/httpToolProfileRouting.ts
@@ -1,0 +1,70 @@
+import {
+  TOOL_PROFILE_IDS,
+  parseToolProfileId,
+  type ToolProfileId,
+} from "../toolProfiles.js";
+
+export const INTERNAL_TOOL_PROFILE_HEADER =
+  "x-optimike-internal-tool-profile" as const;
+
+export function toolProfileForMcpPath(
+  pathname: string,
+): ToolProfileId | undefined {
+  if (pathname === "/mcp") return "full";
+  if (!pathname.startsWith("/mcp/")) return undefined;
+
+  const suffix = pathname.slice("/mcp/".length);
+  if (!suffix || suffix.includes("/")) {
+    throw new Error("Invalid MCP tool profile path.");
+  }
+  return parseToolProfileId(decodeURIComponent(suffix));
+}
+
+/**
+ * Public profile endpoints are rewritten internally to the existing /mcp Hono
+ * route. The internal profile header is always overwritten from the path, so a
+ * caller cannot inject or switch profile through a custom header.
+ */
+export function rewriteProfiledMcpRequest(request: Request): Request | Response {
+  const url = new URL(request.url);
+  let profile: ToolProfileId | undefined;
+  try {
+    profile = toolProfileForMcpPath(url.pathname);
+  } catch {
+    return new Response(
+      JSON.stringify({
+        error: "unknown_tool_profile",
+        message: `MCP profile must be one of: ${TOOL_PROFILE_IDS.join(", ")}.`,
+      }),
+      {
+        status: 404,
+        headers: {
+          "content-type": "application/json; charset=utf-8",
+          "cache-control": "no-store",
+        },
+      },
+    );
+  }
+
+  if (!profile) return request;
+
+  const headers = new Headers(request.headers);
+  headers.set(INTERNAL_TOOL_PROFILE_HEADER, profile);
+  url.pathname = "/mcp";
+  return new Request(url, {
+    method: request.method,
+    headers,
+    body:
+      request.method === "GET" || request.method === "HEAD"
+        ? undefined
+        : request.body,
+    duplex: request.body ? "half" : undefined,
+    signal: request.signal,
+  } as RequestInit & { duplex?: "half" });
+}
+
+export function toolProfileFromInternalRequest(request: Request): ToolProfileId {
+  return parseToolProfileId(
+    request.headers.get(INTERNAL_TOOL_PROFILE_HEADER) ?? "full",
+  );
+}

--- a/src/mcp-server/transports/httpTransport.ts
+++ b/src/mcp-server/transports/httpTransport.ts
@@ -7,8 +7,9 @@
  * 2. a bounded functional limiter keyed by verified authentication claims.
  *
  * Proxy headers are ignored unless the immediate peer belongs to the explicit
- * `MCP_TRUSTED_PROXIES` allowlist. MCP sessions are bound to the verified identity
- * that initialized them. Raw bearer tokens are never used as keys or log fields.
+ * `MCP_TRUSTED_PROXIES` allowlist. MCP sessions are bound to both the verified
+ * identity and the public tool profile that initialized them. Raw bearer tokens
+ * are never used as keys or log fields.
  *
  * @module src/mcp-server/transports/httpTransport
  */
@@ -37,6 +38,12 @@ import {
   RequestContext,
   requestContextService,
 } from "../../utils/index.js";
+import { withToolProfileContext } from "../toolProfileContext.js";
+import type { ToolProfileId } from "../toolProfiles.js";
+import {
+  rewriteProfiledMcpRequest,
+  toolProfileFromInternalRequest,
+} from "./httpToolProfileRouting.js";
 import {
   jwtAuthMiddleware,
   oauthMiddleware,
@@ -81,6 +88,7 @@ type HttpSession = {
   transport: WebStandardStreamableHTTPServerTransport;
   identityKey: string;
   identityPseudonym: string;
+  toolProfile: ToolProfileId;
   createdAt: number;
   lastSeenAt: number;
   activeRequests: number;
@@ -164,6 +172,10 @@ function originAllowed(origin: string): boolean {
   return (config.mcpAllowedOrigins ?? []).includes(origin);
 }
 
+function requestToolProfile(c: Context): ToolProfileId {
+  return toolProfileFromInternalRequest(c.req.raw);
+}
+
 async function authMiddleware(
   c: Context<{ Bindings: HttpBindings }>,
   next: Next,
@@ -200,8 +212,6 @@ async function rateLimitResponse(
   const requestState = getHttpRequestState(c.req.raw);
   const preAuthRejection = scope !== "client-identity";
   if (preAuthRejection && c.req.method === "POST") {
-    // Source limiting runs before the request-body guard. Never clone or parse
-    // an untrusted body on this rejection path; cancel it instead.
     void c.req.raw.body
       ?.cancel("pre-authentication source rate limit")
       .catch(() => undefined);
@@ -238,8 +248,6 @@ async function rateLimitResponse(
             ? "Rate-limit state capacity is temporarily exhausted."
             : "Rate limit exceeded.",
       },
-      // Quota rejection happens before request-body admission. Do not clone or
-      // parse an attacker-controlled body merely to recover its JSON-RPC id.
       id: null,
     },
     429,
@@ -412,6 +420,7 @@ function sessionForRequest(
   const session = transports.get(sessionId);
   if (!session) return undefined;
   const identity = requireIdentity(c);
+  const requestedProfile = requestToolProfile(c);
   if (session.identityKey !== identity.key) {
     logger.warning(
       "HTTP session identity mismatch rejected.",
@@ -419,6 +428,22 @@ function sessionForRequest(
         requestId: getHttpRequestState(c.req.raw).requestId,
         operation: "httpSessionIdentityMismatch",
         clientIdentity: identity.pseudonym,
+      }),
+    );
+    throw new McpError(
+      BaseErrorCode.NOT_FOUND,
+      "Invalid or expired session ID.",
+    );
+  }
+  if (session.toolProfile !== requestedProfile) {
+    logger.warning(
+      "HTTP session tool-profile mismatch rejected.",
+      requestContextService.createRequestContext({
+        requestId: getHttpRequestState(c.req.raw).requestId,
+        operation: "httpSessionToolProfileMismatch",
+        clientIdentity: identity.pseudonym,
+        sessionToolProfile: session.toolProfile,
+        requestedToolProfile: requestedProfile,
       }),
     );
     throw new McpError(
@@ -567,13 +592,18 @@ function startHttpServerWithRetry(
       }
 
       try {
+        const fetch = async (request: Request) => {
+          const routed = rewriteProfiledMcpRequest(request);
+          return routed instanceof Response ? routed : app.fetch(routed);
+        };
         const serverInstance = serve(
-          { fetch: app.fetch, port: currentPort, hostname: host },
+          { fetch, port: currentPort, hostname: host },
           (info: { address: string; port: number }) => {
             const serverAddress = `http://${info.address}:${info.port}${MCP_ENDPOINT_PATH}`;
             logger.info(`HTTP transport listening at ${serverAddress}`, {
               ...attemptContext,
               address: serverAddress,
+              toolProfiles: ["standard", "authoring", "tasks", "full"],
             });
             if (process.stdout.isTTY) {
               console.log(`\n🚀 MCP Server running at: ${serverAddress}\n`);
@@ -687,8 +717,6 @@ export async function startHttpTransport(
 
   app.use(MCP_ENDPOINT_PATH, preAuthRateLimitMiddleware);
   app.use(externalHandoffEndpoint, preAuthRateLimitMiddleware);
-  // Source limiting must happen before buffering. Its 429 path never reads the
-  // body; this guard then protects authentication and identity-quota errors.
   app.use(MCP_ENDPOINT_PATH, httpRequestBodyGuardMiddleware);
   app.use(MCP_ENDPOINT_PATH, authMiddleware);
   app.use(externalHandoffEndpoint, authMiddleware);
@@ -748,11 +776,13 @@ export async function startHttpTransport(
   app.post(MCP_ENDPOINT_PATH, async (c: Context) => {
     const state = getHttpRequestState(c.req.raw);
     const identity = requireIdentity(c);
+    const toolProfile = requestToolProfile(c);
     const postContext = requestContextService.createRequestContext({
       ...transportContext,
       requestId: state.requestId,
       operation: "handlePost",
       clientIdentity: identity.pseudonym,
+      toolProfile,
     });
     const body = await c.req.raw.clone().json();
     const sessionId = c.req.header("mcp-session-id");
@@ -787,6 +817,7 @@ export async function startHttpTransport(
             transport: newTransport,
             identityKey: identity.key,
             identityPseudonym: identity.pseudonym,
+            toolProfile,
             createdAt: now,
             lastSeenAt: now,
             activeRequests: 1,
@@ -800,6 +831,7 @@ export async function startHttpTransport(
                 requestContextService.createRequestContext({
                   operation: "expireHttpSessionMaxLifetime",
                   clientIdentity: identity.pseudonym,
+                  toolProfile,
                   sessionCount: transports.size,
                 }),
               );
@@ -835,7 +867,9 @@ export async function startHttpTransport(
       };
 
       try {
-        const server = await createServerInstanceFn();
+        const server = await withToolProfileContext(toolProfile, () =>
+          createServerInstanceFn(),
+        );
         await server.connect(newTransport);
         transport = newTransport;
       } catch (error) {

--- a/src/mcp-server/transports/httpTransport.ts
+++ b/src/mcp-server/transports/httpTransport.ts
@@ -592,9 +592,11 @@ function startHttpServerWithRetry(
       }
 
       try {
-        const fetch = async (request: Request) => {
+        const fetch: typeof app.fetch = (request, env, executionCtx) => {
           const routed = rewriteProfiledMcpRequest(request);
-          return routed instanceof Response ? routed : app.fetch(routed);
+          return routed instanceof Response
+            ? routed
+            : app.fetch(routed, env, executionCtx);
         };
         const serverInstance = serve(
           { fetch, port: currentPort, hostname: host },

--- a/src/stdio-proxy.ts
+++ b/src/stdio-proxy.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import "./config/toolProfileCli.js";
 import { createHash } from "node:crypto";
 import { readFileSync } from "node:fs";
 import path from "node:path";
@@ -25,6 +26,11 @@ import {
   ExternalStatSchema,
   externalRootsResult,
 } from "./mcp-server/tools/externalRootsTools/registration.js";
+import {
+  selectAvailableToolProfileNames,
+  type ToolProfileId,
+} from "./mcp-server/toolProfiles.js";
+import { resolveToolProfile } from "./mcp-server/toolProfileRuntime.js";
 import { config, profileExternalMoveJournalPath } from "./config/index.js";
 import { ensureLocalBackendRunning } from "./runtime/localBackend.js";
 import {
@@ -57,6 +63,7 @@ const port = Number(process.env.MCP_HTTP_PORT || "3010");
 const backendUrl = new URL(`http://${host}:${port}/mcp`);
 const healthUrl = new URL(`http://${host}:${port}/healthz`);
 const backendBearerToken = process.env.MCP_BACKEND_BEARER_TOKEN?.trim();
+const toolProfile: ToolProfileId = resolveToolProfile();
 
 const proxyServer = new Server(
   { name: `${packageName}-stdio-proxy`, version: packageVersion },
@@ -64,6 +71,7 @@ const proxyServer = new Server(
 );
 
 let backend: BackendClient | undefined;
+let allowedToolNames: Set<string> | undefined;
 let externalRootsService: ExternalRootsService | undefined;
 let externalMoveCoordinator: ExternalMoveCoordinator | undefined;
 let externalMoveBindingIdentity: ExternalMoveBindingIdentity | undefined;
@@ -124,6 +132,26 @@ function invalidExternalArguments(
   };
 }
 
+function hiddenToolResult(toolName: string) {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify(
+          {
+            error: "tool_not_exposed",
+            message: `Tool ${toolName} is not exposed by MCP tool profile ${toolProfile}.`,
+            toolProfile,
+          },
+          null,
+          2,
+        ),
+      },
+    ],
+    isError: true,
+  };
+}
+
 function isReconnectableBackendError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
   return (
@@ -149,6 +177,7 @@ async function ensureBackendConnected(forceReconnect = false): Promise<Client> {
     ]);
     backend = undefined;
   }
+  allowedToolNames = undefined;
 
   await ensureLocalBackendRunning({
     serviceName: packageName,
@@ -159,6 +188,9 @@ async function ensureBackendConnected(forceReconnect = false): Promise<Client> {
     env: {
       ...process.env,
       MCP_TRANSPORT_TYPE: "http",
+      // One shared backend must never inherit a per-agent stdio profile.
+      // Per-client exposure is enforced by this proxy; the backend stays full.
+      MCP_TOOL_PROFILE: "full",
     },
     startupTimeoutMs: Number(process.env.MCP_PROXY_START_TIMEOUT_MS || "20000"),
   });
@@ -217,6 +249,30 @@ async function withBackendRetry<T>(
   }
 }
 
+async function filteredBackendTools(params?: Record<string, unknown>) {
+  const result = await withBackendRetry("listTools", (client) =>
+    client.listTools(params),
+  );
+  const selected = new Set(
+    selectAvailableToolProfileNames({
+      profile: toolProfile,
+      availableNames: result.tools.map((tool) => tool.name),
+    }),
+  );
+  allowedToolNames = selected;
+  return {
+    ...result,
+    tools: result.tools.filter((tool) => selected.has(tool.name)),
+  };
+}
+
+async function toolIsExposed(toolName: string): Promise<boolean> {
+  if (!allowedToolNames) {
+    await filteredBackendTools();
+  }
+  return allowedToolNames?.has(toolName) ?? false;
+}
+
 async function shutdown(signal: string) {
   console.error(`[${packageName}] proxy shutdown on ${signal}`);
   await Promise.allSettled([
@@ -268,10 +324,14 @@ async function start() {
   }
 
   proxyServer.setRequestHandler(ListToolsRequestSchema, async (request) =>
-    withBackendRetry("listTools", (client) => client.listTools(request.params)),
+    filteredBackendTools(request.params),
   );
 
   proxyServer.setRequestHandler(CallToolRequestSchema, async (request) => {
+    if (!(await toolIsExposed(request.params.name))) {
+      return hiddenToolResult(request.params.name);
+    }
+
     if (request.params.name === "external_runtime_status") {
       return externalRootsResult(async () => ({
         enabled: Boolean(externalRootsService),
@@ -494,7 +554,7 @@ async function start() {
   const stdioTransport = new StdioServerTransport();
   await proxyServer.connect(stdioTransport);
   console.error(
-    `[${packageName}] stdio proxy connected to ${backendUrl.toString()}`,
+    `[${packageName}] stdio proxy connected to ${backendUrl.toString()} with tool profile ${toolProfile}`,
   );
 }
 


### PR DESCRIPTION
## 2.10 tool-surface implementation

This PR is the **authoritative P0–P4 chain** for Optimike MCP 2.10. It introduces server-owned, client-agnostic MCP tool surfaces while keeping the 2.x compatibility surface unchanged by default.

### P0 — canonical registry

- one canonical cross-runtime registry for 76 unique tool names;
- current full live/hybrid registration remains 72 tools;
- group/family/runtime/static-requirement/annotation/lifecycle metadata;
- `bases_upsert_config` is isolated in a compatibility group rather than normal authoring;
- real `tools/list` conformance across live, hybrid and all headless registration modes.

### P1 — portable profiles

- `standard`: 19 tools in full live/hybrid;
- `authoring`: 30 tools;
- `tasks`: 31 tools in live mode, intentionally retaining the complete Operon contract and recovery paths; non-live modes expose only the snapshot-safe Operon subset;
- `full`: unchanged active-runtime compatibility/admin surface.

Profiles compose groups from the canonical registry. `bases_upsert_config` remains full-only and is never treated as a formula fallback.

Governed `plan/apply/status/recover` families are atomic. The registration gate is order-independent: a quartet remains fully hidden while only partially registered, and becomes visible as one family when the fourth member exists. A legitimate direct fallback remains visible until that point.

### P2 — selection before `tools/list`

- `MCP_TOOL_PROFILE=standard|authoring|tasks|full`;
- `--tool-profile` overrides env and invalid values fail closed;
- default remains `full` during 2.x;
- direct server exposure uses public SDK `RegisteredTool` enable/disable handles;
- stdio proxy profiles are per-client while the shared backend remains `full`;
- direct calls to hidden proxy/server tools are rejected, not merely omitted from discovery.

### P3 — HTTP profile routes and session binding

- `/mcp` → `full` compatibility alias;
- `/mcp/standard`;
- `/mcp/authoring`;
- `/mcp/tasks`;
- `/mcp/full`.

Each HTTP session is bound to both verified identity and tool profile. A session created on one profile route cannot be reused through another profile route. Profile context is request-scoped during per-session MCP server construction and never mutates process-global state.

Durable governed plans are **not** bound to the creating profile. PlanRef/idempotency/backend/write/security state remains recovery authority.

### Semantic-search compatibility policy

`smart_semantic_search` is the only semantic-search name exposed by `standard`, `authoring` and `tasks`, and the only name taught by canonical routing docs.

`smart_search` and `smart-search` remain physically registered and visible only in `full` during 2.x to avoid silently breaking an existing public client. Their physical removal is deferred to 3.0.

### P4 — docs and routing eval infrastructure

- bilingual portable profile documentation and concise README/routing docs;
- npm package includes the new profile docs;
- tool inventory classifies the two semantic aliases as deprecated 2.x `full`-only compatibility names;
- 31-case harness-neutral routing corpus;
- JSONL scorer for first-tool accuracy, forbidden-tool rate, success, call count, latency and tokens;
- no fabricated model scores: real Codex/Gemini/Claude/Hermes/OpenClaw traces can be scored with the same corpus.

### Compatibility and safety

- runtime mode and exposure profile remain separate dimensions;
- visibility is never authorization;
- existing write policies, scopes, bridge gates, CAS, idempotency and confirmation rules remain authoritative;
- no-profile stdio and legacy `/mcp` remain `full` during 2.x;
- no new move/delete/batch capability is introduced.

## Release gates

This PR remains draft and must not be merged or tagged until:

1. every dedicated P0–P4 and normal repository CI check is green on the exact head;
2. an exact-head hostile/Codex review has no unresolved blocking finding;
3. the agreed live canary validates the profile and governed-recovery paths.

The separate PR #69 is **not** an authority for 2.10. Only narrowly useful 3.0 migration ideas (physical semantic-alias removal/tests) may later be replayed on top of the released 2.10 architecture.