### PR TITLE
fix: isolate stdio backend failures

### DIFF
--- a/.github/workflows/runtime.yml
+++ b/.github/workflows/runtime.yml
@@ -85,6 +85,22 @@ jobs:
       - run: npm ci --silent
       - run: npm run test:http-backpressure
 
+  stdio-proxy-reliability:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+        node: [22]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node }}
+          cache: npm
+      - run: npm ci --silent
+      - run: npm run test:stdio-proxy-reliability
+
   http-observability:
     strategy:
       fail-fast: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1] - 2026-08-23
+
+### Fixed
+
+- The stdio proxy no longer treats an HTTP application outcome such as
+  backpressure `503` or an ordinary `404` as a broken shared transport. One
+  rejected call therefore cannot close admitted sibling calls.
+- Backend session rotation is now single-flight and generation-aware. Retired
+  generations drain for a bounded interval, stale tool annotations cannot
+  overwrite the active generation, and shutdown closes every tracked client.
+- Network retry is limited to one call whose backend annotation proves
+  `readOnlyHint: true` on both the exact failed generation and the exact
+  replacement generation. Mutations are never replayed after an ambiguous
+  network failure and return `backend_outcome_unknown` for explicit
+  reconciliation.
+
+### Added
+
+- Deterministic Windows/Linux CI coverage for `8` admitted calls plus `2`
+  admission failures, ordinary application `404`, concurrent session
+  invalidation, stale tool metadata, bounded drain, one read-only replay and
+  mutation non-replay.
+- A redacted live stdio backpressure canary and profile diagnostics that
+  distinguish Operon hidden by `standard` from an unavailable Desktop Bridge.
+- The live canary requires an already tracked backend, validates the exact
+  admission payload and fails closed instead of auto-spawning an unowned
+  detached process.
+
 ## [3.0.0] - 2026-08-18
 
 ### Removed

--- a/OPERATIONS.fr.md
+++ b/OPERATIONS.fr.md
@@ -626,6 +626,48 @@ Vérifie :
 - le plugin Local REST API
 - `obsidian_runtime_status`
 
+### Un agent affirme qu’Operon n’est pas chargé
+
+Inspecter d’abord le profil d’outils stdio. Sans profil explicite, le proxy
+choisit `standard`, qui n’expose volontairement aucun outil `operon_*`. Cette
+absence ne prouve pas que le plugin Obsidian est désactivé. Utiliser
+`--tool-profile tasks` ou `MCP_TOOL_PROFILE=tasks` pour un client centré sur les
+tâches, reconnecter le client MCP, puis appeler `operon_status` et
+`operon_get_configuration`. Démarrer Obsidian après Codex reste supporté : les
+outils choisis par `tasks` demeurent visibles et renvoient un état structuré
+indisponible ou stale jusqu’au rafraîchissement du Bridge live.
+
+### Un HTTP 503 ferme des appels stdio sans rapport
+
+Ce défaut du proxy a été corrigé après la 3.0.0. Vérifier le candidat avec :
+
+```bash
+npm run test:stdio-proxy-reliability
+```
+
+La fixture déterministe impose l’échec indépendant des appels `503`, maintient
+les lectures sœurs admises, sérialise la reconnexion de session, draine la
+génération retirée, rejoue une seule fois une rupture réseau de lecture prouvée
+et ne rejoue jamais une mutation dont l’issue réseau est ambiguë.
+
+Le gate live est plus strict. Construire et démarrer d’abord le backend dédié,
+puis lancer directement le client sans reconstruire le `dist` actif :
+
+```bash
+OBSIDIAN_STDIO_BACKPRESSURE_CANARY_PATH="chemin/vers/note-jetable-ou-non-sensible.md" \
+MCP_HTTP_PORT=39117 \
+node scripts/smoke-stdio-backpressure-live.mjs
+```
+
+Le cibler sur un backend temporaire dédié en `readonly`, avec journaux uniques
+et limites d’admission basses. Il doit observer un refus d’admission exact,
+zéro appel frère `Connection closed`, puis une lecture suivante réussie. Un
+`503` générique ou un rate-limit `429` fait échouer le gate ; ce dernier peut
+persister 15 minutes pour une identité de développement partagée.
+Le canary exige que ce backend existe et ne démarre jamais un remplacement
+détaché. Après le run, arrêter le processus suivi, vérifier que le port est
+libre et supprimer son état temporaire privé.
+
 ### La mémoire grimpe trop
 
 Vérifie :

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -610,6 +610,47 @@ Check:
 - Local REST API plugin
 - `obsidian_runtime_status`
 
+### An agent says Operon is not loaded
+
+First inspect the stdio tool profile. An omitted profile defaults to `standard`,
+which intentionally exposes no `operon_*` tools. That absence does not prove
+that the Obsidian plugin is disabled. Use `--tool-profile tasks` or
+`MCP_TOOL_PROFILE=tasks` for a task-focused client, reconnect the MCP client,
+then call `operon_status` and `operon_get_configuration`. Starting Obsidian
+after Codex is supported: tools selected by `tasks` remain visible and report a
+structured unavailable/stale state until the live Bridge can be refreshed.
+
+### One HTTP 503 closes unrelated stdio calls
+
+This was a proxy defect fixed after 3.0.0. Verify the candidate with:
+
+```bash
+npm run test:stdio-proxy-reliability
+```
+
+The deterministic fixture requires the `503` calls to fail independently,
+keeps admitted sibling reads alive, serializes session reconnection, drains the
+retired generation, replays a proven read-only network loss once, and never
+replays a mutation with an ambiguous network outcome.
+
+The live gate is stricter. Build and start the dedicated backend first, then
+run the client directly without rebuilding the active `dist`:
+
+```bash
+OBSIDIAN_STDIO_BACKPRESSURE_CANARY_PATH="path/to/disposable-or-non-sensitive-note.md" \
+MCP_HTTP_PORT=39117 \
+node scripts/smoke-stdio-backpressure-live.mjs
+```
+
+Point it at a dedicated temporary `readonly` backend with unique journals and
+low admission limits. It must observe an exact admission rejection, zero
+`Connection closed` siblings and a successful following read. A generic `503`
+or rate-limit `429` fails the gate; the latter can persist for 15 minutes on a
+shared development identity.
+The canary requires that backend to exist and never auto-spawns a detached
+replacement. Stop the tracked process, verify the port is free and delete its
+private temporary state after the run.
+
 ### Memory usage climbs too high
 
 Check:

--- a/docs/http-concurrency-backpressure.fr.md
+++ b/docs/http-concurrency-backpressure.fr.md
@@ -105,6 +105,18 @@ Une réponse admise expose `X-Optimike-Operation-Class` et `X-Optimike-Queue-Wai
 
 `503` signifie que l’opération n’a pas été admise. Le transport ne la rejoue pas. Une gateway ne peut effectuer un retry que selon la sémantique propre de l’outil. Les lectures sont généralement rejouables. Une mutation doit conserver la clé d’idempotence et les préconditions CAS existantes ; une gateway ne doit jamais les inventer ou les supprimer.
 
+Le proxy stdio local conserve cette frontière. Un résultat applicatif HTTP,
+notamment un refus d’admission `503` ou un `404` ordinaire, est renvoyé à l’appel
+concerné sans retirer le transport backend partagé ni interrompre les appels
+frères déjà admis. Seul le contrat Streamable HTTP exact de session invalide
+provoque une rotation et le rejeu de l’appel rejeté. Une rupture réseau ne peut
+être rejouée qu’une fois, et seulement si l’annotation backend prouve
+`readOnlyHint: true` ; une mutation n’est jamais rejouée et renvoie
+`backend_outcome_unknown` afin que son propre contrat de statut, d’idempotence
+ou de recovery réconcilie le résultat. La reconnexion est sérialisée, les
+annotations sont liées à la génération et les générations retirées disposent
+d’un drain borné avant fermeture forcée.
+
 ## Libération des slots
 
 Un slot accordé est libéré exactement une fois après une erreur aval, la fin du
@@ -135,6 +147,36 @@ La CI exécute une charge concurrente déterministe ainsi que les contrats exist
 
 ```bash
 npm run test:http-backpressure
+npm run test:stdio-proxy-reliability
 ```
 
 La suite tourne sur Ubuntu et Windows. Elle prouve les plafonds globaux, par client, coûteux et mutation, les limites de file, l’équité, le timeout, l’annulation, le nettoyage des slots, les headers de retry et une charge déterministe sans coffre personnel.
+
+Pour une preuve stdio live contre Obsidian Desktop, construire d’abord, puis
+démarrer un backend HTTP temporaire dédié en mode `readonly`, sur un port
+unique, avec des chemins d’état et de journaux uniques et des limites
+d’admission volontairement basses. Attendre `/healthz` et `/readyz`, puis lancer
+directement le client sans reconstruire `dist` sous le processus actif :
+
+```bash
+OBSIDIAN_STDIO_BACKPRESSURE_CANARY_PATH="chemin/vers/note-jetable-ou-non-sensible.md" \
+MCP_HTTP_PORT=39117 \
+node scripts/smoke-stdio-backpressure-live.mjs
+```
+
+Le canary ne passe que si au moins une lecture réussit, au moins un appel est
+refusé par le contrat d’admission JSON-RPC exact `SERVICE_UNAVAILABLE`, aucun
+appel frère ne renvoie `Connection closed`, puis une nouvelle lecture réussit.
+Il n’accepte que `queue-full`, `identity-queue-full`, `timeout` ou `cancelled`
+dans `data.admission`, avec le message et la valeur `data.retryable`
+correspondants. Un `503` générique, un échec upstream ou un rate-limit `429`
+n’est pas une preuve de backpressure. Connexion, découverte, burst, lecture de
+contrôle et arrêt sont tous bornés par des watchdogs. Ne pas utiliser pour ce
+gate un backend partagé déjà sollicité à répétition : sa fenêtre indépendante
+de rate-limit par identité, longue de 15 minutes, peut masquer l’admission par
+un `429` légitime.
+
+Le canary impose `MCP_PROXY_REQUIRE_EXISTING_BACKEND=true` : une cible
+indisponible échoue fermée au lieu de laisser un backend détaché non suivi.
+Après le run, arrêter le backend suivi, vérifier qu’aucun listener ne subsiste
+sur son port, puis supprimer son état privé et son dossier de logs ignoré.

--- a/docs/http-concurrency-backpressure.md
+++ b/docs/http-concurrency-backpressure.md
@@ -102,6 +102,17 @@ An admitted response exposes `X-Optimike-Operation-Class` and `X-Optimike-Queue-
 
 `503` means the operation was not admitted. The transport does not retry it. A gateway may retry only under the tool's own semantics. Reads can normally be retried. Mutations must carry the existing idempotency key and CAS preconditions; a gateway must never invent or remove them.
 
+The local stdio proxy preserves the same boundary. An HTTP application outcome,
+including admission `503` and ordinary `404`, is returned to that call without
+retiring the shared backend transport or aborting admitted sibling calls. Only
+the exact Streamable HTTP invalid-session contract rotates the connection and
+replays the rejected call. A network failure may be replayed at most once only
+when the backend tool annotation proves `readOnlyHint: true`; a mutation is
+never replayed and returns `backend_outcome_unknown` so its own status,
+idempotency or recovery contract can reconcile the result. Reconnection is
+single-flight, tool annotations are generation-bound, and retired generations
+drain for a bounded interval before forced closure.
+
 ## Slot release guarantees
 
 A granted slot is released exactly once after downstream error, response-body
@@ -131,6 +142,35 @@ The CI suite runs deterministic concurrent load plus existing note CAS, exact se
 
 ```bash
 npm run test:http-backpressure
+npm run test:stdio-proxy-reliability
 ```
 
 The suite runs on Ubuntu and Windows and proves global, per-client, expensive and mutation ceilings, queue bounds, fairness, timeout, cancellation, slot cleanup, retry headers and deterministic load without using a personal vault.
+
+For a live stdio proof against Obsidian Desktop, build first, then start a
+dedicated temporary HTTP backend in `readonly` mode on a unique port, with
+unique state/journal paths and deliberately low admission limits. Wait for
+both `/healthz` and `/readyz`, then run the client directly without rebuilding
+`dist` under the running process:
+
+```bash
+OBSIDIAN_STDIO_BACKPRESSURE_CANARY_PATH="path/to/disposable-or-non-sensitive-note.md" \
+MCP_HTTP_PORT=39117 \
+node scripts/smoke-stdio-backpressure-live.mjs
+```
+
+The canary passes only when at least one read succeeds, at least one call is
+rejected by the exact JSON-RPC `SERVICE_UNAVAILABLE` admission contract, no
+sibling reports `Connection closed`, and a following read still succeeds. It
+accepts only `queue-full`, `identity-queue-full`, `timeout` or `cancelled` in
+`data.admission`, with the matching message and `data.retryable` value. A
+generic `503`, an upstream failure or rate-limit `429` is not backpressure
+evidence. Connection, discovery, burst, follow-up and shutdown are all bounded
+by watchdogs. Do not use a repeatedly stressed shared backend for this gate:
+its independent 15-minute identity rate-limit window can mask admission with a
+legitimate `429`.
+
+The canary sets `MCP_PROXY_REQUIRE_EXISTING_BACKEND=true`, so an unavailable
+target fails closed instead of leaving an untracked detached backend. After the
+run, stop the tracked backend, verify that its port no longer has a listener,
+then remove its private state and ignored log directory.

--- a/docs/tool-surface-profiles.fr.md
+++ b/docs/tool-surface-profiles.fr.md
@@ -63,6 +63,15 @@ Les profils modernes ne masquent une voie directe que lorsque la famille gouvern
 
 Le défaut de la 3.0 est `standard` lorsqu’aucun profil n’est indiqué.
 
+Le profil est fixé pour toute la durée de vie d’un proxy stdio. Démarrer
+Obsidian après Codex n’ajoute pas les outils exclus par le profil choisi.
+L’absence de `operon_*` dans une session `standard` signifie donc « non exposé
+par ce profil », pas « le plugin Operon n’est pas chargé ». Utiliser `tasks`
+pour une session centrée sur les tâches : ses outils Operon restent découvrables
+si Desktop ou le Bridge est momentanément indisponible et renvoient un état
+structuré indisponible ou stale jusqu’au rafraîchissement du contrat live par
+`operon_status`.
+
 ```bash
 node dist/stdio-proxy.js --tool-profile standard
 ```

--- a/docs/tool-surface-profiles.md
+++ b/docs/tool-surface-profiles.md
@@ -63,6 +63,14 @@ Modern profiles hide a direct tool only when the corresponding governed family i
 
 The 3.0 default is `standard` when no profile is specified.
 
+Profile selection is fixed for the lifetime of one stdio proxy. Starting
+Obsidian after Codex does not add tools that the selected profile excludes.
+Therefore, the absence of `operon_*` from a `standard` session means “not
+exposed by this profile”, not “the Operon plugin is not loaded”. Use `tasks` for
+task-focused sessions: its Operon tools remain discoverable while Desktop or
+the Bridge is temporarily unavailable and return a structured unavailable or
+stale status until `operon_status` can refresh the live contract.
+
 ```bash
 node dist/stdio-proxy.js --tool-profile standard
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optimike-obsidian-mcp",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optimike-obsidian-mcp",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optimike-obsidian-mcp",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Unified Obsidian MCP server with shared local cache, Operon and Tasks tools, Bases support, semantic search, runtime observability, and degraded read mode for durable agent workflows.",
   "main": "dist/index.js",
   "files": [
@@ -146,6 +146,8 @@
     "test:http-external-handoff": "npm run build && node scripts/test-http-external-handoff.mjs",
     "test:http-multiclient": "npm run build && node scripts/test-http-multiclient-rate-limiting.mjs && node scripts/test-http-session-bounds.mjs",
     "test:http-backpressure": "npm run build && node scripts/test-http-backpressure.mjs && node scripts/test-obsidian-cas.mjs && node scripts/test-obsidian-search-replace-cas.mjs && node scripts/test-external-move-integrity.mjs && node scripts/test-operon-service.mjs",
+    "test:stdio-proxy-reliability": "npm run build && node scripts/test-stdio-proxy-reliability.mjs",
+    "smoke:stdio-backpressure-live": "npm run build && node scripts/smoke-stdio-backpressure-live.mjs",
     "test:http-observability": "npm run build && node scripts/test-http-observability.mjs && node scripts/test-http-observability-endpoints.mjs",
     "test:http-headless-multiclient": "npm run build && node scripts/test-http-headless-multiclient.mjs",
     "test:gateway:agentgateway": "npm run build && node scripts/test-agentgateway-compatibility.mjs",

--- a/scripts/smoke-stdio-backpressure-live.mjs
+++ b/scripts/smoke-stdio-backpressure-live.mjs
@@ -1,0 +1,206 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+const filePath = process.env.OBSIDIAN_STDIO_BACKPRESSURE_CANARY_PATH?.trim();
+if (!filePath) {
+  throw new Error(
+    "Set OBSIDIAN_STDIO_BACKPRESSURE_CANARY_PATH to one existing disposable or non-sensitive vault-relative Markdown note.",
+  );
+}
+
+const concurrency = Number(
+  process.env.OBSIDIAN_STDIO_BACKPRESSURE_CONCURRENCY ?? "10",
+);
+if (!Number.isInteger(concurrency) || concurrency < 2 || concurrency > 64) {
+  throw new Error(
+    "OBSIDIAN_STDIO_BACKPRESSURE_CONCURRENCY must be an integer from 2 to 64.",
+  );
+}
+
+const minimumRejections = Number(
+  process.env.OBSIDIAN_STDIO_BACKPRESSURE_MIN_REJECTIONS ?? "1",
+);
+if (
+  !Number.isInteger(minimumRejections) ||
+  minimumRejections < 1 ||
+  minimumRejections >= concurrency
+) {
+  throw new Error(
+    "OBSIDIAN_STDIO_BACKPRESSURE_MIN_REJECTIONS must be an integer from 1 to concurrency - 1.",
+  );
+}
+
+const timeoutMs = Number(
+  process.env.OBSIDIAN_STDIO_BACKPRESSURE_TIMEOUT_MS ?? "60000",
+);
+if (!Number.isFinite(timeoutMs) || timeoutMs < 5_000 || timeoutMs > 300_000) {
+  throw new Error(
+    "OBSIDIAN_STDIO_BACKPRESSURE_TIMEOUT_MS must be from 5000 to 300000.",
+  );
+}
+
+async function withTimeout(promise, label, limitMs = timeoutMs) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`${label} exceeded ${limitMs}ms`)),
+          limitMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+const ADMISSION_REASONS = new Set([
+  "queue-full",
+  "identity-queue-full",
+  "timeout",
+  "cancelled",
+]);
+const ADMISSION_MESSAGES = new Map([
+  ["queue-full", "The HTTP operation queue is full."],
+  [
+    "identity-queue-full",
+    "This client identity already has the maximum number of queued operations.",
+  ],
+  ["timeout", "The operation was not admitted before its queue timeout."],
+  ["cancelled", "The operation was cancelled before admission."],
+]);
+const STREAMABLE_HTTP_POST_ERROR_PREFIX =
+  "Streamable HTTP error: Error POSTing to endpoint: ";
+
+function admissionReason(error) {
+  const message = error instanceof Error ? error.message : String(error);
+  const payloadOffset = message.indexOf(STREAMABLE_HTTP_POST_ERROR_PREFIX);
+  if (payloadOffset < 0) {
+    return undefined;
+  }
+  try {
+    const body = JSON.parse(
+      message.slice(payloadOffset + STREAMABLE_HTTP_POST_ERROR_PREFIX.length),
+    );
+    const reason = body?.error?.data?.admission;
+    if (
+      typeof reason !== "string" ||
+      !ADMISSION_REASONS.has(reason) ||
+      body?.error?.code !== "SERVICE_UNAVAILABLE" ||
+      body?.error?.message !== ADMISSION_MESSAGES.get(reason) ||
+      body?.error?.data?.retryable !== (reason !== "cancelled")
+    ) {
+      return undefined;
+    }
+    return reason;
+  } catch {
+    return undefined;
+  }
+}
+
+const transport = new StdioClientTransport({
+  command: process.execPath,
+  args: ["dist/stdio-proxy.js", "--tool-profile", "standard"],
+  cwd: process.cwd(),
+  env: {
+    ...process.env,
+    MCP_TOOL_PROFILE: "standard",
+    // The live harness owns the backend lifecycle. Fail closed instead of
+    // silently spawning a detached process that it cannot reliably clean up.
+    MCP_PROXY_REQUIRE_EXISTING_BACKEND: "true",
+  },
+});
+const client = new Client({
+  name: "optimike-stdio-backpressure-live-canary",
+  version: "0",
+});
+
+try {
+  await withTimeout(client.connect(transport), "stdio proxy connection");
+  const toolNames = (
+    await withTimeout(client.listTools(), "tool discovery")
+  ).tools.map((tool) => tool.name);
+  assert.ok(
+    toolNames.includes("obsidian_read_note"),
+    "standard profile must expose obsidian_read_note",
+  );
+
+  const burst = await withTimeout(
+    Promise.allSettled(
+      Array.from({ length: concurrency }, () =>
+        client.callTool({
+          name: "obsidian_read_note",
+          arguments: { filePath, format: "markdown", includeStat: false },
+        }),
+      ),
+    ),
+    "concurrent read burst",
+  );
+  const succeeded = burst.filter((result) => result.status === "fulfilled");
+  const rejected = burst.filter((result) => result.status === "rejected");
+  const connectionClosed = rejected.filter((result) =>
+    /Connection closed/u.test(String(result.reason)),
+  );
+  const admissionReasons = rejected.map((result) =>
+    admissionReason(result.reason),
+  );
+
+  assert.equal(
+    connectionClosed.length,
+    0,
+    "one admission or application error must never close sibling stdio calls",
+  );
+  assert.ok(succeeded.length > 0, "the burst must complete at least one read");
+  assert.ok(
+    rejected.length >= minimumRejections,
+    `the burst did not exercise backpressure: expected at least ${minimumRejections} rejection(s), observed ${rejected.length}; increase concurrency or verify backend admission limits`,
+  );
+  assert.equal(
+    admissionReasons.every((reason) => reason !== undefined),
+    true,
+    "every rejection must match the exact HTTP 503 JSON-RPC admission contract",
+  );
+
+  await withTimeout(
+    client.callTool({
+      name: "obsidian_read_note",
+      arguments: { filePath, format: "markdown", includeStat: false },
+    }),
+    "following read",
+  );
+
+  console.log(
+    JSON.stringify(
+      {
+        ok: true,
+        concurrency,
+        minimumRejections,
+        succeeded: succeeded.length,
+        rejected: rejected.length,
+        admissionReasons,
+        connectionClosed: connectionClosed.length,
+        followingReadSucceeded: true,
+        notePathRedacted: true,
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  const closeTimeoutMs = Math.min(timeoutMs, 10_000);
+  await withTimeout(
+    client.close().catch(() => undefined),
+    "MCP client close",
+    closeTimeoutMs,
+  ).catch((error) => console.error(String(error)));
+  await withTimeout(
+    transport.close().catch(() => undefined),
+    "stdio transport close",
+    closeTimeoutMs,
+  ).catch((error) => console.error(String(error)));
+}

--- a/scripts/test-doc-contract.mjs
+++ b/scripts/test-doc-contract.mjs
@@ -106,8 +106,8 @@ assert.match(matrixFr, /\| Admin filesystem\s+\| Non\s+\| Non/);
 const packageJson = JSON.parse(await text("package.json"));
 assert.equal(
   packageJson.version,
-  "3.0.0",
-  "package metadata must match the 3.0.0 canonical tool-surface release",
+  "3.0.1",
+  "package metadata must match the 3.0.1 stdio reliability release",
 );
 assert.equal(packageJson.scripts["start:http"], "node scripts/run-http.mjs");
 assert.equal(packageJson.scripts["start:daemon"], "node scripts/run-http.mjs");
@@ -135,6 +135,10 @@ const bilingualPairs = [
   ["docs/headless-server-profile.md", "docs/headless-server-profile.fr.md"],
   ["docs/operon-mcp-contract.md", "docs/operon-mcp-contract.fr.md"],
   ["docs/operon-cli-audit.md", "docs/operon-cli-audit.fr.md"],
+  [
+    "docs/http-concurrency-backpressure.md",
+    "docs/http-concurrency-backpressure.fr.md",
+  ],
 ];
 for (const pair of bilingualPairs) {
   for (const file of pair) await access(path.join(root, file));
@@ -179,6 +183,27 @@ assert.match(operonContract, /generic CLI passthrough/i);
 assert.match(operonContractFr, /passthrough CLI générique/i);
 assert.match(operonContract, /structured unavailable result/i);
 assert.match(operonContractFr, /indisponibilité structurée/i);
+
+const backpressureContract = await text(
+  "docs/http-concurrency-backpressure.md",
+);
+const backpressureContractFr = await text(
+  "docs/http-concurrency-backpressure.fr.md",
+);
+for (const content of [backpressureContract, backpressureContractFr]) {
+  assert.match(content, /smoke-stdio-backpressure-live\.mjs/u);
+  assert.match(content, /identity-queue-full/u);
+  assert.match(content, /429/u);
+  assert.match(content, /Connection closed/u);
+}
+for (const content of [
+  await text("OPERATIONS.md"),
+  await text("OPERATIONS.fr.md"),
+]) {
+  assert.match(content, /smoke-stdio-backpressure-live\.mjs/u);
+  assert.match(content, /429/u);
+  assert.match(content, /Connection closed/u);
+}
 
 const brokenLinks = [];
 for (const file of await markdownFiles(root)) {

--- a/scripts/test-launchers.mjs
+++ b/scripts/test-launchers.mjs
@@ -7,6 +7,7 @@ import { createServer } from "node:net";
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import { ensureLocalBackendRunning } from "../dist/runtime/localBackend.js";
 
 async function unusedPort() {
   const server = createServer();
@@ -47,6 +48,23 @@ const vaultPath = path.join(sandbox, "vault");
 const cachePath = path.join(sandbox, "shared-cache.sqlite");
 const port = await unusedPort();
 await mkdir(vaultPath, { recursive: true });
+
+const absentBackendPort = await unusedPort();
+await assert.rejects(
+  ensureLocalBackendRunning({
+    serviceName: "optimike-launcher-no-spawn-test",
+    url: new URL(`http://127.0.0.1:${absentBackendPort}/healthz`),
+    command: process.execPath,
+    args: ["-e", "process.exit(97)"],
+    cwd: process.cwd(),
+    env: process.env,
+    startupTimeoutMs: 2_000,
+    healthcheckTimeoutMs: 250,
+    spawnIfUnavailable: false,
+  }),
+  /automatic startup is disabled/u,
+  "require-existing mode must fail closed without spawning a detached backend",
+);
 
 const output = [];
 const child = spawn(process.execPath, ["scripts/run-http.mjs"], {

--- a/scripts/test-obsidian-note-replace-operation.mjs
+++ b/scripts/test-obsidian-note-replace-operation.mjs
@@ -184,7 +184,20 @@ function assertSqliteContentionPolicyPrecedesWal() {
   }
 }
 
-async function waitForFiles(paths, timeoutMs = 5_000) {
+const WORKER_BARRIER_TIMEOUT_MS = Number(
+  process.env.OBSIDIAN_NOTE_REPLACE_WORKER_BARRIER_TIMEOUT_MS ?? "15000",
+);
+if (
+  !Number.isFinite(WORKER_BARRIER_TIMEOUT_MS) ||
+  WORKER_BARRIER_TIMEOUT_MS < 1_000 ||
+  WORKER_BARRIER_TIMEOUT_MS > 120_000
+) {
+  throw new Error(
+    "OBSIDIAN_NOTE_REPLACE_WORKER_BARRIER_TIMEOUT_MS must be from 1000 to 120000.",
+  );
+}
+
+async function waitForFiles(paths, timeoutMs = WORKER_BARRIER_TIMEOUT_MS) {
   const deadline = Date.now() + timeoutMs;
   while (!paths.every((candidate) => existsSync(candidate))) {
     if (Date.now() >= deadline) {

--- a/scripts/test-stdio-proxy-reliability.mjs
+++ b/scripts/test-stdio-proxy-reliability.mjs
@@ -3,6 +3,10 @@
 import assert from "node:assert/strict";
 import { createServer } from "node:http";
 import { once } from "node:events";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 
@@ -17,7 +21,7 @@ function deferred() {
 }
 
 const GLOBAL_WATCHDOG_MS = Number(
-  process.env.STDIO_PROXY_FIXTURE_GLOBAL_TIMEOUT_MS ?? "20000",
+  process.env.STDIO_PROXY_FIXTURE_GLOBAL_TIMEOUT_MS ?? "60000",
 );
 const DEFERRED_WATCHDOG_MS = Number(
   process.env.STDIO_PROXY_FIXTURE_DEFERRED_TIMEOUT_MS ?? "5000",
@@ -347,9 +351,11 @@ const backend = createServer(async (request, response) => {
 const proxyStderr = [];
 let transport;
 let client;
+let fixtureVault;
+let fixtureStage = "runtime scenarios";
 const globalWatchdog = setTimeout(() => {
   console.error(
-    `Fixture watchdog expired after ${GLOBAL_WATCHDOG_MS}ms; a backend/proxy latch was not released.`,
+    `Fixture watchdog expired during ${fixtureStage} after ${GLOBAL_WATCHDOG_MS}ms; a backend/proxy latch was not released.`,
   );
   process.exit(1);
 }, GLOBAL_WATCHDOG_MS);
@@ -359,14 +365,25 @@ try {
   await once(backend, "listening");
   const address = backend.address();
   assert.ok(address && typeof address === "object");
+  fixtureVault = await mkdtemp(join(tmpdir(), "optimike-stdio-proxy-"));
+  const proxyEntryPath = fileURLToPath(
+    new URL("../dist/stdio-proxy.js", import.meta.url),
+  );
 
   transport = new StdioClientTransport({
     command: process.execPath,
-    args: ["dist/stdio-proxy.js", "--tool-profile", "full"],
-    cwd: process.cwd(),
+    args: [proxyEntryPath, "--tool-profile", "full"],
+    // Keep dotenv discovery and runtime inputs independent from a developer's
+    // checkout. The proxy still targets the explicit fixture backend below.
+    cwd: fixtureVault,
     stderr: "pipe",
     env: {
-      ...process.env,
+      OBSIDIAN_RUNTIME_MODE: "headless-readonly",
+      OBSIDIAN_VAULT: fixtureVault,
+      OBSIDIAN_ENABLE_CACHE: "false",
+      MCP_WRITE_MODE: "readonly",
+      SEMANTIC_SEARCH_PREWARM: "false",
+      MCP_TRANSPORT_TYPE: "stdio",
       MCP_HTTP_HOST: "127.0.0.1",
       MCP_HTTP_PORT: String(address.port),
       MCP_TOOL_PROFILE: "full",
@@ -387,10 +404,13 @@ try {
     }
   });
   client = new Client({ name: "stdio-proxy-reliability-test", version: "0" });
+  fixtureStage = "initial client connection";
   await client.connect(transport);
+  fixtureStage = "initial tools/list";
   const tools = await client.listTools();
   assert.equal(tools.tools.length, 3);
 
+  fixtureStage = "generation-fence replay";
   await assert.rejects(
     client.callTool({
       name: "generation_probe",
@@ -410,6 +430,7 @@ try {
   );
   const admissionStderrStart = proxyStderr.join("").length;
 
+  fixtureStage = "admission backpressure";
   const admissionSuccesses = Array.from({ length: 8 }, () =>
     client.callTool({
       name: "read_probe",
@@ -480,6 +501,7 @@ try {
     "an application 404 must not reconnect the shared transport",
   );
 
+  fixtureStage = "concurrent session invalidation and retired-generation drain";
   const initializeBeforeInvalidation = state.initializeCount;
   state.staleToolsListSessionId = state.latestSessionId;
   state.invalidationSessionId = state.latestSessionId;
@@ -527,6 +549,7 @@ try {
     "concurrent 404 session invalidations must single-flight one initialization",
   );
 
+  fixtureStage = "read replay after network loss";
   const initializeBeforeReadNetworkLoss = state.initializeCount;
   await client.callTool({
     name: "read_probe",
@@ -656,6 +679,7 @@ try {
   assert.equal(state.failedReplacementInitializations, 2);
   await client.callTool({ name: "read_probe", arguments: {} });
 
+  fixtureStage = "forced retired-generation drain timeout";
   const drainTimeoutSibling = client.callTool({
     name: "mutation_probe",
     arguments: { drainTimeoutSibling: true },
@@ -694,11 +718,33 @@ try {
   await client.callTool({ name: "read_probe", arguments: {} });
 
   console.log("stdio proxy reliability fixture passed");
+} catch (error) {
+  const stderr = proxyStderr.join("").trim();
+  console.error(
+    `Fixture failed during ${fixtureStage}; state=${JSON.stringify({
+      initializeAttempts: state.initializeAttempts,
+      initializeCount: state.initializeCount,
+      readNetworkRequests: state.readNetworkRequests,
+      invalidationRequests: state.invalidationRequests,
+    })}`,
+  );
+  if (stderr) {
+    console.error(`Captured stdio proxy stderr:\n${stderr}`);
+  }
+  throw error;
 } finally {
-  clearTimeout(globalWatchdog);
+  fixtureStage = "cleanup: release drain-timeout sibling";
   releaseDrainTimeoutSibling.resolve();
+  fixtureStage = "cleanup: client.close";
   await client?.close().catch(() => undefined);
+  fixtureStage = "cleanup: transport.close";
   await transport?.close().catch(() => undefined);
+  fixtureStage = "cleanup: backend.close";
   backend.closeAllConnections?.();
   await new Promise((resolve) => backend.close(resolve));
+  fixtureStage = "cleanup: disposable vault removal";
+  if (fixtureVault) {
+    await rm(fixtureVault, { recursive: true, force: true });
+  }
+  clearTimeout(globalWatchdog);
 }

--- a/scripts/test-stdio-proxy-reliability.mjs
+++ b/scripts/test-stdio-proxy-reliability.mjs
@@ -1,0 +1,704 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+const GLOBAL_WATCHDOG_MS = Number(
+  process.env.STDIO_PROXY_FIXTURE_GLOBAL_TIMEOUT_MS ?? "20000",
+);
+const DEFERRED_WATCHDOG_MS = Number(
+  process.env.STDIO_PROXY_FIXTURE_DEFERRED_TIMEOUT_MS ?? "5000",
+);
+
+function awaitDeferred(latch, label) {
+  let timeout;
+  return Promise.race([
+    latch.promise,
+    new Promise((_, reject) => {
+      timeout = setTimeout(
+        () =>
+          reject(
+            new Error(
+              `Fixture watchdog expired waiting for ${label} after ${DEFERRED_WATCHDOG_MS}ms`,
+            ),
+          ),
+        DEFERRED_WATCHDOG_MS,
+      );
+    }),
+  ]).finally(() => clearTimeout(timeout));
+}
+
+async function readJson(request) {
+  const chunks = [];
+  for await (const chunk of request) chunks.push(chunk);
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function json(response, status, body, headers = {}) {
+  response.writeHead(status, {
+    "content-type": "application/json",
+    ...headers,
+  });
+  response.end(JSON.stringify(body));
+}
+
+function rpcResult(id, result) {
+  return { jsonrpc: "2.0", id, result };
+}
+
+const admissionErrorsObserved = deferred();
+const releaseAdmissionSuccesses = deferred();
+const invalidationRequests = deferred();
+const drainSiblingStarted = deferred();
+const releaseDrainSibling = deferred();
+const replacementInitialized = deferred();
+const staleToolsListStarted = deferred();
+const releaseStaleToolsList = deferred();
+const retiredGenerationClosed = deferred();
+const drainTimeoutSiblingStarted = deferred();
+const releaseDrainTimeoutSibling = deferred();
+const drainTimeoutConnectionClosed = deferred();
+const RECONNECT_FAILURE_SECRET = "fixture-reconnect-secret";
+const SESSION_REPLAY_SECRET = "fixture-session-replay-secret";
+const state = {
+  initializeAttempts: 0,
+  initializeCount: 0,
+  failedReplacementInitializations: 0,
+  admissionRequests: 0,
+  admissionErrors: 0,
+  invalidationRequests: 0,
+  readNetworkRequests: 0,
+  mutationRequests: 0,
+  mutationReconnectFailureRequests: 0,
+  readReconnectFailureRequests: 0,
+  drainTimeoutMutationRequests: 0,
+  drainTimeoutTriggerRequests: 0,
+  generationFenceRequests: 0,
+  sessionInvalidMutationReplayRequests: 0,
+  sessionInvalidApplicationRequests: 0,
+  failNextInitialize: false,
+  deferStaleToolsList: false,
+  staleToolsListSessionId: undefined,
+  invalidationSessionId: undefined,
+  expectedReplacementInitializeCount: undefined,
+  sessions: new Set(),
+  invalidSessions: new Set(),
+  initialSessionId: undefined,
+};
+
+const backend = createServer(async (request, response) => {
+  if (request.url === "/healthz") {
+    response.writeHead(200).end();
+    return;
+  }
+  if (request.method !== "POST" || request.url !== "/mcp/full") {
+    response.writeHead(404).end();
+    return;
+  }
+
+  const message = await readJson(request);
+  if (message.method === "initialize") {
+    state.initializeAttempts += 1;
+    if (state.failNextInitialize) {
+      state.failNextInitialize = false;
+      state.failedReplacementInitializations += 1;
+      json(response, 503, {
+        error: `replacement initialization failed: ${RECONNECT_FAILURE_SECRET}`,
+      });
+      return;
+    }
+    state.initializeCount += 1;
+    const sessionId = `session-${state.initializeCount}`;
+    state.sessions.add(sessionId);
+    state.latestSessionId = sessionId;
+    state.initialSessionId ??= sessionId;
+    if (state.initializeCount === state.expectedReplacementInitializeCount) {
+      replacementInitialized.resolve();
+    }
+    json(
+      response,
+      200,
+      rpcResult(message.id, {
+        protocolVersion: message.params.protocolVersion,
+        capabilities: { tools: {} },
+        serverInfo: { name: "stdio-proxy-reliability-fixture", version: "0" },
+      }),
+      { "mcp-session-id": sessionId },
+    );
+    return;
+  }
+  if (message.method === "notifications/initialized") {
+    response.writeHead(202).end();
+    return;
+  }
+  if (message.method === "tools/list") {
+    const sessionId = request.headers["mcp-session-id"];
+    if (
+      state.deferStaleToolsList &&
+      sessionId === state.staleToolsListSessionId
+    ) {
+      state.deferStaleToolsList = false;
+      staleToolsListStarted.resolve();
+      await awaitDeferred(releaseStaleToolsList, "release stale tools/list");
+    }
+    json(
+      response,
+      200,
+      rpcResult(message.id, {
+        tools: [
+          {
+            name: "read_probe",
+            description: "deterministic read fixture",
+            inputSchema: { type: "object", properties: {} },
+            annotations: { readOnlyHint: true },
+          },
+          {
+            name: "mutation_probe",
+            description: "deterministic mutation fixture",
+            inputSchema: { type: "object", properties: {} },
+            annotations: { readOnlyHint: false },
+          },
+          {
+            name: "generation_probe",
+            description: "generation-bound annotation fixture",
+            inputSchema: { type: "object", properties: {} },
+            annotations: {
+              readOnlyHint: sessionId === state.initialSessionId,
+            },
+          },
+        ],
+      }),
+    );
+    return;
+  }
+  if (message.method !== "tools/call") {
+    response.writeHead(202).end();
+    return;
+  }
+
+  const sessionId = request.headers["mcp-session-id"];
+  if (!state.sessions.has(sessionId) || state.invalidSessions.has(sessionId)) {
+    response.writeHead(404).end("session not found");
+    return;
+  }
+
+  const args = message.params?.arguments ?? {};
+  if (args.sessionInvalidThenReplayNetworkLoss) {
+    state.sessionInvalidMutationReplayRequests += 1;
+    if (state.sessionInvalidMutationReplayRequests === 1) {
+      json(response, 404, {
+        jsonrpc: "2.0",
+        error: { code: -32001, message: "Invalid or expired session ID." },
+        id: message.id,
+      });
+      return;
+    }
+    if (state.sessionInvalidMutationReplayRequests === 2) {
+      response.destroy(
+        Object.assign(new Error(SESSION_REPLAY_SECRET), {
+          code: "ECONNRESET",
+        }),
+      );
+      return;
+    }
+  }
+  if (args.sessionInvalidThenApplication503) {
+    state.sessionInvalidApplicationRequests += 1;
+    if (state.sessionInvalidApplicationRequests === 1) {
+      json(response, 404, {
+        jsonrpc: "2.0",
+        error: { code: -32001, message: "Invalid or expired session ID." },
+        id: message.id,
+      });
+      return;
+    }
+    response.writeHead(503, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: "application-after-session-retry" }));
+    return;
+  }
+  if (args.admissionError) {
+    state.admissionRequests += 1;
+    state.admissionErrors += 1;
+    if (state.admissionErrors === 2) admissionErrorsObserved.resolve();
+    response.writeHead(503, { "content-type": "application/json" });
+    response.end(JSON.stringify({ error: "backpressure" }));
+    return;
+  }
+  if (args.admissionSuccess) {
+    state.admissionRequests += 1;
+    await awaitDeferred(
+      releaseAdmissionSuccesses,
+      "release admitted sibling calls",
+    );
+    json(
+      response,
+      200,
+      rpcResult(message.id, { content: [{ type: "text", text: "ok" }] }),
+    );
+    return;
+  }
+  if (args.invalidateSession && sessionId === state.invalidationSessionId) {
+    state.invalidationRequests += 1;
+    if (state.invalidationRequests === 2) {
+      state.invalidSessions.add(sessionId);
+      invalidationRequests.resolve();
+    }
+    await awaitDeferred(invalidationRequests, "both session invalidations");
+    json(response, 404, {
+      jsonrpc: "2.0",
+      error: { code: -32001, message: "Invalid or expired session ID." },
+      id: message.id,
+    });
+    return;
+  }
+  if (args.application404) {
+    response.writeHead(404).end("application endpoint missing");
+    return;
+  }
+  if (args.networkLossRead) {
+    state.readNetworkRequests += 1;
+    if (state.readNetworkRequests === 1) {
+      response.destroy(
+        Object.assign(new Error("fixture read network loss"), {
+          code: "ECONNRESET",
+        }),
+      );
+      return;
+    }
+  }
+  if (args.generationFenceNetworkLoss) {
+    state.generationFenceRequests += 1;
+    response.destroy(
+      Object.assign(new Error("fixture generation fence network loss"), {
+        code: "ECONNRESET",
+      }),
+    );
+    return;
+  }
+  if (args.networkLoss) {
+    state.mutationRequests += 1;
+    // Destroy only this response stream after the request arrived: this is a
+    // transport failure with an outcome that could be unknown to the caller.
+    response.destroy(
+      Object.assign(new Error("fixture network loss"), { code: "ECONNRESET" }),
+    );
+    return;
+  }
+  if (args.networkLossReconnectFailure) {
+    if (message.params?.name === "mutation_probe") {
+      state.mutationReconnectFailureRequests += 1;
+    } else {
+      state.readReconnectFailureRequests += 1;
+    }
+    state.failNextInitialize = true;
+    response.destroy(
+      Object.assign(
+        new Error("fixture network loss before reconnect failure"),
+        {
+          code: "ECONNRESET",
+        },
+      ),
+    );
+    return;
+  }
+  if (args.drainTimeoutSibling) {
+    state.drainTimeoutMutationRequests += 1;
+    drainTimeoutSiblingStarted.resolve();
+    await awaitDeferred(
+      releaseDrainTimeoutSibling,
+      "release drain-timeout sibling call",
+    );
+  }
+  if (args.drainTimeoutTrigger) {
+    state.drainTimeoutTriggerRequests += 1;
+    if (state.drainTimeoutTriggerRequests === 1) {
+      response.destroy(
+        Object.assign(new Error("fixture drain-timeout trigger"), {
+          code: "ECONNRESET",
+        }),
+      );
+      return;
+    }
+  }
+  if (args.drainSibling) {
+    drainSiblingStarted.resolve();
+    await awaitDeferred(releaseDrainSibling, "release retired sibling call");
+  }
+  json(
+    response,
+    200,
+    rpcResult(message.id, { content: [{ type: "text", text: "ok" }] }),
+  );
+});
+
+const proxyStderr = [];
+let transport;
+let client;
+const globalWatchdog = setTimeout(() => {
+  console.error(
+    `Fixture watchdog expired after ${GLOBAL_WATCHDOG_MS}ms; a backend/proxy latch was not released.`,
+  );
+  process.exit(1);
+}, GLOBAL_WATCHDOG_MS);
+
+try {
+  backend.listen(0, "127.0.0.1");
+  await once(backend, "listening");
+  const address = backend.address();
+  assert.ok(address && typeof address === "object");
+
+  transport = new StdioClientTransport({
+    command: process.execPath,
+    args: ["dist/stdio-proxy.js", "--tool-profile", "full"],
+    cwd: process.cwd(),
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      MCP_HTTP_HOST: "127.0.0.1",
+      MCP_HTTP_PORT: String(address.port),
+      MCP_TOOL_PROFILE: "full",
+      MCP_LOG_LEVEL: "error",
+      MCP_PROXY_START_TIMEOUT_MS: "5000",
+      MCP_PROXY_RETIRED_DRAIN_TIMEOUT_MS: "1000",
+      MCP_PROXY_REQUIRE_EXISTING_BACKEND: "true",
+    },
+  });
+  transport.stderr?.on("data", (chunk) => {
+    const output = String(chunk);
+    proxyStderr.push(output);
+    if (output.includes("backend generation 1 closed after drained")) {
+      retiredGenerationClosed.resolve();
+    }
+    if (output.includes("closed after drain-timeout")) {
+      drainTimeoutConnectionClosed.resolve();
+    }
+  });
+  client = new Client({ name: "stdio-proxy-reliability-test", version: "0" });
+  await client.connect(transport);
+  const tools = await client.listTools();
+  assert.equal(tools.tools.length, 3);
+
+  await assert.rejects(
+    client.callTool({
+      name: "generation_probe",
+      arguments: { generationFenceNetworkLoss: true },
+    }),
+    /backend_outcome_unknown/u,
+  );
+  assert.equal(
+    state.generationFenceRequests,
+    1,
+    "a tool that changes from read-only to mutation must not replay on the replacement generation",
+  );
+  assert.equal(
+    state.initializeCount,
+    2,
+    "the generation-fence fixture must rotate the backend exactly once",
+  );
+  const admissionStderrStart = proxyStderr.join("").length;
+
+  const admissionSuccesses = Array.from({ length: 8 }, () =>
+    client.callTool({
+      name: "read_probe",
+      arguments: { admissionSuccess: true },
+    }),
+  );
+  const admissionErrors = await Promise.allSettled(
+    Array.from({ length: 2 }, () =>
+      client.callTool({
+        name: "read_probe",
+        arguments: { admissionError: true },
+      }),
+    ),
+  );
+  await awaitDeferred(
+    admissionErrorsObserved,
+    "two propagated admission errors",
+  );
+  assert.equal(admissionErrors.length, 2);
+  assert.equal(
+    admissionErrors.filter((result) => result.status === "rejected").length,
+    2,
+  );
+  assert.equal(
+    admissionErrors.some(
+      (result) =>
+        result.status === "rejected" &&
+        /Connection closed/u.test(String(result.reason)),
+    ),
+    false,
+  );
+  assert.equal(
+    proxyStderr
+      .join("")
+      .slice(admissionStderrStart)
+      .includes("reconnecting once"),
+    false,
+    "503 admission outcomes must not retire the shared backend transport",
+  );
+  releaseAdmissionSuccesses.resolve();
+  const admissionSuccessResults = await Promise.allSettled(admissionSuccesses);
+  assert.equal(
+    admissionSuccessResults.filter((result) => result.status === "fulfilled")
+      .length,
+    8,
+  );
+  assert.equal(
+    admissionSuccessResults.some(
+      (result) =>
+        result.status === "rejected" &&
+        /Connection closed/u.test(String(result.reason)),
+    ),
+    false,
+  );
+  await client.callTool({ name: "read_probe", arguments: {} });
+
+  const initializeBeforeApplication404 = state.initializeCount;
+  await assert.rejects(
+    client.callTool({
+      name: "read_probe",
+      arguments: { application404: true },
+    }),
+    /application endpoint missing/u,
+  );
+  assert.equal(
+    state.initializeCount,
+    initializeBeforeApplication404,
+    "an application 404 must not reconnect the shared transport",
+  );
+
+  const initializeBeforeInvalidation = state.initializeCount;
+  state.staleToolsListSessionId = state.latestSessionId;
+  state.invalidationSessionId = state.latestSessionId;
+  state.expectedReplacementInitializeCount = state.initializeCount + 1;
+  state.deferStaleToolsList = true;
+  const staleToolsList = client.listTools();
+  await awaitDeferred(staleToolsListStarted, "old-generation tools/list");
+  const sibling = client.callTool({
+    name: "read_probe",
+    arguments: { drainSibling: true },
+  });
+  await awaitDeferred(drainSiblingStarted, "retired sibling call admission");
+  const invalidationResults = await Promise.all([
+    client.callTool({
+      name: "read_probe",
+      arguments: { invalidateSession: true },
+    }),
+    client.callTool({
+      name: "read_probe",
+      arguments: { invalidateSession: true },
+    }),
+  ]);
+  await awaitDeferred(
+    replacementInitialized,
+    "single-flight replacement initialization",
+  );
+  releaseStaleToolsList.resolve();
+  const toolsAfterStaleList = await staleToolsList;
+  assert.equal(
+    toolsAfterStaleList.tools.find((tool) => tool.name === "generation_probe")
+      ?.annotations?.readOnlyHint,
+    false,
+    "a stale generation tools/list result must be discarded and refreshed",
+  );
+  releaseDrainSibling.resolve();
+  await sibling;
+  await awaitDeferred(
+    retiredGenerationClosed,
+    "retired generation 1 transport close after drain",
+  );
+  assert.equal(invalidationResults.length, 2);
+  assert.equal(
+    state.initializeCount,
+    initializeBeforeInvalidation + 1,
+    "concurrent 404 session invalidations must single-flight one initialization",
+  );
+
+  const initializeBeforeReadNetworkLoss = state.initializeCount;
+  await client.callTool({
+    name: "read_probe",
+    arguments: { networkLossRead: true },
+  });
+  assert.equal(
+    state.readNetworkRequests,
+    2,
+    "a proven read-only call may replay once",
+  );
+  assert.equal(state.initializeCount, initializeBeforeReadNetworkLoss + 1);
+
+  await assert.rejects(
+    client.callTool({
+      name: "mutation_probe",
+      arguments: { networkLoss: true },
+    }),
+    /backend_outcome_unknown/u,
+  );
+  assert.equal(
+    state.mutationRequests,
+    1,
+    "mutations must not be replayed after network loss",
+  );
+  await client.callTool({ name: "read_probe", arguments: {} });
+
+  let sessionInvalidMutationReplayFailure;
+  try {
+    await client.callTool({
+      name: "mutation_probe",
+      arguments: { sessionInvalidThenReplayNetworkLoss: true },
+    });
+    assert.fail(
+      "a mutation whose session-invalid retry loses the network must reject",
+    );
+  } catch (error) {
+    sessionInvalidMutationReplayFailure = error;
+  }
+  assert.match(
+    String(sessionInvalidMutationReplayFailure),
+    /backend_outcome_unknown/u,
+  );
+  assert.equal(
+    String(sessionInvalidMutationReplayFailure).includes(SESSION_REPLAY_SECRET),
+    false,
+    "the replay network failure must remain redacted",
+  );
+  assert.equal(
+    state.sessionInvalidMutationReplayRequests,
+    2,
+    "an exact session-invalid mutation may retry once, but a network failure on that replay must never cause a third execution",
+  );
+  await client.callTool({ name: "read_probe", arguments: {} });
+
+  let sessionInvalidApplicationFailure;
+  try {
+    await client.callTool({
+      name: "read_probe",
+      arguments: { sessionInvalidThenApplication503: true },
+    });
+    assert.fail("the application 503 after a session retry must reject");
+  } catch (error) {
+    sessionInvalidApplicationFailure = error;
+  }
+  assert.match(
+    String(sessionInvalidApplicationFailure),
+    /application-after-session-retry/u,
+  );
+  assert.doesNotMatch(
+    String(sessionInvalidApplicationFailure),
+    /backend_unreachable|backend_outcome_unknown/u,
+    "an application outcome on the permitted retry must propagate unchanged",
+  );
+  assert.equal(
+    state.sessionInvalidApplicationRequests,
+    2,
+    "the application outcome must not trigger a third execution",
+  );
+
+  const initializeAttemptsBeforeMutationReconnectFailure =
+    state.initializeAttempts;
+  let mutationReconnectFailure;
+  try {
+    await client.callTool({
+      name: "mutation_probe",
+      arguments: { networkLossReconnectFailure: true },
+    });
+    assert.fail("mutation with a failed reconnect must reject");
+  } catch (error) {
+    mutationReconnectFailure = error;
+  }
+  assert.match(String(mutationReconnectFailure), /backend_outcome_unknown/u);
+  assert.match(String(mutationReconnectFailure), /reconnect=failed/u);
+  assert.equal(
+    String(mutationReconnectFailure).includes(RECONNECT_FAILURE_SECRET),
+    false,
+    "reconnect failure details must be redacted",
+  );
+  assert.equal(state.mutationReconnectFailureRequests, 1);
+  assert.equal(
+    state.initializeAttempts,
+    initializeAttemptsBeforeMutationReconnectFailure + 1,
+    "the proxy must attempt one best-effort replacement initialization",
+  );
+  assert.equal(state.failedReplacementInitializations, 1);
+  await client.callTool({ name: "read_probe", arguments: {} });
+
+  let readReconnectFailure;
+  try {
+    await client.callTool({
+      name: "read_probe",
+      arguments: { networkLossReconnectFailure: true },
+    });
+    assert.fail("read with a failed reconnect must reject");
+  } catch (error) {
+    readReconnectFailure = error;
+  }
+  assert.match(String(readReconnectFailure), /backend_unreachable/u);
+  assert.doesNotMatch(String(readReconnectFailure), /backend_outcome_unknown/u);
+  assert.equal(
+    String(readReconnectFailure).includes(RECONNECT_FAILURE_SECRET),
+    false,
+    "read-only reconnect failures must redact backend response details",
+  );
+  assert.match(String(readReconnectFailure), /message=\[REDACTED\]/u);
+  assert.equal(state.readReconnectFailureRequests, 1);
+  assert.equal(state.failedReplacementInitializations, 2);
+  await client.callTool({ name: "read_probe", arguments: {} });
+
+  const drainTimeoutSibling = client.callTool({
+    name: "mutation_probe",
+    arguments: { drainTimeoutSibling: true },
+  });
+  await awaitDeferred(
+    drainTimeoutSiblingStarted,
+    "drain-timeout sibling admission",
+  );
+  await client.callTool({
+    name: "read_probe",
+    arguments: { drainTimeoutTrigger: true },
+  });
+  assert.equal(
+    state.drainTimeoutTriggerRequests,
+    2,
+    "the proven read-only trigger may replay after replacing the generation",
+  );
+  await awaitDeferred(
+    drainTimeoutConnectionClosed,
+    "forced retired-generation close after drain timeout",
+  );
+  assert.match(
+    proxyStderr.join(""),
+    /exceeded the 1000ms retired drain; aborting 1 in-flight call\(s\)/u,
+  );
+  releaseDrainTimeoutSibling.resolve();
+  await assert.rejects(
+    drainTimeoutSibling,
+    /Connection closed|backend_outcome_unknown/u,
+  );
+  assert.equal(
+    state.drainTimeoutMutationRequests,
+    1,
+    "the blocked mutation must not replay after forced retirement",
+  );
+  await client.callTool({ name: "read_probe", arguments: {} });
+
+  console.log("stdio proxy reliability fixture passed");
+} finally {
+  clearTimeout(globalWatchdog);
+  releaseDrainTimeoutSibling.resolve();
+  await client?.close().catch(() => undefined);
+  await transport?.close().catch(() => undefined);
+  backend.closeAllConnections?.();
+  await new Promise((resolve) => backend.close(resolve));
+}

--- a/scripts/test-tool-profile-stdio-proxy.mjs
+++ b/scripts/test-tool-profile-stdio-proxy.mjs
@@ -119,6 +119,7 @@ try {
     assert.ok(!names.includes("smart_search"));
     assert.ok(!names.includes("smart-search"));
     assert.ok(!names.includes("external_read"));
+    assert.ok(!names.includes("operon_status"));
 
     const hidden = await standard.callTool({
       name: "external_read",
@@ -128,8 +129,45 @@ try {
     const hiddenText = hidden.content.map((item) => item.text ?? "").join("\n");
     assert.match(hiddenText, /tool_not_exposed/);
     assert.match(hiddenText, /standard/);
+
+    const hiddenOperon = await standard.callTool({
+      name: "operon_status",
+      arguments: {},
+    });
+    assert.equal(hiddenOperon.isError, true);
+    const hiddenOperonText = hiddenOperon.content
+      .map((item) => item.text ?? "")
+      .join("\n");
+    assert.match(hiddenOperonText, /tool_not_exposed/);
+    assert.match(hiddenOperonText, /standard/);
   } finally {
     await standard.close().catch(() => undefined);
+  }
+
+  const tasks = await openProxy(vault, port, "tasks");
+  try {
+    const result = await tasks.listTools();
+    const names = result.tools.map((tool) => tool.name);
+    assert.equal(names.length, 14);
+    assert.ok(names.includes("operon_status"));
+    assert.ok(names.includes("operon_get_configuration"));
+    assert.ok(names.includes("operon_list_tasks"));
+    assert.ok(!names.includes("obsidian_update_note"));
+
+    const status = await tasks.callTool({
+      name: "operon_status",
+      arguments: {},
+    });
+    const statusText = status.content
+      .map((item) => item.text ?? "")
+      .join("\n");
+    assert.match(
+      statusText,
+      /operon-cache|unavailable|headless|stale/u,
+      "the tasks profile must expose a structured non-live Operon status rather than hiding the tool",
+    );
+  } finally {
+    await tasks.close().catch(() => undefined);
   }
 
   const full = await openProxy(vault, port, "full");
@@ -146,7 +184,7 @@ try {
   }
 
   console.log(
-    "PASS: stdio proxy defaults to standard, explicit profiles remain per-client, and the shared backend remains full",
+    "PASS: stdio proxy defaults to standard, tasks exposes structured Operon status in non-live mode, explicit profiles remain per-client, and the shared backend remains full",
   );
 } finally {
   if (backend.exitCode === null) backend.kill("SIGTERM");

--- a/src/runtime/localBackend.ts
+++ b/src/runtime/localBackend.ts
@@ -13,6 +13,7 @@ export type LocalBackendOptions = {
   startupTimeoutMs?: number;
   healthcheckTimeoutMs?: number;
   pollIntervalMs?: number;
+  spawnIfUnavailable?: boolean;
 };
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
@@ -100,6 +101,7 @@ export async function ensureLocalBackendRunning({
   startupTimeoutMs = 15000,
   healthcheckTimeoutMs = 1000,
   pollIntervalMs = 400,
+  spawnIfUnavailable = true,
 }: LocalBackendOptions): Promise<void> {
   const lockPath = path.join(
     os.tmpdir(),
@@ -110,6 +112,11 @@ export async function ensureLocalBackendRunning({
 
   const initialHealth = await checkHealth(url, healthcheckTimeoutMs);
   if (initialHealth.ok) return;
+  if (!spawnIfUnavailable) {
+    throw new Error(
+      `Backend is not healthy at ${url.toString()} and automatic startup is disabled.`,
+    );
+  }
 
   while (Date.now() < deadlineMs) {
     const releaseLock = await acquireLock(lockPath, startupTimeoutMs * 2);

--- a/src/stdio-proxy.ts
+++ b/src/stdio-proxy.ts
@@ -6,7 +6,10 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
-import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import {
+  StreamableHTTPClientTransport,
+  StreamableHTTPError,
+} from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
@@ -47,6 +50,34 @@ type BackendClient = {
   client: Client;
   transport: StreamableHTTPClientTransport;
 };
+type BackendConnection = BackendClient & {
+  generation: number;
+  inFlight: number;
+  retired: boolean;
+  retiredTimer?: NodeJS.Timeout;
+  closePromise?: Promise<void>;
+};
+type BackendFailureKind = "application" | "network" | "session-invalid";
+type NetworkReplayPolicy = boolean | { toolName: string };
+type BackendRetryOptions<T> = {
+  /** Only calls with an explicit readOnlyHint may be replayed after a network loss. */
+  replayNetworkFailure: NetworkReplayPolicy;
+  onSuccess?: (result: { generation: number; value: T }) => void;
+};
+
+class BackendOperationError extends Error {
+  constructor(
+    readonly generation: number,
+    readonly originalError: unknown,
+    readonly networkReplayAuthorized: boolean,
+  ) {
+    super("Backend operation failed");
+  }
+}
+
+class BackendGenerationChangedError extends Error {}
+
+class BackendReplayNotAuthorizedError extends Error {}
 
 const packageInfo = JSON.parse(
   readFileSync(new URL("../package.json", import.meta.url), "utf-8"),
@@ -72,11 +103,34 @@ const proxyServer = new Server(
   { capabilities: { tools: { listChanged: true } } },
 );
 
-let backend: BackendClient | undefined;
+let backend: BackendConnection | undefined;
+let backendGeneration = 0;
+let initialConnectionPromise: Promise<BackendConnection> | undefined;
+let reconnectPromise: Promise<BackendConnection> | undefined;
 let allowedToolNames: Set<string> | undefined;
+let readOnlyToolNames: Set<string> | undefined;
+let toolMetadataGeneration: number | undefined;
+const retiredConnections = new Set<BackendConnection>();
 let externalRootsService: ExternalRootsService | undefined;
 let externalMoveCoordinator: ExternalMoveCoordinator | undefined;
 let externalMoveBindingIdentity: ExternalMoveBindingIdentity | undefined;
+
+function boundedDurationFromEnvironment(
+  name: string,
+  fallbackMs: number,
+): number {
+  const configured = Number(process.env[name] ?? fallbackMs);
+  return Number.isFinite(configured) &&
+    configured >= 1_000 &&
+    configured <= 300_000
+    ? Math.floor(configured)
+    : fallbackMs;
+}
+
+const retiredDrainTimeoutMs = boundedDurationFromEnvironment(
+  "MCP_PROXY_RETIRED_DRAIN_TIMEOUT_MS",
+  30_000,
+);
 
 function canonicalJson(value: unknown): string {
   if (Array.isArray(value)) {
@@ -154,33 +208,187 @@ function hiddenToolResult(toolName: string) {
   };
 }
 
-function isReconnectableBackendError(error: unknown): boolean {
-  const message = error instanceof Error ? error.message : String(error);
-  return (
-    message.includes("fetch failed") ||
-    message.includes("ECONNREFUSED") ||
-    message.includes("ECONNRESET") ||
-    message.includes("Invalid or expired session ID") ||
-    message.includes("Streamable HTTP error") ||
-    message.includes("terminated") ||
-    message.includes("socket hang up")
+const NETWORK_ERROR_CODES = new Set([
+  "ECONNABORTED",
+  "ECONNREFUSED",
+  "ECONNRESET",
+  "EHOSTUNREACH",
+  "ENETUNREACH",
+  "EPIPE",
+  "ETIMEDOUT",
+  "UND_ERR_ABORTED",
+  "UND_ERR_BODY_TIMEOUT",
+  "UND_ERR_CONNECT_TIMEOUT",
+  "UND_ERR_HEADERS_TIMEOUT",
+  "UND_ERR_SOCKET",
+]);
+const STREAMABLE_HTTP_POST_ERROR_PREFIX =
+  "Streamable HTTP error: Error POSTing to endpoint: ";
+const SESSION_INVALID_MESSAGES = new Set([
+  "Invalid or expired session ID.",
+  "Session not found or expired.",
+]);
+
+function errorHasNetworkCause(
+  error: unknown,
+  seen = new Set<unknown>(),
+): boolean {
+  if (typeof error !== "object" || error === null || seen.has(error)) {
+    return false;
+  }
+  seen.add(error);
+  const candidate = error as {
+    code?: unknown;
+    cause?: unknown;
+    errors?: unknown;
+  };
+  if (
+    typeof candidate.code === "string" &&
+    NETWORK_ERROR_CODES.has(candidate.code)
+  ) {
+    return true;
+  }
+  if (Array.isArray(candidate.errors)) {
+    return candidate.errors.some((nested) =>
+      errorHasNetworkCause(nested, seen),
+    );
+  }
+  return errorHasNetworkCause(candidate.cause, seen);
+}
+
+function streamableHttpApplicationMessage(
+  error: StreamableHTTPError,
+): string | undefined {
+  if (!error.message.startsWith(STREAMABLE_HTTP_POST_ERROR_PREFIX)) {
+    return undefined;
+  }
+  const responseBody = error.message.slice(
+    STREAMABLE_HTTP_POST_ERROR_PREFIX.length,
+  );
+  try {
+    const parsed = JSON.parse(responseBody) as {
+      error?: { message?: unknown };
+    };
+    return typeof parsed.error?.message === "string"
+      ? parsed.error.message
+      : undefined;
+  } catch {
+    return responseBody;
+  }
+}
+
+function classifyBackendFailure(error: unknown): BackendFailureKind {
+  // HTTP replies are application outcomes. Only the Streamable HTTP session
+  // contract gives its exact 404 payload the special meaning that the handler
+  // was not entered. A generic 404 can be an application/route outcome.
+  if (error instanceof StreamableHTTPError) {
+    return error.code === 404 &&
+      SESSION_INVALID_MESSAGES.has(
+        streamableHttpApplicationMessage(error) ?? "",
+      )
+      ? "session-invalid"
+      : "application";
+  }
+  return errorHasNetworkCause(error) ? "network" : "application";
+}
+
+function redactedBackendFailureDetail(error: unknown): string {
+  const candidate =
+    typeof error === "object" && error !== null
+      ? (error as { code?: unknown })
+      : undefined;
+  const rawCode = candidate?.code;
+  const safeCode =
+    (typeof rawCode === "string" && /^[A-Z0-9_.-]{1,64}$/u.test(rawCode)) ||
+    (typeof rawCode === "number" && Number.isInteger(rawCode))
+      ? String(rawCode)
+      : "unknown";
+  return `kind=${classifyBackendFailure(error)}, code=${safeCode}, message=[REDACTED]`;
+}
+
+function backendOutcomeUnknownError(
+  operationName: string,
+  originalError: unknown,
+  reconnectError?: unknown,
+): Error {
+  const reconnectDetail =
+    reconnectError === undefined
+      ? "reconnect=succeeded for future calls"
+      : `reconnect=failed (${redactedBackendFailureDetail(reconnectError)})`;
+  return new Error(
+    `MCP backend_outcome_unknown for ${operationName}: the network failed after a non-read-only call may have reached the backend; the proxy did not replay it. ${reconnectDetail}; original_failure=${redactedBackendFailureDetail(originalError)}`,
   );
 }
 
-async function ensureBackendConnected(forceReconnect = false): Promise<Client> {
-  if (backend && !forceReconnect) {
-    return backend.client;
-  }
+function backendReplayNotAuthorizedError(
+  operationName: string,
+  originalError: unknown,
+): Error {
+  return new Error(
+    `MCP backend_outcome_unknown for ${operationName}: the network failed and the replacement backend generation did not prove the tool read-only; the proxy did not replay it. reconnect=succeeded for future calls; original_failure=${redactedBackendFailureDetail(originalError)}`,
+  );
+}
 
-  if (backend) {
-    await Promise.allSettled([
-      backend.client.close(),
-      backend.transport.close(),
-    ]);
-    backend = undefined;
-  }
-  allowedToolNames = undefined;
+function backendOutcomeUnknownAfterRetryError(
+  operationName: string,
+  retryError: unknown,
+): Error {
+  return new Error(
+    `MCP backend_outcome_unknown for ${operationName}: the network failed after the one permitted retry of a request that may have reached the backend; the proxy did not replay it again. reconnect=not-attempted after retry; retry_failure=${redactedBackendFailureDetail(retryError)}`,
+  );
+}
 
+function closeBackendConnection(
+  connection: BackendConnection,
+  reason: "drained" | "drain-timeout" | "shutdown",
+): Promise<void> {
+  if (connection.closePromise) return connection.closePromise;
+  if (connection.retiredTimer) {
+    clearTimeout(connection.retiredTimer);
+    connection.retiredTimer = undefined;
+  }
+  connection.closePromise = Promise.allSettled([
+    connection.client.close(),
+    connection.transport.close(),
+  ]).then((results) => {
+    retiredConnections.delete(connection);
+    const rejected = results.filter(
+      (result): result is PromiseRejectedResult => result.status === "rejected",
+    );
+    if (rejected.length > 0) {
+      console.error(
+        `[${packageName}] backend generation ${connection.generation} closed after ${reason} with ${rejected.length} close error(s)`,
+      );
+    } else {
+      console.error(
+        `[${packageName}] backend generation ${connection.generation} closed after ${reason}`,
+      );
+    }
+  });
+  return connection.closePromise;
+}
+
+function closeRetiredBackend(connection: BackendConnection): void {
+  if (!connection.retired || connection.inFlight !== 0) return;
+  void closeBackendConnection(connection, "drained");
+}
+
+function retireBackend(connection: BackendConnection): void {
+  if (connection.retired) return;
+  connection.retired = true;
+  retiredConnections.add(connection);
+  connection.retiredTimer = setTimeout(() => {
+    if (connection.closePromise) return;
+    console.error(
+      `[${packageName}] backend generation ${connection.generation} exceeded the ${retiredDrainTimeoutMs}ms retired drain; aborting ${connection.inFlight} in-flight call(s)`,
+    );
+    void closeBackendConnection(connection, "drain-timeout");
+  }, retiredDrainTimeoutMs);
+  connection.retiredTimer.unref?.();
+  closeRetiredBackend(connection);
+}
+
+async function createBackendConnection(): Promise<BackendConnection> {
   await ensureLocalBackendRunning({
     serviceName: packageName,
     url: healthUrl,
@@ -195,6 +403,8 @@ async function ensureBackendConnected(forceReconnect = false): Promise<Client> {
       MCP_TOOL_PROFILE: "full",
     },
     startupTimeoutMs: Number(process.env.MCP_PROXY_START_TIMEOUT_MS || "20000"),
+    spawnIfUnavailable:
+      process.env.MCP_PROXY_REQUIRE_EXISTING_BACKEND?.toLowerCase() !== "true",
   });
 
   if (process.env.MCP_AUTH_MODE && !backendBearerToken) {
@@ -220,41 +430,260 @@ async function ensureBackendConnected(forceReconnect = false): Promise<Client> {
     { capabilities: {} },
   );
   await client.connect(transport);
-  backend = { client, transport };
-  return client;
+  return {
+    client,
+    transport,
+    generation: ++backendGeneration,
+    inFlight: 0,
+    retired: false,
+  };
+}
+
+async function ensureBackendConnected(): Promise<BackendConnection> {
+  if (backend) return backend;
+  initialConnectionPromise ??= createBackendConnection().then((connection) => {
+    backend ??= connection;
+    if (backend !== connection) retireBackend(connection);
+    return backend;
+  });
+  try {
+    return await initialConnectionPromise;
+  } finally {
+    initialConnectionPromise = undefined;
+  }
+}
+
+async function reconnectBackend(
+  failedGeneration: number,
+): Promise<BackendConnection> {
+  if (backend && backend.generation !== failedGeneration) return backend;
+  if (!backend) return ensureBackendConnected();
+  reconnectPromise ??= (async () => {
+    const failedConnection = backend;
+    if (!failedConnection || failedConnection.generation !== failedGeneration) {
+      return ensureBackendConnected();
+    }
+    const replacement = await createBackendConnection();
+    if (backend !== failedConnection) {
+      retireBackend(replacement);
+      return backend ?? ensureBackendConnected();
+    }
+    backend = replacement;
+    allowedToolNames = undefined;
+    readOnlyToolNames = undefined;
+    toolMetadataGeneration = undefined;
+    retireBackend(failedConnection);
+    return replacement;
+  })();
+  try {
+    return await reconnectPromise;
+  } finally {
+    reconnectPromise = undefined;
+  }
+}
+
+async function withBackendLease<T>(
+  operation: (client: Client) => Promise<T>,
+  options: {
+    expectedGeneration?: number;
+    networkReplayAuthorized: boolean;
+  },
+): Promise<{ generation: number; value: T }> {
+  const connection = await ensureBackendConnected();
+  if (
+    options.expectedGeneration !== undefined &&
+    connection.generation !== options.expectedGeneration
+  ) {
+    throw new BackendGenerationChangedError();
+  }
+  connection.inFlight += 1;
+  try {
+    return {
+      generation: connection.generation,
+      value: await operation(connection.client),
+    };
+  } catch (error) {
+    throw new BackendOperationError(
+      connection.generation,
+      error,
+      options.networkReplayAuthorized,
+    );
+  } finally {
+    connection.inFlight -= 1;
+    closeRetiredBackend(connection);
+  }
+}
+
+async function toolReplayProof(
+  toolName: string,
+): Promise<{ generation: number; readOnly: boolean }> {
+  if (!readOnlyToolNames || toolMetadataGeneration !== backend?.generation) {
+    await filteredBackendTools();
+  }
+  if (
+    toolMetadataGeneration === undefined ||
+    toolMetadataGeneration !== backend?.generation
+  ) {
+    throw new Error(
+      "Backend changed generation while resolving tool replay metadata; refusing automatic replay.",
+    );
+  }
+  return {
+    generation: toolMetadataGeneration,
+    readOnly: readOnlyToolNames?.has(toolName) ?? false,
+  };
+}
+
+async function withGenerationBoundToolLease<T>(
+  toolName: string,
+  operation: (client: Client) => Promise<T>,
+  requireReadOnly: boolean,
+): Promise<{ generation: number; value: T }> {
+  // A concurrent reconnect may rotate the active backend between metadata
+  // resolution and lease acquisition. Retry only that pre-execution binding;
+  // never carry an annotation proof across generations.
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const proof = await toolReplayProof(toolName);
+    if (requireReadOnly && !proof.readOnly) {
+      throw new BackendReplayNotAuthorizedError();
+    }
+    try {
+      return await withBackendLease(operation, {
+        expectedGeneration: proof.generation,
+        networkReplayAuthorized: proof.readOnly,
+      });
+    } catch (error) {
+      if (error instanceof BackendGenerationChangedError) continue;
+      throw error;
+    }
+  }
+  throw new Error(
+    "Backend changed generation repeatedly while binding tool replay metadata; refusing automatic replay.",
+  );
 }
 
 async function withBackendRetry<T>(
   operationName: string,
   operation: (client: Client) => Promise<T>,
+  options: BackendRetryOptions<T>,
 ): Promise<T> {
+  const replayPolicy = options.replayNetworkFailure;
+  const execute = (requireReadOnly: boolean) => {
+    if (typeof replayPolicy === "boolean") {
+      return withBackendLease(operation, {
+        networkReplayAuthorized: replayPolicy,
+      });
+    }
+    return withGenerationBoundToolLease(
+      replayPolicy.toolName,
+      operation,
+      requireReadOnly,
+    );
+  };
   try {
-    return await operation(await ensureBackendConnected());
+    const result = await execute(false);
+    options.onSuccess?.(result);
+    return result.value;
   } catch (error) {
-    if (!isReconnectableBackendError(error)) {
-      throw error;
+    const failedGeneration =
+      error instanceof BackendOperationError ? error.generation : undefined;
+    const originalError =
+      error instanceof BackendOperationError ? error.originalError : error;
+    const networkReplayAuthorized =
+      error instanceof BackendOperationError
+        ? error.networkReplayAuthorized
+        : false;
+    const failureKind = classifyBackendFailure(originalError);
+    if (failureKind === "application") {
+      throw originalError;
     }
 
     console.error(
-      `[${packageName}] ${operationName} failed against backend (${error instanceof Error ? error.message : String(error)}); reconnecting once`,
+      `[${packageName}] ${operationName} failed against backend (${redactedBackendFailureDetail(originalError)}); reconnecting once`,
     );
 
+    if (failedGeneration === undefined) throw originalError;
+
     try {
-      return await operation(await ensureBackendConnected(true));
+      await reconnectBackend(failedGeneration);
     } catch (retryError) {
-      const message =
-        retryError instanceof Error ? retryError.message : String(retryError);
+      if (failureKind === "network" && !networkReplayAuthorized) {
+        throw backendOutcomeUnknownError(
+          operationName,
+          originalError,
+          retryError,
+        );
+      }
       throw new Error(
-        `MCP backend_unreachable after retry for ${operationName}. Backend ${backendUrl.toString()} did not complete the request: ${message}`,
+        `MCP backend_unreachable after retry for ${operationName}. Backend ${backendUrl.toString()} did not complete the request: ${redactedBackendFailureDetail(retryError)}`,
+      );
+    }
+
+    if (failureKind === "network" && !networkReplayAuthorized) {
+      throw backendOutcomeUnknownError(operationName, originalError);
+    }
+
+    try {
+      const retried = await execute(failureKind === "network");
+      options.onSuccess?.(retried);
+      return retried.value;
+    } catch (retryError) {
+      if (retryError instanceof BackendReplayNotAuthorizedError) {
+        throw backendReplayNotAuthorizedError(operationName, originalError);
+      }
+      const retryOriginal =
+        retryError instanceof BackendOperationError
+          ? retryError.originalError
+          : retryError;
+      const retryFailureKind = classifyBackendFailure(retryOriginal);
+      if (retryFailureKind === "application") {
+        throw retryOriginal;
+      }
+      if (
+        retryError instanceof BackendOperationError &&
+        retryFailureKind === "network" &&
+        !retryError.networkReplayAuthorized
+      ) {
+        throw backendOutcomeUnknownAfterRetryError(
+          operationName,
+          retryOriginal,
+        );
+      }
+      throw new Error(
+        `MCP backend_unreachable after retry for ${operationName}. Backend ${backendUrl.toString()} did not complete the request: ${redactedBackendFailureDetail(retryOriginal)}`,
       );
     }
   }
 }
 
-async function filteredBackendTools(params?: Record<string, unknown>) {
-  const result = await withBackendRetry("listTools", (client) =>
-    client.listTools(params),
+async function filteredBackendTools(
+  params?: Record<string, unknown>,
+  staleRefreshesRemaining = 1,
+) {
+  let resultGeneration: number | undefined;
+  const result = await withBackendRetry(
+    "listTools",
+    (client) => client.listTools(params),
+    {
+      replayNetworkFailure: true,
+      onSuccess: ({ generation }) => {
+        resultGeneration = generation;
+      },
+    },
   );
+  if (resultGeneration === undefined) {
+    throw new Error(
+      "Backend tools/list completed without a connection generation.",
+    );
+  }
+  if (backend?.generation !== resultGeneration) {
+    if (staleRefreshesRemaining <= 0) {
+      throw new Error(
+        "Backend changed generation while tools/list was in flight; refusing to expose stale tool metadata.",
+      );
+    }
+    return filteredBackendTools(params, staleRefreshesRemaining - 1);
+  }
   const selected = new Set(
     selectAvailableToolProfileNames({
       profile: toolProfile,
@@ -262,6 +691,12 @@ async function filteredBackendTools(params?: Record<string, unknown>) {
     }),
   );
   allowedToolNames = selected;
+  readOnlyToolNames = new Set(
+    result.tools
+      .filter((tool) => tool.annotations?.readOnlyHint === true)
+      .map((tool) => tool.name),
+  );
+  toolMetadataGeneration = resultGeneration;
   return {
     ...result,
     tools: result.tools.filter((tool) => selected.has(tool.name)),
@@ -269,7 +704,7 @@ async function filteredBackendTools(params?: Record<string, unknown>) {
 }
 
 async function toolIsExposed(toolName: string): Promise<boolean> {
-  if (!allowedToolNames) {
+  if (!allowedToolNames || toolMetadataGeneration !== backend?.generation) {
     await filteredBackendTools();
   }
   return allowedToolNames?.has(toolName) ?? false;
@@ -277,10 +712,13 @@ async function toolIsExposed(toolName: string): Promise<boolean> {
 
 async function shutdown(signal: string) {
   console.error(`[${packageName}] proxy shutdown on ${signal}`);
+  const connections = new Set<BackendConnection>(retiredConnections);
+  if (backend) connections.add(backend);
   await Promise.allSettled([
     proxyServer.close(),
-    backend?.client.close() ?? Promise.resolve(),
-    backend?.transport.close() ?? Promise.resolve(),
+    ...[...connections].map((connection) =>
+      closeBackendConnection(connection, "shutdown"),
+    ),
   ]);
   process.exit(0);
 }
@@ -298,7 +736,7 @@ async function start() {
       process.env.MCP_EXTERNAL_ROOTS_FILE!,
     );
     const vault = new BackendVaultAdapter(
-      (name, args) =>
+      async (name, args) =>
         withBackendRetry(
           `external reference backend adapter: ${name}`,
           (client) =>
@@ -306,6 +744,7 @@ async function start() {
               { name, arguments: args },
               CompatibilityCallToolResultSchema,
             ),
+          { replayNetworkFailure: { toolName: name } },
         ),
       {
         backendEndpoint: backendUrl.toString(),
@@ -548,8 +987,11 @@ async function start() {
       )();
     }
 
-    return withBackendRetry("callTool", (client) =>
-      client.callTool(request.params, CompatibilityCallToolResultSchema),
+    return withBackendRetry(
+      "callTool",
+      (client) =>
+        client.callTool(request.params, CompatibilityCallToolResultSchema),
+      { replayNetworkFailure: { toolName: request.params.name } },
     );
   });
 


### PR DESCRIPTION
## Résumé

Cette PR stabilise le proxy stdio quand plusieurs clients partagent un backend HTTP soumis à la backpressure.

Le défaut racine était un mélange entre erreurs applicatives et rupture de session : un `503 SERVICE_UNAVAILABLE` ordinaire pouvait provoquer la rotation du transport partagé et fermer les connexions stdio concurrentes.

## Invariants ajoutés

- Les réponses applicatives (`503`, `404`, etc.) sont propagées sans rotation du transport.
- Seule une invalidation de session exacte autorise une reconnexion/relecture.
- Les reconnexions sont single-flight et liées à une génération de transport.
- Les métadonnées d'outils et `readOnlyHint` sont liées à la génération qui les a prouvées.
- Une lecture peut être rejouée au plus une fois seulement si elle est read-only sur la génération défaillante et la génération de remplacement.
- Une mutation n'est jamais rejouée après une rupture réseau ambiguë ; le reçu devient `backend_outcome_unknown`.
- Les générations retirées sont drainées de façon bornée et suivies jusqu'au shutdown.
- Les diagnostics de reconnexion sont expurgés des messages bruts du backend.

## Canary live

Canary exécuté contre un backend readonly isolé et un vrai coffre Obsidian, avec journaux temporaires distincts et limites d'admission minimales :

- 16 appels concurrents ;
- 1 succès et 15 rejets structurés `queue-full` ;
- 0 `MCP error -32000: Connection closed` ;
- lecture suivante réussie ;
- port, processus et répertoire temporaire nettoyés.

Le canary exige désormais un backend existant et suivi (`MCP_PROXY_REQUIRE_EXISTING_BACKEND=true`) afin de ne pas auto-démarrer un backend détaché.

## Compatibilité Operon / profils

La documentation et les tests distinguent maintenant :

- profil `standard` : outils Operon non exposés ;
- profil `tasks` : outils Operon exposés même si Obsidian/Bridge n'est pas encore prêt, avec indisponibilité structurée ;
- Bridge prêt : statut live après rafraîchissement.

## Vérifications

- build TypeScript ;
- fixture de fiabilité stdio et fences de générations ;
- tests des launchers et profils ;
- suites runtime, operation runtime et HTTP ;
- tests docs et packaging ;
- audit production : 0 vulnérabilité ;
- CI dédiée stdio reliability sous Windows et Linux ;
- review hostile finale : aucun finding P1/P2/P3.

## Release

Candidate patch `3.0.1`.