### PR TITLE
feat: support attested Operon 3.5 workflows

### DIFF
--- a/.github/workflows/operon-bridge.yml
+++ b/.github/workflows/operon-bridge.yml
@@ -3,18 +3,26 @@ name: Operon Bridge
 on:
   push:
     branches:
-      - feat/operon-bridge-integration
+      - main
   pull_request:
     paths:
       - "src/services/operon/**"
       - "src/mcp-server/tools/operonTools/**"
       - "src/mcp-server/tools/runtimeTools/registration.ts"
+      - "src/mcp-server/toolSurfaceRegistry.ts"
+      - "src/services/writePolicy.ts"
       - "plugins/obsidian-operon-bridge/**"
       - "scripts/test-operon-contract.mjs"
       - "scripts/test-operon-service.mjs"
+      - "scripts/smoke-operon-35-live.mjs"
       - "docs/operon-*.md"
       - "docs/adr/ADR-Operon-Bridge.md"
+      - "profiles/elysia-tasks/**"
+      - "README.md"
+      - "README.fr.md"
+      - "CHANGELOG.md"
       - "package.json"
+      - "package-lock.json"
       - ".github/workflows/operon-bridge.yml"
 
 permissions:
@@ -22,7 +30,14 @@ permissions:
 
 jobs:
   mcp:
-    runs-on: ubuntu-latest
+    name: MCP contract and service (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -33,10 +48,18 @@ jobs:
       - run: npm run test:runtime
       - run: npm run test:operon-contract
       - run: npm run test:operon-service
+      - run: npm run test:docs
       - run: npm pack --dry-run
 
   bridge:
-    runs-on: ubuntu-latest
+    name: Bridge (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+    runs-on: ${{ matrix.os }}
     defaults:
       run:
         working-directory: plugins/obsidian-operon-bridge
@@ -52,7 +75,7 @@ jobs:
       - name: Upload installable Bridge artifact
         uses: actions/upload-artifact@v4
         with:
-          name: optimike-operon-bridge
+          name: optimike-operon-bridge-${{ matrix.os }}
           path: |
             plugins/obsidian-operon-bridge/build/main.js
             plugins/obsidian-operon-bridge/build/manifest.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.1.0] - 2026-08-24
+
+### Added
+
+- Official Operon task adoption through the exact additive
+  `tasks.adopt.preview` / `tasks.adopt.apply` grant pair. The MCP applies only
+  Operon's opaque sealed plan and recovers only that same plan; it never falls
+  back to a Markdown rewrite.
+- Capability-gated Daily and Weekly Note tools:
+  `operon_create_periodic_task` lets Operon own periodic routing and
+  `operon_update_periodic_scheduling` lets it retain, detach or realign a task
+  without moving the source Markdown.
+- Typed Task Type and Task Image scalar fields plus lossless ordered Task
+  Gallery arrays. The derived `__taskDataType` field remains read-only.
+
+### Changed
+
+- Candidate compatibility target: Operon `3.5.2`, Operon CLI `1.2.0` and
+  Optimike Operon Bridge `0.8.0`. The patched acceptance candidate passed the
+  complete live Desktop canary on 2026-08-24 with exact restoration and no
+  pending recovery. The official Operon artifact remains
+  `compatible-provisional` until upstream PRs `#182`, `#183` and `#184` ship
+  and that stock release passes the same gate.
+- The Operon contract now contains 25 tools. Live `tasks` contains 33 tools and
+  live `full` contains 72; `standard` and `authoring` remain unchanged.
+
+### Security
+
+- Optional task-workflow grants are negotiated independently. A missing or
+  denied adoption/periodic grant disables only its dependent tool and never
+  invalidates established core reads or authorizes a broader fallback.
+
 ## [3.0.1] - 2026-08-23
 
 ### Fixed

--- a/README.fr.md
+++ b/README.fr.md
@@ -14,7 +14,7 @@ Optimike Obsidian MCP fournit aux clients MCP une surface opérationnelle gouver
 | ----------------------- | ------------------------------------------------------------------------------- | ---------------------------------------------------- |
 | Notes                   | Lecture/recherche/éditions directes + opérations gouvernées Note et Frontmatter | Coffre ; Local REST API + Atomic Write Bridge        |
 | Bases et Canvas         | Requêtes, écritures bornées, formules et graphes Canvas gouvernés               | Bases Bridge ; Atomic Write Bridge                   |
-| Tâches                  | Markdown Tasks-compatible + 23 outils Operon gouvernés                          | Operon Developer API V1 via le Bridge                |
+| Tâches                  | Markdown Tasks-compatible + 25 outils Operon gouvernés                          | Operon Developer API V1 via le Bridge                |
 | Recherche sémantique    | Recherche dans l’index Smart Connections                                        | `.smart-env` + embedding Ollama ou compatible OpenAI |
 | Runtime                 | Cache SQLite partagé, santé, maintenance et modes dégradés                      | Filesystem local                                     |
 | Documents externes      | Lectures/handoff default-deny + move local opt-in                               | Allowlist de racines                                 |
@@ -41,8 +41,8 @@ Le runtime répond à ce que le backend peut exécuter. Il ne décide pas combie
 | ---------------------------------------------------- | ----------- | --------------------------: |
 | Travail général sur le coffre                        | `standard`  |                          19 |
 | Notes, tags, Bases et Canvas                         | `authoring` |                          30 |
-| Workflows Tasks / Operon                             | `tasks`     |                          31 |
-| Surface complète explicite, admin et spécialisations | `full`      |                          70 |
+| Workflows Tasks / Operon                             | `tasks`     |                          33 |
+| Surface complète explicite, admin et spécialisations | `full`      |                          72 |
 
 En 3.0, l’absence de profil sélectionne `standard`. `smart_semantic_search` est le seul nom de recherche sémantique enregistré ; les anciens alias `smart_search` et `smart-search` ont été supprimés. `full` reste disponible par opt-in explicite pour toute la surface du runtime actif. `bases_upsert_config` reste une voie de compatibilité whole-Base réservée à `full` ; l’authoring normal utilise la création/écriture de lignes bornée et la famille gouvernée des formules.
 
@@ -114,7 +114,7 @@ N’activer que les surfaces utilisées :
 - **Bases Bridge** inclus pour Bases live et le CAS de formules gouvernées ;
 - **Optimike Atomic Write Bridge** inclus pour les cycles Note, Frontmatter et Canvas `plan → apply → status → recover` ;
 - **Smart Connections** pour l’index sémantique local ;
-- **Operon Developer API V1** et **Optimike Operon Bridge** pour les tâches gouvernées ;
+- **Operon Developer API V1** et **Optimike Operon Bridge 0.8.0** pour les tâches gouvernées. La candidate 3.1 cible Operon 3.5.2 et CLI 1.2.0. Une candidate d’acceptation patchée a passé le canary complet dans Pilot 2 le 2026-08-24 ; la release officielle reste `compatible-provisional` jusqu’à la publication des correctifs upstream requis et au passage du même gate par l’artefact stock ;
 - **Obsidian Tasks** pour le parsing Markdown Tasks-compatible.
 
 Les mutations Operon exigent le réglage de mutation du Bridge plus :
@@ -123,7 +123,7 @@ Les mutations Operon exigent le réglage de mutation du Bridge plus :
 OPERON_MUTATIONS_ENABLED=true
 ```
 
-Les snapshots Operon obsolètes restent read-only. Aucune route Operon ne retombe sur du Markdown brut ou des API privées. Les versions certifiées/provisoires, la récupération et les gaps d’API sont détaillés dans le [Contrat MCP Operon](docs/operon-mcp-contract.fr.md) et l’[Audit CLI / Developer API](docs/operon-cli-audit.fr.md).
+Les snapshots Operon obsolètes restent read-only. Aucune route Operon ne retombe sur du Markdown brut ou des API privées. L’adoption officielle et le routage Daily/Weekly ne sont exposés qu’après leurs grants additifs exacts. Operon reste propriétaire de chaque plan opaque scellé et de sa récupération same-plan. Task Type et Task Image restent scalaires, Task Gallery reste un tableau ordonné et `__taskDataType` est read-only. Les versions certifiées/provisoires, la récupération et les gaps d’API sont détaillés dans le [Contrat MCP Operon](docs/operon-mcp-contract.fr.md) et l’[Audit CLI / Developer API](docs/operon-cli-audit.fr.md).
 
 ## Opérations gouvernées
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Optimike Obsidian MCP gives MCP clients a governed operational surface over an O
 | ----------------------- | ---------------------------------------------------------------------- | ---------------------------------------------------------- |
 | Notes                   | Read/search/direct edits plus governed note and Frontmatter operations | Vault; Local REST API + Atomic Write Bridge                |
 | Bases and Canvas        | Queries, bounded writes, governed formulas and Canvas graph plans      | Bases Bridge; Atomic Write Bridge                          |
-| Tasks                   | Tasks-compatible Markdown plus 23 governed Operon tools                | Operon Developer API V1 through the Bridge                 |
+| Tasks                   | Tasks-compatible Markdown plus 25 governed Operon tools                | Operon Developer API V1 through the Bridge                 |
 | Semantic search         | Smart Connections index search                                         | `.smart-env` + Ollama or OpenAI-compatible query embedding |
 | Runtime                 | Shared SQLite cache, health, maintenance and degraded modes            | Local filesystem                                           |
 | External documents      | Default-deny reads/handoff plus opt-in local move                      | Explicit root allowlist                                    |
@@ -41,8 +41,8 @@ Runtime answers what the backend can execute. It does not decide how many tools 
 | ------------------------------------------------- | ----------- | --------------------: |
 | General vault work                                | `standard`  |                    19 |
 | Notes, tags, Bases and Canvas authoring           | `authoring` |                    30 |
-| Tasks / Operon workflows                          | `tasks`     |                    31 |
-| Explicit complete, admin and specialized surfaces | `full`      |                    70 |
+| Tasks / Operon workflows                          | `tasks`     |                    33 |
+| Explicit complete, admin and specialized surfaces | `full`      |                    72 |
 
 In 3.0, an unspecified profile defaults to `standard`. `smart_semantic_search` is the only registered semantic-search name; the former `smart_search` and `smart-search` aliases have been removed. `full` remains an explicit opt-in for the complete active-runtime surface. `bases_upsert_config` is a `full`-only whole-Base compatibility path; legacy whole-file config writes are default-off, while normal authoring uses bounded Base creation/row writes plus the governed formula family.
 
@@ -114,7 +114,7 @@ Enable only the surfaces you use:
 - bundled **Bases Bridge** for live Bases and governed formula CAS;
 - bundled **Optimike Atomic Write Bridge** for governed Note, Frontmatter and Canvas `plan → apply → status → recover`;
 - **Smart Connections** for the local semantic index;
-- **Operon Developer API V1** and bundled **Optimike Operon Bridge** for governed task operations;
+- **Operon Developer API V1** and bundled **Optimike Operon Bridge 0.8.0** for governed task operations. The 3.1 candidate targets Operon 3.5.2 and CLI 1.2.0. A patched acceptance candidate passed the complete Pilot 2 canary on 2026-08-24; the official release remains `compatible-provisional` until the required upstream fixes ship and the stock artifact passes the same gate;
 - **Obsidian Tasks** for Tasks-compatible Markdown parsing.
 
 Operon mutations require the Bridge mutation setting plus:
@@ -123,7 +123,7 @@ Operon mutations require the Bridge mutation setting plus:
 OPERON_MUTATIONS_ENABLED=true
 ```
 
-Stale Operon snapshots remain read-only. No Operon route falls back to raw Markdown or private APIs. Full compatibility, certified/provisional versions, recovery semantics and current API gaps live in the [Operon MCP contract](docs/operon-mcp-contract.md) and [CLI / Developer API audit](docs/operon-cli-audit.md).
+Stale Operon snapshots remain read-only. No Operon route falls back to raw Markdown or private APIs. Official adoption and Daily/Weekly routing are exposed only after their exact additive grants. Operon owns every opaque sealed plan and same-plan recovery. Task Type and Task Image stay scalar, Task Gallery stays an ordered array, and `__taskDataType` is read-only. Full compatibility, certified/provisional versions, recovery semantics and current API gaps live in the [Operon MCP contract](docs/operon-mcp-contract.md) and [CLI / Developer API audit](docs/operon-cli-audit.md).
 
 ## Governed operations
 

--- a/docs/adr/ADR-Operon-Bridge.md
+++ b/docs/adr/ADR-Operon-Bridge.md
@@ -2,20 +2,20 @@
 
 - Status: accepted and implemented on `main`
 - Date: 2026-07-21
-- Amended: 2026-08-09
+- Amended: 2026-08-24
 - MCP baseline: `optimikelabs/optimike-obsidian-mcp@8cea94610a526e50a017d334be6008b8dab79500`
-- Operon baselines: upstream `2.4.0@76d251973b149afc69192ef565d626740aa7b7cf`, `2.5.0@31099cc3d5231b320cd8520424fc29449b003778`, and official `3.2.1` Developer API V1 (`3.2.0` complete live-pilot baseline)
+- Operon baselines: upstream `2.4.0@76d251973b149afc69192ef565d626740aa7b7cf`, `2.5.0@31099cc3d5231b320cd8520424fc29449b003778`, certified official `3.2.1`, historical live `3.3.2`, and provisional candidate `3.5.2` / CLI `1.2.0`
 
 ## Problem
 
-Operon unifies inline and file tasks around stable identity and one domain model. Earlier releases exposed no public versioned mutation API; official Operon `3.2.x` exposes Developer API V1 plus an additive task-workflow filter API. Agent writes must still preserve workflow normalization, dependencies, recurrence, aggregates, project serials, archiving, auto-unpin, conversions, and index/view reconciliation. Direct Markdown edits or direct `TaskWriter` calls do not satisfy that contract.
+Operon unifies inline and file tasks around stable identity and one domain model. Earlier releases exposed no public versioned mutation API; official Operon `3.5.2` exposes Developer API V1 plus additive saved-filter, adoption and Daily/Weekly task workflows. Agent writes must still preserve workflow normalization, dependencies, recurrence, aggregates, project serials, archiving, auto-unpin, conversions, ordered task media and index/view reconciliation. Direct Markdown edits or direct `TaskWriter` calls do not satisfy that contract.
 
 ## Decision
 
 Use one MCP server and three explicit layers:
 
 ```text
-Official Operon 3.2.x / legacy Kairélys
+Official Operon 3.x / legacy Kairélys
     ↓ Developer API V1 / PublicApiV1
 Optimike Operon Bridge
     ↓ Local REST API contract v1
@@ -33,7 +33,7 @@ Official Operon `2.4.0` and `2.5.0` remain supported for reads. Official Operon 
 - `KEEP DISABLED` — Tasks and TaskNotes only as reversible rollback assets after the completed cutover.
 - `ADD` — companion Bridge for live reads and guarded mutations.
 - `KEEP` — the legacy Kairélys/Public API v1 path only as a bounded rollback compatibility surface.
-- `ADD` — twenty-three governed Operon MCP tools, including six bounded native reads, relationship and recurrence writes, snapshot tables, durable mutation journal, and same-plan recovery.
+- `ADD` — twenty-five governed Operon MCP tools, including six bounded native reads, relationship and recurrence writes, official adoption, Daily/Weekly workflows, snapshot tables, durable mutation journal, and same-plan recovery.
 - `REJECT` — MCP-side Operon parser/domain reimplementation.
 - `REJECT` — raw Markdown/YAML mutation fallback.
 - `REJECT` — reflective production calls to private Operon methods.
@@ -41,7 +41,7 @@ Official Operon `2.4.0` and `2.5.0` remain supported for reads. Official Operon 
 
 ## Public API boundary
 
-`OperonPublicApiV1` remains the legacy Kairélys boundary. Official Operon `3.2.0` exposes host-verified Developer API V1 reads plus preview/apply/recovery for typed create, update, transition, relationship replacement, recurrence update, conversion, and inline relocation. Its additive task-workflow API evaluates a caller-supplied saved-filter ID after an exact grant, but does not expose the catalog. Elevated or destructive applies require fresh host-owned consent in the owning vault window and fail closed after a bounded timeout. The implementation stays inside Operon and calls its existing parser/converter, creator, workflow, writer, dependency, recurrence, aggregate, archive, and conversion paths.
+`OperonPublicApiV1` remains the legacy Kairélys boundary. Official Operon `3.x` exposes host-verified Developer API V1 reads plus preview/apply/recovery for typed create, update, transition, relationship replacement, recurrence update, conversion, and inline relocation. Operon `3.5.2` adds exact-grant adoption and Daily/Weekly workflows to the additive task-workflow API. Those plans are opaque and session-bound; recovery continues only the same `recoveryRef`. Task Type and Task Image remain scalar, Task Gallery remains ordered, and `__taskDataType` remains read-only. Elevated or destructive applies require fresh host-owned consent in the owning vault window and fail closed after a bounded timeout.
 
 No ÉLYSIA-specific workflow, UX, view, calendar, Kanban, or data-model logic belongs in Operon. Compatibility fixes remain generic upstream PRs; the MCP never depends on private methods or an ÉLYSIA-specific Operon fork.
 
@@ -53,7 +53,7 @@ If live access fails, the last snapshot may be returned only as `operon-cache` w
 
 ## Mutation model
 
-Every apply requires a live Bridge, the matching official mutation surface, the Bridge mutation toggle, and `OPERON_MUTATIONS_ENABLED=true`. Existing Operon-task mutations require `expectedRevision`; legacy checkbox adoption requires an exact source path, one-based line and `expectedLine`; every request requires `idempotencyKey`; `dryRun` defaults to true. Official Operon 3.2.0 applies only the exact host-sealed preview plan and surfaces `outcome-unknown` with recovery metadata. Recovery is a separate same-plan route, never a new mutation.
+Every apply requires a live Bridge, the matching official mutation surface, the Bridge mutation toggle, and `OPERON_MUTATIONS_ENABLED=true`. Existing Operon-task mutations require `expectedRevision`; adoption requires an exact source path, one-based line and `expectedLine`; every request requires `idempotencyKey`; `dryRun` defaults to true. Official Operon applies only the exact opaque host-sealed preview plan and surfaces `outcome-unknown` with recovery metadata. Recovery is a separate same-plan route, never a new mutation. The public input nests ownership under `recovery`: `{ kind: "developer-api" }` or `{ kind: "adopt" | "periodic-create" | "periodic-update", planDigest?: sha256 }`. The flat top-level kind/digest shape is internal migration state only. A non-empty mutation path allowlist disables pending-recovery listing and apply because the recovery record exposes no canonical route that can be proved inside that scope.
 
 The Bridge returns before/requested/after and waits for a verified idle index after apply. The MCP reserves the idempotency key durably before the Bridge call, stores the result in `operon_mutation_journal`, and blocks blind retry after an uncertain timeout/restart. The same completed key and request never call the Bridge twice, while reuse with a different request is rejected as a conflict.
 
@@ -64,12 +64,20 @@ To avoid false atomicity, update accepts exactly one group per operation: descri
 - Live/hybrid with API: exact reads and mutations according to capabilities.
 - Headless: cached reads only; no mutation.
 - `readonly`: dry-run only.
-- `guarded`: capability-backed adopt/create/update/transition/relationship/relocate apply with normal preconditions and fresh consent when the sealed plan is elevated.
+- `guarded`: capability-backed adopt/create/Daily-Weekly/periodic-scheduling/update/transition/relationship/relocate apply with normal preconditions and fresh consent when the sealed plan is elevated.
 - `full`: conversion, recurrence and exact-plan recovery apply in addition.
 
 ## Evidence gates
 
 The disposable Operon 2.5 vault remains historical evidence for the legacy Public API path. The local Operon 3.2.0 acceptance build passed host grant/identity checks, live exact reads, saved-filter execution with opaque pagination, typed preview/apply for the validated mutation families, relationship inverse-edge verification, scoped recurrence add/change/clear, postflight, idempotent replay, exact restoration, and restart/recovery without a Markdown/private-API fallback. The build differs from the release only by the settings-renderer fix that restores Developer API grant controls.
+
+The patched Operon `3.5.2` acceptance candidate combining upstream PRs `#182`,
+`#183` and `#184` passed the complete Pilot 2 canary on 2026-08-24. It proved
+non-blocking startup before Obsidian, exact-grant auth, Daily/Weekly creation,
+periodic scheduling with a configured modified-time plugin, same-source graph
+ordering, durable concurrent replay, zero validation violations, zero pending
+recoveries and exact restoration. Stock `3.5.2` remains provisional until those
+fixes ship and the released artifact passes the same gate.
 
 Still outside this local acceptance proof:
 

--- a/docs/obsidian_mcp_tools_spec.md
+++ b/docs/obsidian_mcp_tools_spec.md
@@ -27,8 +27,8 @@ registration and tool-profile exposure are separate filters:
 - a hidden tool remains protected by the same runtime/write/security checks;
   visibility is not authorization.
 
-The current cross-runtime registry contains 74 unique names. Full live/hybrid
-registration currently contains 70 names. See
+The current cross-runtime registry contains 76 unique names. Full live/hybrid
+registration currently contains 72 names. See
 [Tool Surface Profiles](tool-surface-profiles.md) for exact profile semantics.
 
 ## MCP Resources
@@ -200,22 +200,31 @@ The authoritative English guarantees and compatibility matrix are in the
 - `operon_get_relationships`: bounded explicit, derived, and inferred relationship graph for one stable task.
 - `operon_build_context`: bounded exact-task, neighborhood, project, planning, or creation context with a strict hydration allowlist.
 - `operon_get_timer_state`: read active and transitioning timer state without exposing timer control.
-- `operon_adopt_task`: upgrade one exact legacy checkbox only when the loaded engine advertises adoption; official Operon 3.2.0 currently returns a structured unavailable result.
+- `operon_adopt_task`: adopt one exact checkbox only when the loaded engine grants the official task-workflow preview/apply pair. Operon 3.5.2 owns the opaque sealed plan and same-plan recovery; no Markdown fallback exists.
 - `operon_create_task`: create inline/file tasks through the loaded engine's official Developer API V1 or bounded legacy Public API v1 surface.
+- `operon_create_periodic_task`: create one inline task in the configured Daily or Weekly Note through Operon's additive periodic workflow; Operon owns routing, template, container identity and receipt.
+- `operon_update_periodic_scheduling`: set or clear one task's scheduled date through Operon's periodic workflow; Operon decides retain, detach or realign without moving source Markdown.
 - `operon_update_task`: update one mutation group with expected revision.
 - `operon_transition_task`: apply a stable status-ID or exact workflow transition through Operon's guards when the live Developer API advertises the capability; the Bridge bounds uncertain stock-runtime applies and never retries blindly.
 - `operon_set_relationships`: replace or clear parent/blocker edges with revision locking, graph validation, and inverse-edge postflight; apply is allowed in `guarded`.
 - `operon_update_recurrence`: set or clear official recurrence fields with explicit series scope; apply requires `full`.
 - `operon_convert_task`: convert inline/file shape in `MCP_WRITE_MODE=full`.
 - `operon_relocate_task`: move an inline task to another Markdown note while preserving `operonId`.
-- `operon_list_pending_recoveries`: list durable official Developer API recovery references without applying them.
-- `operon_recover_mutation`: recover one exact official mutation plan by `recoveryRef`; requires both mutation opt-ins and full MCP write mode.
+- `operon_list_pending_recoveries`: list durable official recovery references without applying them; fails closed when a path allowlist is configured because no canonical recovery route can be proved.
+- `operon_recover_mutation`: recover one exact official mutation plan with public input `{ idempotencyKey, recoveryRef, recovery }`. The nested union is `{ kind: "developer-api" }` or `{ kind: "adopt" | "periodic-create" | "periodic-update", planDigest?: sha256 }`; the flat top-level kind/digest representation is internal migration state, not public input. It requires both mutation opt-ins, full MCP write mode, and an empty path allowlist.
 
 Operon responses always declare `source`, `stale`, `snapshotAt`, `snapshotAgeMs`,
 Operon/Bridge versions, capabilities, and limitations.
 
 Mutations require a live Bridge and the loaded engine's official contract.
-Operon 3.2.0 uses Developer API V1 typed preview/apply/recovery; legacy
+Operon 3.5.2 plus CLI 1.2.0 is the 3.1 candidate target through Bridge 0.8.0
+and remains `compatible-provisional`. A patched acceptance candidate passed the
+live canary on 2026-08-24; official admission still requires upstream fixes
+`#182`, `#183` and `#184` to ship and the stock artifact to pass the same gate.
+Task Type and Task Image are scalar, Task Gallery is a lossless ordered array, and
+`__taskDataType` is read-only. Optional adoption and Daily/Weekly grants are
+negotiated independently from core reads. Operon 3.2.0 uses Developer API V1
+typed preview/apply/recovery for the earlier surface; legacy
 Kairélys uses Public API v1. Dry-run is the default, idempotency is mandatory,
 existing tasks require `expectedRevision`, and there is no direct Markdown
 fallback.

--- a/docs/operon-cli-audit.fr.md
+++ b/docs/operon-cli-audit.fr.md
@@ -2,20 +2,33 @@
 
 English version: [operon-cli-audit.md](operon-cli-audit.md)
 
-Date : 2026-08-17
+Mise à jour : 2026-08-24
 
-Référence : Operon officiel `3.3.2` admis provisoirement par contrat, Operon
-`3.2.1` certifié, Operon CLI `1.1.2`, Developer API V1 et
-`cli-manifest-v1.json`.
+Candidate courante : Operon officiel `3.5.2`, Operon CLI `1.2.0`, Bridge
+`0.8.0`, Developer API V1 et API task-workflow additive. Une candidate patchée
+a passé le canary Desktop exact le 2026-08-24. L’artefact officiel reste
+`compatible-provisional` jusqu’à la publication des PR upstream `#182`, `#183`
+et `#184`, puis au passage du même gate par la release stock.
+
+Operon CLI `1.2.0` ajoute la surface opérateur pour le routage Daily/Weekly et
+les champs typés Task Type, Task Image et Task Gallery ordonnée. Le MCP ne
+relaie pas la CLI génériquement : il expose uniquement les deux opérations
+périodiques bornées et l’adoption officielle après leurs grants exacts. Operon
+reste propriétaire de chaque plan opaque scellé et de sa récupération same-plan.
+`taskType` et `taskImage` restent scalaires, `taskGallery` reste un tableau
+ordonné et `__taskDataType` est read-only.
+
+## Acceptation historique 3.3.2
 
 Les observations CLI initiales du 1er août 2026 utilisaient Operon `3.0.1` et
 restent des preuves historiques. L’adaptateur MCP certifie `3.2.1` et admet
 `3.3.2` provisoirement après négociation du contrat. Le pilote live complet
 `3.3.2` avec CLI `1.1.2` est vert : les contrôles de grant dans les réglages,
 le refus des renommages implicites de File Tasks et le règlement des
-transitions sans portée Project Serial sont corrigés upstream. L’adoption reste
-indisponible dans l’API développeur officielle et est suivie dans
-[#140](https://github.com/hasanyilmaz/operon/issues/140). Le MCP échoue fermé et
+transitions sans portée Project Serial sont corrigés upstream. L’adoption était
+indisponible dans cette génération d’API et suivie dans
+[#140](https://github.com/hasanyilmaz/operon/issues/140). Operon `3.5.2`
+l’expose désormais après des grants additifs exacts. Le MCP échoue fermé et
 ne bascule jamais vers Markdown ou une API privée.
 
 ## Décision
@@ -35,17 +48,18 @@ un agent.
 
 ## Comparaison des surfaces
 
-Le MCP enregistre vingt-trois outils gouvernés, dont six lectures de raisonnement
+Le MCP enregistre vingt-cinq outils gouvernés, dont six lectures de raisonnement
 Developer API bornées. L’exécution des filtres sauvegardés fonctionne lorsque
 le contrat négocié annonce `tasks.filter-query`, après un grant exact, mais l’API officielle ne
-publie pas leur catalogue. L’adoption reste un outil de compatibilité
-indisponible :
+publie pas leur catalogue. L’adoption et les workflows de notes périodiques
+restent bornés par capacité :
 
 - lectures : statut, configuration, liste/get/query, filtre sauvegardé borné par
   capacité et validation ;
 - lectures de raisonnement : diagnostics, finder, résolution, relations,
   contexte et état du timer ;
-- mutations : adoption bornée par capacité, création, update, transition,
+- mutations : adoption bornée par capacité, création, création Daily/Weekly,
+  mise à jour du scheduling périodique, update, transition,
   relations, récurrence, conversion et relocation ;
 - récupération : liste des plans incertains et récupération d’un plan exact.
 
@@ -58,20 +72,20 @@ avec un cas d’usage ÉLYSIA clair, une capacité officielle et des gardes prou
 
 ## Classement des extensions
 
-| Candidate | Utilité ÉLYSIA | Risque | Décision |
-| --- | --- | --- | --- |
-| diagnostics | Élevée | Faible | Implémenté en lecture seule |
-| finder / résolution | Élevée | Faible | Implémenté avec résultats bornés |
-| lecture des relations | Élevée | Moyen | Implémenté avec racine exacte, profondeur et plafond |
-| pack de contexte | Élevée | Moyen | Implémenté avec projections et hydratation allowlistée |
-| état du timer | Moyenne | Faible | Lecture seulement, aucun contrôle |
-| écriture de relations | Élevée | Moyen à élevé | Implémentée avec révision, plan scellé, postflight inverse et récupération |
-| écriture de récurrence | Moyenne à élevée | Élevé | Implémentée avec portée explicite, mode full, postflight et récupération |
-| rappels | Moyenne | Élevé | Différé, reste dans la CLI |
-| contrôle/session du timer | Moyenne | Élevé | Différé, change l’exécution active |
-| état épinglé | Faible à moyenne | Moyen | Différé, préférence de présentation |
-| suppression | Moyenne | Destructif | Refusée sans contrat de corbeille réversible |
-| commande CLI générique | Non bornée | Élevé | Rejetée, contournerait le contrat Bridge |
+| Candidate                 | Utilité ÉLYSIA   | Risque        | Décision                                                                   |
+| ------------------------- | ---------------- | ------------- | -------------------------------------------------------------------------- |
+| diagnostics               | Élevée           | Faible        | Implémenté en lecture seule                                                |
+| finder / résolution       | Élevée           | Faible        | Implémenté avec résultats bornés                                           |
+| lecture des relations     | Élevée           | Moyen         | Implémenté avec racine exacte, profondeur et plafond                       |
+| pack de contexte          | Élevée           | Moyen         | Implémenté avec projections et hydratation allowlistée                     |
+| état du timer             | Moyenne          | Faible        | Lecture seulement, aucun contrôle                                          |
+| écriture de relations     | Élevée           | Moyen à élevé | Implémentée avec révision, plan scellé, postflight inverse et récupération |
+| écriture de récurrence    | Moyenne à élevée | Élevé         | Implémentée avec portée explicite, mode full, postflight et récupération   |
+| rappels                   | Moyenne          | Élevé         | Différé, reste dans la CLI                                                 |
+| contrôle/session du timer | Moyenne          | Élevé         | Différé, change l’exécution active                                         |
+| état épinglé              | Faible à moyenne | Moyen         | Différé, préférence de présentation                                        |
+| suppression               | Moyenne          | Destructif    | Refusée sans contrat de corbeille réversible                               |
+| commande CLI générique    | Non bornée       | Élevé         | Rejetée, contournerait le contrat Bridge                                   |
 
 ## Frontière de preuve actuelle
 

--- a/docs/operon-cli-audit.md
+++ b/docs/operon-cli-audit.md
@@ -2,16 +2,26 @@
 
 French version: [operon-cli-audit.fr.md](operon-cli-audit.fr.md)
 
-Date: 2026-08-17
-Reference: official Operon `3.3.2` provisionally admitted by contract, certified Operon `3.2.1`, Operon CLI `1.1.2`, Developer API V1 and `cli-manifest-v1.json`.
+Updated: 2026-08-24
+Current candidate: official Operon `3.5.2`, Operon CLI `1.2.0`, Bridge `0.8.0`, Developer API V1 and the additive task-workflow API. A patched candidate passed the exact live Desktop canary on 2026-08-24. The official artifact remains `compatible-provisional` until upstream PRs `#182`, `#183` and `#184` ship and the stock release passes the same gate.
+
+Operon CLI `1.2.0` adds operator access to Daily/Weekly routing and the typed
+Task Type, Task Image and ordered Task Gallery fields. The MCP does not relay
+the CLI generically: it exposes only the two bounded periodic operations and
+official adoption after their exact grants. Operon owns every opaque sealed
+plan and same-plan recovery. `taskType` and `taskImage` remain scalar,
+`taskGallery` remains an ordered array, and `__taskDataType` is read-only.
+
+## Historical 3.3.2 acceptance
 
 The original 2026-08-01 CLI observations were made against Operon `3.0.1` and
 remain historical evidence. The current MCP adapter certifies `3.2.1` and
 admits `3.3.2` provisionally after contract negotiation. The complete `3.3.2`
 live acceptance run is green with CLI `1.1.2`: Settings grant controls, File
 Task rename refusal, and unscoped transition settlement are fixed upstream.
-Adoption remains unavailable through the official Developer API and is tracked
-in [#140](https://github.com/hasanyilmaz/operon/issues/140). The MCP remains
+Adoption was unavailable through that Developer API generation and was tracked
+in [#140](https://github.com/hasanyilmaz/operon/issues/140). Operon `3.5.2` now
+exposes it through exact additive grants. The MCP remains
 fail-closed and does not fall back to Markdown or private APIs.
 
 ## Decision
@@ -28,16 +38,17 @@ Do not expose a generic CLI passthrough through MCP.
 
 ## Surface comparison
 
-The MCP registers twenty-three governed tools, including six bounded Developer
+The MCP registers twenty-five governed tools, including six bounded Developer
 API reasoning reads. Saved-filter execution is available when the negotiated
 task-workflow contract advertises it
 after an exact `tasks.filter-query` grant, but the official API does not expose
-the saved-filter catalog. Adoption remains an unavailable compatibility tool:
+the saved-filter catalog. Adoption and periodic-note workflows remain
+capability-gated:
 
 - reads: status, configuration, list/get/query, capability-gated saved filters, validation;
 - native reasoning reads: diagnostics, finder, resolve, relationships, context,
   and timer state;
-- mutations: capability-gated adoption, create, update, transition, relationships, recurrence, convert, relocate;
+- mutations: capability-gated adoption, create, Daily/Weekly create, periodic scheduling update, transition, relationships, recurrence, convert, relocate;
 - recovery: list pending official recoveries and recover one exact plan.
 
 The official CLI/Developer API additionally exposes:
@@ -56,20 +67,20 @@ operation with a clear ÉLYSIA use case and a matching proof/guard.
 
 ## Extension ranking
 
-| Candidate | ÉLYSIA utility | Risk | Decision |
-| --- | --- | --- | --- |
-| diagnostics snapshot | High | Low | Implemented read-only through Developer API V1 |
-| task finder / entity resolve | High | Low | Implemented with bounded candidates/results |
-| relationships read | High | Medium | Implemented with one exact root, depth ≤ 3 and result cap |
-| context pack | High | Medium | Implemented with projections, size caps and hydration allowlist |
-| timer read | Medium | Low | Implemented as observation only; no timer control |
-| relationship writes | High | Medium-High | Implemented as complete typed replacement with revision, sealed preview/apply, inverse-edge postflight and recovery |
-| recurrence writes | Medium-High | High | Implemented as scoped typed update; apply requires full mode, postflight and recovery |
-| reminder writes | Medium | High | Defer; keep in CLI until a concrete agent use case and dedicated contract exist |
-| timer control/session | Medium | High | Defer; changes active execution state and needs an explicit human gate |
-| pinned state | Low-Medium | Medium | Defer; presentation/state preference, not a core ÉLYSIA action |
-| delete | Medium | Destructive | Do not expose until a dedicated reversible-trash contract exists |
-| generic CLI command | Unbounded | High | Reject; it bypasses the Bridge contract and makes capability drift invisible |
+| Candidate                    | ÉLYSIA utility | Risk        | Decision                                                                                                            |
+| ---------------------------- | -------------- | ----------- | ------------------------------------------------------------------------------------------------------------------- |
+| diagnostics snapshot         | High           | Low         | Implemented read-only through Developer API V1                                                                      |
+| task finder / entity resolve | High           | Low         | Implemented with bounded candidates/results                                                                         |
+| relationships read           | High           | Medium      | Implemented with one exact root, depth ≤ 3 and result cap                                                           |
+| context pack                 | High           | Medium      | Implemented with projections, size caps and hydration allowlist                                                     |
+| timer read                   | Medium         | Low         | Implemented as observation only; no timer control                                                                   |
+| relationship writes          | High           | Medium-High | Implemented as complete typed replacement with revision, sealed preview/apply, inverse-edge postflight and recovery |
+| recurrence writes            | Medium-High    | High        | Implemented as scoped typed update; apply requires full mode, postflight and recovery                               |
+| reminder writes              | Medium         | High        | Defer; keep in CLI until a concrete agent use case and dedicated contract exist                                     |
+| timer control/session        | Medium         | High        | Defer; changes active execution state and needs an explicit human gate                                              |
+| pinned state                 | Low-Medium     | Medium      | Defer; presentation/state preference, not a core ÉLYSIA action                                                      |
+| delete                       | Medium         | Destructive | Do not expose until a dedicated reversible-trash contract exists                                                    |
+| generic CLI command          | Unbounded      | High        | Reject; it bypasses the Bridge contract and makes capability drift invisible                                        |
 
 ## Current proof boundary
 

--- a/docs/operon-decision-report.md
+++ b/docs/operon-decision-report.md
@@ -1,12 +1,37 @@
 # Operon integration decision report
 
-## Current status — 2026-08-17
+## Current candidate — 2026-08-24
+
+Optimike MCP `3.1.0` and Bridge `0.8.0` target official Operon `3.5.2` with
+Operon CLI `1.2.0`. The candidate preserves ordered `taskGallery` values,
+keeps `taskType` and `taskImage` scalar, rejects writes to `__taskDataType`, and
+adds two bounded Daily/Weekly operations. Official adoption and periodic
+workflows require their exact additive grants; missing grants fail closed and
+never activate a Markdown fallback. Operon remains the owner of every opaque
+sealed plan and same-plan recovery.
+
+The deterministic contract candidate is `compatible-provisional`. It must not
+be described as certified until the required upstream fixes ship and the stock
+artifact passes the exact live Obsidian Desktop canary.
+The disposable Pilot 2 vault is upgraded and tested directly after recording
+its initial state and keeping only the minimal diagnostic/rollback evidence.
+The real startup-order sub-gate is green: one MCP client survived the initial
+degraded status and became live after Pilot 2 opened. The final patched
+candidate (`#182` + `#183` + `#184`, combined code head `4412a20`, local
+attested manifest version `3.5.240438`) also passed the
+complete canary with exact restoration, zero retained periodic artifacts and
+zero pending recoveries. This proves the integration design and the proposed
+fixes; it does not certify stock `3.5.2` before those fixes are merged, released
+and rerun. The detailed execution journal lives in
+[the local validation recipe](operon-local-validation.md).
+
+## Historical status — 2026-08-17
 
 Optimike Obsidian MCP Bridge `0.7.0` certifies Operon through `3.2.1` and admits
 the non-denied Operon `3.3.2` version with its Developer API V1 accessor as
 `compatible-provisional`. Developer API status, schema, index readiness, and
 capabilities remain separate live-use gates. The canonical server registers
-twenty-three governed Operon tools. Kairélys remains disabled and retained only
+twenty-three governed Operon tools at that historical baseline. Kairélys remains disabled and retained only
 for bounded rollback compatibility.
 
 The complete local acceptance run is green on Operon `3.3.2`, Operon CLI
@@ -20,7 +45,7 @@ tracked official API gap ([#140](https://github.com/hasanyilmaz/operon/issues/14
 No MCP or Bridge route falls back to raw Markdown, private Operon methods or UI
 commands when a capability is missing or an outcome is uncertain.
 
-## Implemented surface
+## Implemented surface: historical baseline and 3.1 extension
 
 - official Operon `3.2.0` Developer API V1 adapter;
 - Bridge status/configuration/list/get/query/validate and complete pagination;
@@ -29,12 +54,17 @@ commands when a capability is missing or an outcome is uncertain.
 - governed create, update, transition, relationship replacement, recurrence,
   conversion and inline relocation;
 - saved-filter execution through `tasks.filter-query` after an exact grant and
-  caller-supplied filter ID; adoption remains an unavailable compatibility tool;
+  caller-supplied filter ID; at the historical 3.3.2 baseline, adoption was
+  an unavailable compatibility tool;
 - durable pending-recovery listing and exact-plan recovery;
 - dry-run by default, live `expectedRevision`, durable idempotency and postflight;
 - SQLite live/stale snapshots and mutation journal;
 - double mutation opt-in and mode-based write policy;
 - no generic CLI passthrough.
+
+The 3.1 candidate extends that list to twenty-five tools with
+`operon_create_periodic_task` and `operon_update_periodic_scheduling`; adoption
+is now official but still grant-gated.
 
 ## Why MCP and CLI remain separate
 
@@ -106,15 +136,18 @@ reconciliation remains fixture evidence, not part of this live acceptance
 claim.
 
 The 2026-08-01 Operon `3.0.1` cutover and CLI `1.0.0` Windows observations also
-remain historical. The current runtime target is Operon `3.3.2` with Bridge
-`0.7.0`; CLI `1.1.2` is the paired operator-reference target.
+remain historical. The current candidate target is Operon `3.5.2` with Bridge
+`0.8.0`; CLI `1.2.0` is the paired operator-reference target. This target stays
+`compatible-provisional` until the fixes validated by the patched canary ship
+and the stock artifact passes the same live gate.
 
 ## Deliberately excluded or unavailable
 
 - deletion: CLI operator action until a reversible `operon_trash_task` contract
   exists;
 - reminders, pinned state and timer control/session: retained in the CLI;
-- adoption remains unavailable in the official Developer API;
+- official adoption in the 3.5.2 candidate remains capability- and grant-gated;
+  it was unavailable in the historical 3.3.2 Developer API generation;
 - saved-filter execution is available with an exact ID and grant, while catalog
   discovery and filter creation/editing remain unavailable;
 - generic CLI execution: rejected;
@@ -126,5 +159,8 @@ Keep the current Operon integration active. Use MCP/Bridge for governed agent
 workflows and CLI for broad operator work. Keep Kairélys disabled but available
 for rollback until a separate non-dependency proof authorizes removal.
 
-The code, publication, and local acceptance work are complete. The separate
-real Sync/non-dependency decision remains outside this integration scope.
+The 3.1 implementation, deterministic checks and patched-candidate Pilot 2
+acceptance are complete. Publication as a certified official Operon baseline
+remains pending on upstream merge/release of `#182`, `#183` and `#184`, followed
+by the same canary against the stock artifact. The separate real
+Sync/non-dependency decision remains outside this integration scope.

--- a/docs/operon-local-validation.md
+++ b/docs/operon-local-validation.md
@@ -7,20 +7,64 @@ This recipe is the Desktop proof. Run destructive fixtures only in a disposable 
 - Node.js `>=22.7.5`
 - Obsidian Desktop
 - Local REST API enabled
-- Operon `3.3.2` with Operon CLI `1.1.2` for the completed contract-first live pilot; `3.2.1` remains in the explicit certified set, and `2.4.0` / `2.5.0` remain legacy-read fixtures
+- Operon `3.5.2` with Operon CLI `1.2.0` for the current candidate; `3.2.1` remains in the explicit certified set, `3.3.2` / CLI `1.1.2` remains completed historical evidence, and `2.4.0` / `2.5.0` remain legacy-read fixtures
+- Optimike Operon Bridge `0.8.0`
 - Optimike Operon Bridge built from this branch
 - Optimike Obsidian MCP built from this branch
 - a backup or disposable vault
 
-The adapter certifies through Operon `3.2.1` and gives `3.3.2` provisional
-version/accessor admission. The `3.3.2` live acceptance run separately proves
+The adapter certifies through Operon `3.2.1` and gives later non-denied V1
+releases provisional version/accessor admission. The `3.3.2` live acceptance run separately proves
 the Developer API, schema, index, capability, and readiness gates and is
 complete and green; keeping its runtime state provisional preserves the
 contract-first policy. Settings grant controls, implicit File Task rename
-refusal, and unscoped transition settlement are fixed in `3.3.2`. Adoption
-remains unavailable through the official Developer API and is tracked in
-[#140](https://github.com/hasanyilmaz/operon/issues/140). Unsupported or uncertain paths stay fail-closed; this
+refusal, and unscoped transition settlement are fixed in `3.3.2`. Adoption was
+unavailable through that Developer API generation. Operon `3.5.2` exposes
+adoption plus Daily/Weekly workflows through exact additive grants. The 3.1
+candidate preserves `taskGallery` as an ordered array, keeps `taskType` and
+`taskImage` scalar, and treats `__taskDataType` as read-only. It remains
+`compatible-provisional` until this recipe passes on the exact candidate.
+Unsupported or uncertain paths stay fail-closed; this
 recipe never authorizes a Markdown/private-API fallback or a blind retry.
+
+For the explicitly disposable Pilot 2 vault, record the initial plugin/runtime
+state and retain only minimal diagnostic/rollback evidence, then upgrade and
+test that vault directly. Do not create a sibling clone as a release gate.
+Obsidian CLI can target and open this vault with `vault=<name>`, but it exposes
+no dedicated supported `close` or `quit` command. For this disposable vault,
+the CLI can target its window and evaluate `window.close()`. Record the exact
+Pilot 2 Local REST port first: the command result alone does not prove that the
+intended window closed.
+
+On Windows PowerShell, substitute the exact vault name and the Local REST HTTP
+port configured in Pilot 2. The port must identify Pilot 2 rather than another
+open vault:
+
+```powershell
+$pilotVault = "Operon Bridge Pilot 2"
+$pilotRestPort = 27123
+
+if (-not (Test-NetConnection 127.0.0.1 -Port $pilotRestPort -InformationLevel Quiet)) {
+  throw "Pilot 2 Local REST port is not listening before close"
+}
+
+obsidian vault="$pilotVault" eval code="window.close();'closing-pilot-2'"
+if ($LASTEXITCODE -ne 0) { throw "Targeted Pilot 2 close failed" }
+
+$deadline = (Get-Date).AddSeconds(15)
+do {
+  $pilotPortOpen = Test-NetConnection 127.0.0.1 -Port $pilotRestPort -InformationLevel Quiet
+  if ($pilotPortOpen) { Start-Sleep -Milliseconds 250 }
+} while ($pilotPortOpen -and (Get-Date) -lt $deadline)
+
+if ($pilotPortOpen) { throw "Pilot 2 Local REST port is still listening after close" }
+```
+
+PASS only when the bounded port check reaches `False`. If it remains `True`,
+stop and identify the listening vault/process instead of assuming a clean restart.
+Reopen the same disposable vault with `obsidian vault="$pilotVault"` and recheck
+the same port before continuing the canary. This targeted `eval` is a Pilot 2
+test operation, not a generic supported Obsidian `close` command.
 
 ## 1. Automated checks
 
@@ -79,11 +123,13 @@ PASS when:
 - index generation is greater than zero;
 - diagnostics report `health=healthy`, `runtimePhase=idle`,
   `verifiedThisSession=true`, and `dirtySourceCount=0`;
-- official Operon `3.2.0` reports the exact grants and typed Developer APIs
-  surface; the Bridge advertises only the mutation capabilities that the live
-  runtime proves, and bounds uncertain applies without a blind retry;
-- `adopt` remains false on official Operon; legacy Kairélys/Public API probes
-  are tested separately;
+- official Operon `3.5.2` reports the exact Developer API V1 and additive
+  task-workflow grants; the Bridge advertises only the mutation capabilities
+  that the live runtime proves and bounds uncertain applies without a blind
+  retry;
+- adoption and periodic capabilities are true only after their exact grants;
+  missing grants remain structured unavailable results, while historical
+  3.2.x and legacy Kairélys/Public API probes are tested separately;
 - duplicate conflict count is zero.
 
 FAIL if the route claims compatibility while Operon is absent or incompatible.
@@ -176,6 +222,8 @@ operon_build_context
 operon_get_timer_state
 operon_adopt_task
 operon_create_task
+operon_create_periodic_task
+operon_update_periodic_scheduling
 operon_update_task
 operon_transition_task
 operon_set_relationships
@@ -188,13 +236,116 @@ operon_recover_mutation
 
 PASS when:
 
-- all twenty-three tools are registered;
-- official Operon `3.2.0` returns a structured unavailable result for adoption;
+- all twenty-five tools are registered;
+- official Operon `3.5.2` remains read-only through the Bridge even when
+  adoption and periodic grants exist; only the locally attested `3.5.240438`
+  build exercises those mutation workflows, and a missing grant returns a
+  structured unavailable result without a Markdown fallback;
 - saved-filter execution succeeds only after an exact `tasks.filter-query`
   grant and caller-supplied filter ID; the official catalog remains unavailable;
+- recovery requires the public nested `recovery` union: `{ kind:
+"developer-api" }` or `{ kind: "adopt" | "periodic-create" |
+"periodic-update", planDigest?: sha256 }`; flat top-level kind/digest input is
+  internal migration state only;
+- with `OPERON_MUTATION_ALLOWED_PATH_PREFIXES` non-empty, both pending-recovery
+  listing and apply fail closed before inventory disclosure or native dispatch;
 - the first complete call creates a snapshot;
 - subsequent calls with unchanged generation do not rewrite the full snapshot;
 - responses say `source=operon-live`, `stale=false`.
+
+## 8a. Exact Operon 3.5.2 live canary
+
+Run only after the exact candidate Bridge is installed and the Pilot 2 status,
+grants, index and validation gates above are green. The recommended mode proves
+the real startup order: MCP connects first while Pilot 2 is closed, the same MCP
+connection survives a degraded status, then the CLI opens only Pilot 2 and that
+same client becomes live.
+
+From Windows PowerShell in the MCP repository, first close Pilot 2 with the
+targeted command and port proof documented above. Then set the exact disposable
+vault path required by the script and run:
+
+```powershell
+$env:OBSIDIAN_VAULT = "<exact disposable Pilot 2 path required by the script>"
+$env:OBSIDIAN_BASE_URL = "http://127.0.0.1:27233"
+$env:OBSIDIAN_API_KEY = "<Pilot 2 Local REST API key>"
+$env:OPERON_MUTATIONS_ENABLED = "true"
+$env:OPERON_35_CANARY_CONFIRM = "I_CONFIRM_PILOT_2_DISPOSABLE_LIVE_MUTATIONS"
+$env:OPERON_35_CANARY_OPEN_VAULT = "true"
+$env:OPERON_35_CANARY_CONFIRM_OPEN_VAULT = "I_CONFIRM_OPENING_ONLY_OPERON_PILOT_2"
+Remove-Item Env:OPERON_35_CANARY_CONFIRM_PILOT_ALREADY_OPEN -ErrorAction SilentlyContinue
+
+npm run build
+npm run smoke:operon-35-live
+```
+
+If `obsidian` is not on `PATH`, set
+`OPERON_35_CANARY_OBSIDIAN_CLI` to its exact executable or launcher first. To
+test an already-open Pilot 2 instead, remove the two `OPEN_VAULT` variables and
+set `OPERON_35_CANARY_CONFIRM_PILOT_ALREADY_OPEN=true`; that mode does not prove
+the startup-order contract.
+
+The script refuses to start unless all of these gates hold:
+
+- the resolved vault is the one exact disposable Pilot 2 compiled into the
+  canary, with the expected vault name;
+- Local REST uses exactly `http://127.0.0.1:27233` and a non-empty API key;
+- `OPERON_MUTATIONS_ENABLED=true`, the Bridge mutation setting is enabled, and
+  all required Developer API/task-workflow grants and capabilities are live;
+- `Canary/Operon-3.5.2-Live-Canary.md` does not already exist;
+- the explicit mutation confirmation is exact; startup-order mode additionally
+  requires the exact open-vault confirmation;
+- the canary process forces `MCP_WRITE_MODE=full`, an empty mutation path
+  allowlist, non-blocking startup, the `tasks` profile, and a private temporary
+  cache/backup scope.
+
+The command writes its JSON evidence under the OS temporary root and prints the
+exact `evidenceFile`. Certification is forbidden unless the command exits `0`,
+the printed summary has `ok=true`, `fixtureRestored=true` and
+`periodicArtifactsRetained=0`, and the evidence confirms the exact candidate
+versions, zero validation violations, zero pending recoveries, byte-exact
+artifact restoration, and—when startup-order mode is selected—
+`degradedObserved=true`, `connectionAliveAfterDegraded=true`,
+`sameClientBecameLive=true`. A failed run retains the private backup path for
+diagnosis and is never certification evidence.
+
+### Execution journal — 2026-08-24
+
+The first startup-order attempt produced `MCP error -32000: Connection closed`
+in `operon-35-live-evidence-c8a4b93c-6aac-4b62-8b03-5b00cdffd804.json`. This was
+a harness false signal: `LOGS_DIR` pointed to an OS-temporary directory outside
+the configured `projectRoot`, so startup directory validation terminated the
+backend before the startup-order behavior could be observed. The harness now
+uses `<projectRoot>/logs`; this failure is not evidence that non-blocking MCP
+startup is broken.
+
+Two later real startup-order attempts—captured in
+`operon-35-live-evidence-0ebe3260-9175-4923-9437-77bc92a7123d.json` and
+`operon-35-live-evidence-e5d7c95d-de81-441b-9830-43acd06d0b0f.json`—recorded
+the intended sub-proof:
+
+- `degradedObserved=true` while Pilot 2 was closed;
+- `connectionAliveAfterDegraded=true` on the same MCP client;
+- CLI exit `0`, then `sameClientBecameLive=true` after two live-status attempts;
+- all canary Markdown artifacts restored on failure.
+
+Those runs remain `ok=false`: one stopped at the Frontmatter Date Manager gate
+and the next at adoption apply. They led to bounded upstream fixes for auth,
+same-source graph ordering and modified-time settlement.
+
+The final patched candidate (`#182` + `#183` + `#184`, combined code head
+`4412a20`, local attested manifest version `3.5.240438`) passed the complete
+startup-order canary on 2026-08-24. The printed
+summary reported `ok=true`, `fixtureRestored=true` and
+`periodicArtifactsRetained=0`. It also proved Daily/Weekly creation, periodic
+scheduling set/clear with Frontmatter Date Manager active, concurrent Bridge
+replay, zero validation violations and zero pending recoveries. This is
+acceptance evidence for the patched candidate, not certification of the stock
+`3.5.2` artifact. Keep the official release `compatible-provisional` until the
+three upstream fixes ship and the released artifact passes this same recipe.
+Bridge `0.8.0` therefore keeps stock `3.5.2` readable but masks every mutation
+capability. The synthetic `3.5.240438` identity is reserved for this disposable
+acceptance build and must never be published as an upstream Operon release.
 
 ## 9. Restart and reindex
 
@@ -473,9 +624,10 @@ PASS:
 - the final snapshot returned to 30 tasks, two historical Operon Pilot tasks,
   zero recovery, and `P0/P1/P2 = 0/0/0`.
 
-CURRENT BOUNDARIES:
+BOUNDARIES OF THAT 3.3.2 RUN:
 
-- adoption remains unavailable through the official Developer API (#140);
+- adoption was unavailable through that official Developer API generation
+  (#140);
 - saved-filter execution requires an exact known ID because catalog discovery
   is not exposed;
 - delete, reminders, pin state, and timer control/session remain CLI operator

--- a/docs/operon-mcp-contract.fr.md
+++ b/docs/operon-mcp-contract.fr.md
@@ -4,7 +4,7 @@ English version: [operon-mcp-contract.md](operon-mcp-contract.md)
 
 ## Surface
 
-Le serveur MCP principal enregistre vingt-trois outils Operon :
+Le serveur MCP principal enregistre vingt-cinq outils Operon :
 
 - `operon_status`
 - `operon_get_configuration`
@@ -21,6 +21,8 @@ Le serveur MCP principal enregistre vingt-trois outils Operon :
 - `operon_get_timer_state`
 - `operon_adopt_task`
 - `operon_create_task`
+- `operon_create_periodic_task`
+- `operon_update_periodic_scheduling`
 - `operon_update_task`
 - `operon_transition_task`
 - `operon_set_relationships`
@@ -100,7 +102,7 @@ opération. Une capacité optionnelle absente désactive seulement les outils qu
 en dépendent. Un futur contrat n’est jamais accepté silencieusement.
 
 `operon_query_saved_filter` est live-only et dépend d’une capacité native. Sur
-Operon officiel `3.2.0`, il utilise la Developer API task-workflow après un grant
+Operon officiel `3.5.2`, il utilise la Developer API task-workflow après un grant
 exact `tasks.filter-query`. L’appelant doit fournir un `filterSetId` exact :
 l’API officielle exécute les filtres mais n’en publie pas le catalogue. Le MCP
 ne tente jamais de reproduire leur sémantique depuis le cache.
@@ -118,30 +120,47 @@ anglais ne sont pas des identifiants d’automatisation durables.
 ## Mutations
 
 Les mutations passent par les routes REST du Bridge et la surface officielle du
-moteur chargé. Operon `3.2.0` utilise les plans typés preview/apply/recovery de
-Developer API V1. Le chemin legacy Kairélys utilise Public API v1. Aucun chemin
+moteur chargé. Pour la campagne 3.5, seule l’identité locale attestée
+`3.5.240438` utilise les plans typés preview/apply/recovery de Developer API V1 ;
+la `3.5.2` stock reste en lecture seule. Le chemin legacy Kairélys utilise Public API v1. Aucun chemin
 ne modifie directement le Markdown, n’appelle `TaskWriter`, ne lance une
 commande UI et ne réfléchit vers une méthode privée.
+
+Les plans task-workflow officiels sont des handles opaques liés à la session.
+Le MCP ne les reconstruit jamais : la récupération continue uniquement le même
+plan via son `recoveryRef`.
 
 Contrôles communs :
 
 - `dryRun` vaut `true` par défaut ;
 - `idempotencyKey` est obligatoire ;
 - une tâche Operon existante exige `expectedRevision` ;
-- l’adoption legacy exige `line` et `expectedLine` exacts ;
-- Operon `3.2.0` applique uniquement le plan prévisualisé et scellé par l’hôte ;
+- l’adoption exige `line` et `expectedLine` exacts ;
+- la candidate locale attestée `3.5.240438` applique uniquement le plan opaque prévisualisé et scellé par l’hôte ; la `3.5.2` stock reste en lecture seule ;
 - `outcome-unknown` est exposé avec sa référence de récupération et n’est jamais
   rejoué à l’aveugle ;
+- les résultats Task Workflow sont validés strictement avant projection ; une
+  preuve native malformée ou contradictoire reste `outcome-unknown`, et
+  `nativeProof` ne contient que la projection de preuve bornée ;
 - après apply, le Bridge relit l’index live vérifié et le MCP rafraîchit son
   snapshot SQLite ;
 - aucune mutation ne s’appuie sur un snapshot headless ou obsolète.
 
-Le journal `operon_mutation_journal` réserve la clé avant l’appel au Bridge.
+Le journal MCP `operon_mutation_journal` réserve la clé avant l’appel au Bridge.
 Rejouer une requête terminée avec la même clé renvoie le même `operationId` sans
 second appel. Réutiliser la clé pour une autre requête renvoie `CONFLICT`. Une
 révision périmée renvoie `conflict` sans écriture. Une réservation restée
 `in_progress` après timeout ou redémarrage bloque toute nouvelle mutation à
 l’aveugle.
+
+Bridge 0.8 réserve aussi les clés d’idempotence atomiquement et persiste son
+journal version 1 dans les données locales du plugin Obsidian avant tout dispatch
+natif. Ce journal est borné à 500 entrées et 30 jours. Une entrée `in-progress`
+restaurée devient `outcome-unknown`, non rejouable, avec
+`recoveryRequired: true`. Cette garantie couvre seulement le replay/redémarrage
+local borné : aucune promesse après expiration, éviction, perte/reset des données
+plugin, échec de persistance ou transfert vers un autre coffre/appareil. Si la
+réservation ne peut pas être persistée, aucune mutation native n’est envoyée.
 
 L’apply exige aussi `OPERON_MUTATIONS_ENABLED=true` et le réglage Bridge
 **Allow task mutations**. Une mise à jour de package ne peut donc pas activer les
@@ -151,31 +170,55 @@ L’apply exige aussi `OPERON_MUTATIONS_ENABLED=true` et le réglage Bridge
 
 - `MCP_WRITE_MODE=readonly` : dry-run uniquement.
 - `MCP_WRITE_MODE=guarded` : apply d’adoption si la capacité existe, création,
-  update, transition, remplacement de relations et relocation inline.
+  création Daily/Weekly, mise à jour du scheduling périodique, update,
+  transition, remplacement de relations et relocation inline.
 - `MCP_WRITE_MODE=full` : conversion et récurrence en plus.
-- `operon_recover_mutation` exige aussi le mode `full` et ne récupère que le
-  `recoveryRef` exact.
+- `operon_recover_mutation` exige aussi le mode `full`, le `recoveryRef` exact
+  et une union imbriquée `recovery` portant un `kind` explicite :
+  `developer-api`, `adopt`, `periodic-create` ou `periodic-update`.
 
 `OPERON_MUTATION_ALLOWED_PATH_PREFIXES` peut limiter toutes les mutations à des
 dossiers relatifs au coffre. Les sources et destinations explicites doivent
 rester dans cette allowlist. Operon officiel `3.2.0` refuse encore un
 `targetFolder` arbitraire lorsqu’aucun contrat de destination exacte n’existe.
+Comme les entrées de récupération ne publient aucune route canonique prouvable
+contre cette politique, une allowlist de chemins non vide désactive à la fois
+`operon_list_pending_recoveries` et l’apply de récupération. Les deux échouent
+fermés avant divulgation de l’inventaire ou dispatch natif.
 
 La conversion reste destructive : file-to-inline déplace le fichier source
 dans la corbeille et inline-to-file remplace la ligne source par un lien durable.
 
 ### Règles propres aux outils
 
-`operon_adopt_task` est un outil de compatibilité enregistré, pas une capacité
-officielle d’Operon `3.2.0`. Un moteur legacy compatible peut adopter une
-checkbox exacte avec verrouillage du chemin, de la ligne et du contenu source.
-Operon officiel renvoie une indisponibilité structurée et le MCP ne simule pas
-l’adoption en éditant le Markdown.
+`operon_adopt_task` utilise l’API task-workflow additive officielle uniquement
+sur un build admis en mutation et après les grants exacts `tasks.adopt.preview`
+et `tasks.adopt.apply`. Pour la campagne 3.5, ce build est l’identité locale
+attestée `3.5.240438` ; la `3.5.2` stock reste en lecture seule. Operon applique son plan opaque scellé à une checkbox
+exacte. Un moteur legacy compatible peut encore annoncer son contrat borné,
+mais un grant officiel absent renvoie une indisponibilité structurée et le MCP
+ne simule jamais l’adoption en éditant le Markdown.
 
 `operon_create_task` crée une tâche inline ou fichier par les services officiels
 du moteur. Operon `3.2.0` accepte les champs typés, tags, `statusId`, relations,
 `targetPath` inline et templates configurés. Les propriétés YAML non gérées et
 les `targetFolder` arbitraires restent legacy-only.
+
+`operon_create_periodic_task` crée exactement une tâche inline dans la Daily ou
+Weekly Note configurée après les grants périodiques preview/apply exacts. Operon
+reste propriétaire du routage par date, des templates, de l’identité du
+conteneur et du reçu ; le MCP ne peut pas imposer un chemin ou un parent. Le
+postflight vérifie `priorityId` contre la priorité stable projetée. Si l’apply a
+pu réussir sans qu’une identité créée unique puisse être prouvée, le résultat
+reste `outcome-unknown` et le MCP ne rejoue jamais cette création ambiguë.
+`operon_update_periodic_scheduling` fixe ou efface la date planifiée d’une tâche
+exacte. Operon décide de la conserver, la détacher ou la réaligner, sans déplacer
+le Markdown source.
+
+Les champs gérés conservent leur forme officielle : `taskType` et `taskImage`
+sont des chaînes scalaires, `taskGallery` est un tableau ordonné sans perte et
+les chaînes à séparateurs sont refusées. Le champ dérivé `__taskDataType` est
+read-only et ne peut pas entrer dans une création ou une mise à jour.
 
 `operon_update_task` accepte un seul groupe par appel : description, champs
 gérés/tags ou propriété fichier non gérée lorsque le moteur l’autorise. Les
@@ -206,8 +249,21 @@ explicite en conservant `operonId`. Le Bridge vérifie source et destination
 après stabilisation de l’index.
 
 `operon_list_pending_recoveries` liste les références officielles sans appliquer
-quoi que ce soit. `operon_recover_mutation` récupère un seul plan exact et
-préserve ses preuves `planDigest` et `recoveryRef`.
+quoi que ce soit, uniquement lorsque l’allowlist de chemins est vide.
+L’entrée publique de `operon_recover_mutation` est
+`{ idempotencyKey, recoveryRef, recovery }`. `recovery` vaut soit
+`{ kind: "developer-api" }`, soit
+`{ kind: "adopt" | "periodic-create" | "periodic-update", planDigest?: sha256 }`.
+La branche `developer-api` appelle la récupération Developer API V1 et
+n’accepte pas `planDigest`. Seules les trois branches Task Workflow acceptent
+un digest SHA-256 optionnel pour lier la récupération au reçu/replay scellé.
+Sans ce digest, le Bridge ne peut prouver le lien Task Workflow qu’à partir de
+l’entrée correspondante de `pendingRecoveries` ; sinon il échoue fermé avant
+dispatch. Les champs `kind` et `planDigest` top-level ne font pas partie du
+contrat public ; cette forme plate reste une migration interne candidate/legacy.
+Toute allowlist de chemins non vide bloque aussi listing et apply, faute de route
+canonique prouvable. La réponse préserve `planDigest` lorsqu’il existe et
+`recoveryRef`.
 
 ## Preuves du pilote
 
@@ -233,14 +289,32 @@ le runtime ne peut pas prouver le résultat.
 
 ## Capacités indisponibles ou exclues
 
-Suppression, rappels, état épinglé, contrôle/session de timer, adoption et
+Suppression, rappels, état épinglé, contrôle/session de timer et
 gestion des filtres sauvegardés restent hors de la surface officielle de
 mutation agentique. L’**exécution** d’un filtre sauvegardé fonctionne sur
-Operon `3.2.0` avec un ID exact et le grant requis ; la découverte du catalogue,
-la création et l’édition des filtres ne sont pas exposées. L’adoption reste
-indisponible dans la Developer API officielle.
+Operon `3.5.2` avec un ID exact et le grant requis ; la découverte du catalogue,
+la création et l’édition des filtres ne sont pas exposées. Sur le chemin
+d’acceptation 3.5 courant, l’adoption est disponible uniquement pour le build
+admis en mutation `3.5.240438`, après ses grants additifs exacts ; la `3.5.2`
+stock reste en lecture seule.
 
 La suppression reste une action opérateur dans la CLI. Un futur
 `operon_trash_task` ne pourra être envisagé qu’avec restauration garantie sous
 le même `operonId`, relations réconciliées, journal durable et confirmation
 humaine explicite. Il n’est pas implémenté.
+
+## Admission de la candidate 3.1
+
+Optimike MCP `3.1.0`, Bridge `0.8.0`, Operon `3.5.2` et Operon CLI `1.2.0`
+forment l’ensemble candidat courant. La négociation du contrat et les tests
+déterministes l’admettent comme `compatible-provisional`. Une candidate patchée
+a passé le canary Obsidian Desktop exact le 2026-08-24 ; la certification exige
+encore la publication des correctifs des PR upstream `#182`, `#183` et `#184`,
+puis le passage du même gate par l’artefact stock. Ce statut provisoire ne
+relâche aucun gate de capacité, grant, mode d’écriture ou récupération.
+
+Le Bridge `0.8.0` admet les lectures de la `3.5.2` stock après négociation du
+contrat, mais masque toutes ses capacités de mutation. Le build local Pilot 2
+utilise la version manifeste synthétique explicite `3.5.240438` ; lui seul est
+admis en mutation pour l’acceptation 3.5 et ce n’est pas un identifiant de
+release upstream.

--- a/docs/operon-mcp-contract.md
+++ b/docs/operon-mcp-contract.md
@@ -4,7 +4,7 @@ French version: [operon-mcp-contract.fr.md](operon-mcp-contract.fr.md)
 
 ## Surface
 
-The main MCP server registers twenty-three Operon tools:
+The main MCP server registers twenty-five Operon tools:
 
 - `operon_status`
 - `operon_get_configuration`
@@ -21,6 +21,8 @@ The main MCP server registers twenty-three Operon tools:
 - `operon_get_timer_state`
 - `operon_adopt_task`
 - `operon_create_task`
+- `operon_create_periodic_task`
+- `operon_update_periodic_scheduling`
 - `operon_update_task`
 - `operon_transition_task`
 - `operon_set_relationships`
@@ -76,7 +78,7 @@ Missing optional capabilities disable only dependent tools. A future contract
 version is never accepted silently.
 
 `operon_query_saved_filter` is intentionally live-only and capability-gated. On
-official Operon `3.2.0`, it delegates to the additive task-workflow Developer
+official Operon `3.5.2`, it delegates to the additive task-workflow Developer
 API after an exact `tasks.filter-query` grant. The caller must supply an exact
 `filterSetId`: the official API executes saved filters but does not expose their
 catalog. Headless snapshots never attempt to reproduce plugin filter semantics.
@@ -93,40 +95,47 @@ The cached metadata also stores the configuration used for that snapshot. Tasks 
 
 ## Mutations
 
-Mutation tools call Bridge REST routes backed by the loaded engine's official mutation surface. Operon 3.x uses Developer API V1 typed preview → apply plans with host-owned recovery; legacy Kairélys versions continue to use their Public API v1 contract. No route edits Markdown, calls `TaskWriter` directly, invokes UI commands, or reflects into private methods.
+Mutation tools call Bridge REST routes backed by the loaded engine's official mutation surface. Operon 3.x uses Developer API V1 typed preview → apply plans with host-owned recovery; legacy Kairélys versions continue to use their Public API v1 contract. Official task-workflow plans are opaque, session-bound handles: the MCP never reconstructs them and recovery continues only the same plan through its `recoveryRef`. No route edits Markdown, calls `TaskWriter` directly, invokes UI commands, or reflects into private methods.
 
 Common controls:
 
 - `dryRun` defaults to `true`;
 - `idempotencyKey` is mandatory;
 - existing Operon tasks require `expectedRevision`;
-- legacy checkbox adoption requires an exact one-based `line` and `expectedLine` precondition;
-- Operon 3.2.0 previews and applies one exact host-sealed plan;
+- adoption requires an exact one-based `line` and `expectedLine` precondition;
+- the locally attested Operon `3.5.240438` acceptance build previews and applies one exact host-sealed opaque plan; stock `3.5.2` remains read-only at the Bridge boundary;
 - `outcome-unknown` is surfaced with its recovery reference and never blind-retried;
+- Task Workflow results are strictly validated before projection; malformed or contradictory native evidence remains `outcome-unknown`, while `nativeProof` exposes only the bounded proof projection;
 - after apply, the Bridge rereads the verified live index;
 - the MCP refreshes its SQLite snapshot;
 - no mutation is available from a stale/headless snapshot.
 
-Durable results are stored in `operon_mutation_journal`. A reservation is committed before the Bridge call. Reusing an idempotency key with the same completed request returns the original `operationId` and result without calling the Bridge again. A restart or timeout that leaves the reservation `in_progress` is treated as an uncertain outcome and blocks blind retry. Reusing a key for a different request is rejected as `CONFLICT`. Revision mismatch returns `conflict` without writing.
+MCP results are stored in `operon_mutation_journal`. A reservation is committed before the Bridge call. Reusing an idempotency key with the same completed request returns the original `operationId` and result without calling the Bridge again. A restart or timeout that leaves the MCP reservation `in_progress` is treated as an uncertain outcome and blocks blind retry. Reusing a key for a different request is rejected as `CONFLICT`. Revision mismatch returns `conflict` without writing.
+
+Bridge 0.8 independently reserves idempotency keys atomically and persists its version-1 journal in local Obsidian plugin data before native dispatch. The journal is bounded to 500 entries and 30 days. A restored `in-progress` entry becomes non-retryable `outcome-unknown` with `recoveryRequired: true`. This supports bounded local replay/restart only; it promises nothing after expiry, eviction, plugin-data reset/loss, failed persistence, or transfer to another vault/device. Failure to persist the reservation prevents native dispatch.
 
 Apply additionally requires `OPERON_MUTATIONS_ENABLED=true` and the Bridge setting **Allow task mutations**. This two-sided opt-in prevents an accidental package upgrade from enabling writes.
 
 ### Write policy
 
 - `MCP_WRITE_MODE=readonly`: dry-run only.
-- `MCP_WRITE_MODE=guarded`: adopt, create, update, transition, relationship replacement, and inline relocation apply are allowed with their normal preconditions.
+- `MCP_WRITE_MODE=guarded`: adopt, create, Daily/Weekly create, periodic scheduling update, transition, relationship replacement, and inline relocation apply are allowed with their normal preconditions.
 - `MCP_WRITE_MODE=full`: conversion and recurrence apply are additionally allowed.
-- `operon_recover_mutation` also requires `MCP_WRITE_MODE=full` because it may complete an uncertain prior write; it only recovers the exact `recoveryRef` plan.
+- `operon_recover_mutation` also requires `MCP_WRITE_MODE=full` because it may complete an uncertain prior write; it requires the exact `recoveryRef` and a nested `recovery` union containing one explicit `kind`: `developer-api`, `adopt`, `periodic-create`, or `periodic-update`.
 
-`OPERON_MUTATION_ALLOWED_PATH_PREFIXES` optionally limits every Operon mutation to a comma-separated set of vault-relative folders. When configured, existing tasks must already live under one of those prefixes, and creation requires an explicit allowed destination: `targetFolder` for legacy file-task creation or `targetPath` for inline tasks. Official Operon 3.2.0 still rejects arbitrary `targetFolder` because its Developer API has no exact folder-only target contract. Scoped conversion apply is allowed in guarded mode only when the current source and explicit destination are both inside the allowlist.
+`OPERON_MUTATION_ALLOWED_PATH_PREFIXES` optionally limits every Operon mutation to a comma-separated set of vault-relative folders. When configured, existing tasks must already live under one of those prefixes, and creation requires an explicit allowed destination: `targetFolder` for legacy file-task creation or `targetPath` for inline tasks. Official Operon 3.2.0 still rejects arbitrary `targetFolder` because its Developer API has no exact folder-only target contract. Scoped conversion apply is allowed in guarded mode only when the current source and explicit destination are both inside the allowlist. Because pending recovery records expose no canonical task route that can be proved against this policy, a non-empty path allowlist disables both `operon_list_pending_recoveries` and recovery apply; both fail closed before inventory disclosure or native dispatch.
 
 Conversion remains classified as destructive because file-to-inline moves the source file to trash and inline-to-file replaces the source line with a durable link.
 
 ### Tool-specific rules
 
-`operon_adopt_task` is a registered compatibility tool, not an official Operon `3.2.0` capability. When a compatible legacy engine advertises adoption, it upgrades one existing plain Markdown or Obsidian Tasks checkbox in place. The target file, one-based line, and exact source line must still match; otherwise the operation returns `conflict` without writing. Official Operon `3.2.0` returns a structured unavailable result and the MCP does not simulate adoption with a Markdown edit.
+`operon_adopt_task` uses the official additive task-workflow API only on a mutation-admitted build and after the exact `tasks.adopt.preview` and `tasks.adopt.apply` grants. For the 3.5 acceptance campaign, that build is the synthetic local identity `3.5.240438`; stock `3.5.2` remains read-only. The tool upgrades one exact checkbox through Operon's opaque sealed plan. The target file, one-based line, and exact source line must match; otherwise the operation returns `conflict` without writing. A compatible legacy engine may still advertise its bounded adoption contract, but a missing official grant returns a structured unavailable result and the MCP never simulates adoption with a Markdown edit.
 
 `operon_create_task` creates inline or file tasks through Operon's creator services. On official Operon 3.2.0, typed fields, tags, stable `statusId`, relationships, exact inline `targetPath`, and configured/default file templates are supported. Unmanaged YAML properties and arbitrary `targetFolder` placement are legacy-only; the official Developer API path rejects them instead of using a fallback.
+
+`operon_create_periodic_task` creates exactly one inline task in Operon's configured Daily or Weekly Note after the exact periodic preview/apply grants. Operon owns date routing, templates, container identity and receipts; the MCP cannot supply an arbitrary target path or parent. `priorityId` postflight is verified against the stable projected priority. If apply may have succeeded but no unique created identity can be proven, the result remains `outcome-unknown`; the MCP never retries the ambiguous creation. `operon_update_periodic_scheduling` sets or clears the scheduled date of one exact task. Operon decides whether the task is retained, detached or realigned, and never moves the source Markdown as a side effect of that route.
+
+Managed fields preserve their official shape. `taskType` and `taskImage` are scalar strings. `taskGallery` is a lossless ordered string array and delimiter-based strings are rejected. The derived `__taskDataType` field is read-only and cannot enter create or update input.
 
 `operon_update_task` accepts exactly one group per call: description, managed fields/tags, or one unmanaged file property. Status transitions use the dedicated tool. Unmanaged file properties are supported only by the legacy Public API path; official Operon 3.2.0 rejects them explicitly.
 
@@ -140,7 +149,7 @@ Conversion remains classified as destructive because file-to-inline moves the so
 
 `operon_relocate_task` moves an inline task to an explicit Markdown `targetPath` through Operon while preserving `operonId`. Official Operon 3.2.0 resolves a live blank destination line through `context.build`; it never guesses a line or writes the file directly. Source and target are verified after the index settles.
 
-`operon_list_pending_recoveries` lists durable official recovery references without applying anything. `operon_recover_mutation` invokes the official same-plan recovery, requires both opt-ins plus full MCP write mode, and preserves the original `planDigest`/`recoveryRef` evidence.
+`operon_list_pending_recoveries` lists durable official recovery references without applying anything, but only while the path allowlist is empty. `operon_recover_mutation` is always same-plan recovery. Its public input is `{ idempotencyKey, recoveryRef, recovery }`, where `recovery` is `{ kind: "developer-api" }` or `{ kind: "adopt" | "periodic-create" | "periodic-update", planDigest?: sha256 }`. The Developer API branch accepts no `planDigest`. Only the three Task Workflow branches accept the optional digest to bind recovery to the sealed receipt/replay. Without that digest, the Bridge can prove the Task Workflow binding only from the matching `pendingRecoveries` entry; otherwise recovery fails closed before dispatch. Top-level `kind`/`planDigest` is an internal candidate/legacy migration shape, not the public tool contract. Any non-empty path allowlist also blocks listing and apply because no canonical recovery route can be proved inside it. The tool requires both opt-ins plus full MCP write mode and preserves the original `planDigest`/`recoveryRef` evidence when present.
 
 ## Verified pilot behavior
 
@@ -172,11 +181,26 @@ reports uncertainty or unavailability without retrying or falling back.
 
 ## Deliberately unavailable or excluded capabilities
 
-Deletion, reminders, pinned state, timer control/session, adoption, and
+Deletion, reminders, pinned state, timer control/session, and
 saved-filter management remain outside the official agent mutation surface.
-Saved-filter **execution** is available on Operon `3.2.0` when the exact ID and
+Saved-filter **execution** is available on Operon `3.5.2` when the exact ID and
 grant are present; catalog discovery and filter creation/editing are not.
-Adoption remains unavailable on the official Developer API. Delete remains an
+Adoption is available on the current 3.5 acceptance path only for the mutation-admitted `3.5.240438` build after its exact additive grants; stock `3.5.2` remains read-only. Delete remains an
 operator CLI action. A future `operon_trash_task` may be considered only with
 guaranteed restoration under the same `operonId`, reconciled relations, durable
 journal evidence, and an explicit human confirmation; it is not implemented.
+
+## 3.1 candidate admission
+
+Optimike MCP `3.1.0`, Bridge `0.8.0`, Operon `3.5.2` and Operon CLI `1.2.0`
+form the current candidate set. Contract negotiation and deterministic tests
+admit it as `compatible-provisional`. A patched candidate passed the exact live
+Obsidian Desktop canary on 2026-08-24; certification still requires the fixes
+from upstream PRs `#182`, `#183` and `#184` to ship and the stock artifact to
+pass the same gate. This provisional label is intentional and does not weaken
+any capability, grant, write-mode or recovery gate.
+
+Bridge `0.8.0` admits stock `3.5.2` reads after contract negotiation but masks
+all mutation capabilities. The local Pilot 2 build uses the explicit synthetic
+manifest version `3.5.240438`; it is the only 3.5 acceptance artifact admitted
+for mutation and is not an upstream release identifier.

--- a/docs/operon-rest-contract.md
+++ b/docs/operon-rest-contract.md
@@ -110,6 +110,13 @@ For official Operon, the Bridge sends the exact preview plan to `apply`; it neve
 
 Bridge 0.8 persists its version-1 journal in local Obsidian plugin data before dispatch. It retains at most 500 entries and only entries updated during the last 30 days. On restart, a persisted `in-progress` reservation is projected to non-retryable `outcome-unknown` with `recoveryRequired: true`; callers must inspect pending recoveries and recover the same native plan. This is a bounded local replay/restart guarantee, not permanent storage: there is no promise after expiry, eviction, plugin-data loss/reset, failed persistence, or movement to another vault/device. If the reservation cannot be persisted before dispatch, no native mutation is sent.
 
+For adopted and periodic-created tasks, the Bridge also persists a bounded
+`workflow kind + planDigest -> operonId` receipt beside that journal. It uses
+the same 500-entry and 30-day boundary. A native `already-applied` replay must
+reload that exact identity and revalidate it against the live locator and
+requested stable fields; a missing, stale or mismatching identity fails closed
+instead of guessing among similar tasks.
+
 ### `GET /mutations/pending-recoveries`
 
 Returns the durable recovery references currently owned by this Bridge consumer. It is read-only and requires the official Developer API recovery surface.

--- a/docs/operon-rest-contract.md
+++ b/docs/operon-rest-contract.md
@@ -123,36 +123,35 @@ against the path allowlist, so it must not return an unscoped inventory.
 ```json
 {
   "idempotencyKey": "recovery-001",
-  "recoveryRef": "dvr1_...",
-  "recovery": {
-    "kind": "developer-api"
-  }
+  "recoveryRef": "dvr1_..."
 }
 ```
 
-For a Task Workflow recovery, the public request instead uses the nested union:
+This route accepts Developer API V1 recovery references only.
+
+### `POST /task-workflows/recover`
+
+Task Workflow recovery uses its dedicated Bridge route and flat wire shape:
 
 ```json
 {
   "idempotencyKey": "recovery-002",
   "recoveryRef": "twr1_...",
-  "recovery": {
-    "kind": "adopt",
-    "planDigest": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
-  }
+  "kind": "adopt",
+  "planDigest": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 }
 ```
 
-`recovery.kind` is mandatory and prevents the Bridge from guessing which native
-recovery surface owns the reference. `developer-api` uses Developer API V1
-recovery and its object must contain only `kind`. The three Task Workflow kinds
+`kind` is mandatory on the Task Workflow route and prevents the Bridge from
+guessing which workflow owns the reference. The three Task Workflow kinds
 (`adopt`, `periodic-create`, and `periodic-update`) accept optional `planDigest`.
 It must be an exact lowercase SHA-256 digest and binds the request to the sealed
 receipt/replay. Without it, the Bridge dispatches only if
 the same digest can be proven from `pendingRecoveries`; it does not guess or
-derive a digest from `recoveryRef`. Top-level `kind` and `planDigest` fields are
-not part of the public wire contract; that flat representation exists only as
-an internal candidate/legacy migration shape. When
+derive a digest from `recoveryRef`. The MCP tool exposes a nested `recovery`
+union, validates it, then routes `developer-api` to `/mutations/recover` and the
+three workflow kinds to `/task-workflows/recover`; direct Bridge clients must use
+the REST shapes above. When
 `OPERON_MUTATION_ALLOWED_PATH_PREFIXES` is non-empty, apply also fails closed
 before native dispatch because the recovery reference has no canonical route
 that can be proved inside the allowlist. Recovery never accepts a new mutation

--- a/docs/operon-rest-contract.md
+++ b/docs/operon-rest-contract.md
@@ -136,14 +136,16 @@ Task Workflow recovery uses its dedicated Bridge route and flat wire shape:
 ```json
 {
   "idempotencyKey": "recovery-002",
-  "recoveryRef": "twr1_...",
+  "recoveryRef": "dvr1_...",
   "kind": "adopt",
   "planDigest": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 }
 ```
 
-`kind` is mandatory on the Task Workflow route and prevents the Bridge from
-guessing which workflow owns the reference. The three Task Workflow kinds
+Task Workflow V1 uses Operon's host-owned `dvr1_` recovery-reference family,
+the same opaque family as core Developer API mutations. The dedicated route
+and mandatory `kind` prevent the Bridge from guessing which workflow owns the
+reference. The three Task Workflow kinds
 (`adopt`, `periodic-create`, and `periodic-update`) accept optional `planDigest`.
 It must be an exact lowercase SHA-256 digest and binds the request to the sealed
 receipt/replay. Without it, the Bridge dispatches only if

--- a/docs/operon-rest-contract.md
+++ b/docs/operon-rest-contract.md
@@ -2,7 +2,7 @@
 
 ## Scope
 
-The Bridge projects the active Operon-compatible engine's live index through Obsidian Local REST API. Reads work with official Operon `2.4.0` and `2.5.0`, with certified official Operon `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, and `3.2.1`, and provisionally with non-denied `3.3.2` when its Developer API V1 accessor is present. Kairélys legacy support remains bounded to the documented allowlist. Developer API mutations use the official preview/apply/recovery surface; legacy Kairélys mutations use Public API v1. There is no raw Markdown or private-reflection fallback.
+The Bridge projects the active Operon-compatible engine's live index through Obsidian Local REST API. Reads work with official Operon `2.4.0` and `2.5.0`, with certified official Operon `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, and `3.2.1`, and provisionally with non-denied `3.3.2` and `3.5.2` when the Developer API V1 accessor is present. Kairélys legacy support remains bounded to the documented allowlist. Developer API mutations use official opaque preview/apply/recovery plans; legacy Kairélys mutations use Public API v1. There is no raw Markdown or private-reflection fallback.
 
 Prefix:
 
@@ -15,24 +15,29 @@ All routes inherit Local REST API authentication and TLS behavior.
 ## Compatibility and capabilities
 
 - Bridge contract: `1`
-- Certified compatibility through official Operon `3.2.1`; provisional contract admission and complete live read/write pilot: `3.3.2` with Operon CLI `1.1.2`
+- Certified compatibility through official Operon `3.2.1`; completed provisional live pilot: `3.3.2` with CLI `1.1.2`; current provisional candidate: `3.5.2` with CLI `1.2.0` and Bridge `0.8.0`. Its patched acceptance build passed the exact live canary on 2026-08-24; stock admission still awaits the upstream fixes and a stock rerun
 - Official Operon legacy read allowlist: `2.4.0`, `2.5.0`
 - Official Operon Developer API V1 allowlist: `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, `3.2.1`
 - Kairélys read allowlist: `2.5.1`, `2.5.2`, `2.5.3`, `2.6.1`, `2.6.2`, `2.6.3`
 - Legacy mutation contract: Operon Public API `1`
 - Official Operon `2.5.0`: read-only
-- Official Operon `3.x` with the negotiated V1 boundary: typed create/update/transition/relationship/recurrence/convert/relocate through Developer API V1, plus saved-filter execution through the additive task-workflow API, when the exact grants are active. The grant state and capability advertisement are both reported in `/status`; an uncertain apply is returned as such and is never retried blindly.
+- Official Operon `3.x` with the negotiated V1 boundary: typed create/update/transition/relationship/recurrence/convert/relocate through Developer API V1, plus saved-filter execution, adoption and Daily/Weekly workflows through the additive task-workflow API when their exact grants are active. The grant state and capability advertisement are both reported in `/status`; an uncertain apply is returned as such and is never retried blindly.
 - Kairélys `2.5.1` through `2.5.3` and `2.6.1` through `2.6.3` with Public API v1: read-write
 
 `GET /status` reports `bridge.mode` as `read-only` or `read-write` and exposes each capability independently. A future non-denied Operon version is admitted provisionally when its Developer API V1 accessor is present; Markdown similarity is irrelevant. Live use remains independently gated by successful negotiation, `developerApi`, top-level `ok`, `index.ready`, and the exact advertised capability.
 
-The adapter certifies official `3.2.1` and provisionally admits `3.3.2`; the complete `3.3.2` live acceptance run is green with Bridge `0.7.0` and CLI `1.1.2`. The release restores the Settings grant controls, rejects implicit File Task renames, and fixes transition settlement without Project Serial scopes. The live acceptance applied and restored a non-terminal transition, returned to 30 tasks, left no pending recovery, and validated `P0/P1/P2 = 0/0/0`. Adoption remains unavailable through the official Developer API and is tracked in [#140](https://github.com/hasanyilmaz/operon/issues/140). No Markdown or private-API fallback is introduced.
+The adapter certifies official `3.2.1` and provisionally admits later non-denied V1 releases. The complete `3.3.2` live acceptance remains historical green evidence with Bridge `0.7.0` and CLI `1.1.2`. The `3.5.2` / CLI `1.2.0` / Bridge `0.8.0` candidate adds official adoption, periodic-note routing and typed task media fields. Its patched acceptance build passed the live canary, but the stock release remains `compatible-provisional` until upstream fixes `#182`, `#183` and `#184` ship and the released artifact passes the same gate. Task Type and Task Image are scalar, Task Gallery is an ordered array and `__taskDataType` is read-only. No Markdown or private-API fallback is introduced.
+
+Stock `3.5.2` remains readable after successful negotiation but reports no
+mutation capabilities. The disposable Pilot 2 acceptance artifact is
+distinguished by the synthetic manifest version `3.5.240438`; that exact local
+identity alone is admitted for 3.5 mutations and is never an upstream release.
 
 Readiness requires a compatible plugin, positive generation, healthy idle V8 index, zero dirty sources, and a task count matching diagnostics. A duplicate-ID conflict is reported separately and causes MCP snapshot refresh refusal.
 
 ## Stable task projection
 
-Each task includes durable `operonId`, inline/file source, path and one-based line, description, checkbox, workflow, priority, tags, parent, dependency edges, normalized dates, managed fields, source mtime, and deterministic `revision`. Workflow projection includes both visible values (`pipeline`, `status`, `statusLabel`) and language-stable `pipelineId` / `statusId` values resolved from the live Operon settings.
+Each task includes durable `operonId`, inline/file source, path and one-based line, description, checkbox, workflow, priority, tags, parent, dependency edges, normalized dates, managed fields, source mtime, and deterministic `revision`. Managed values preserve arrays: `taskGallery` remains ordered rather than being delimiter-encoded. Workflow projection includes both visible values (`pipeline`, `status`, `statusLabel`) and language-stable `pipelineId` / `statusId` values resolved from the live Operon settings.
 
 For file tasks, `includeProperties=true` also returns unmanaged YAML properties such as `north_star` and `rang`. Raw note bodies and raw task lines are never exposed.
 
@@ -71,7 +76,7 @@ Live validation reports duplicate IDs, missing sources, unknown workflow statuse
 
 ## Mutation controls
 
-All mutation routes require `idempotencyKey`. The key is bound to the canonical request: an identical replay returns the cached result, while reuse for different input returns HTTP 409 with `idempotency_key_reused` before later payload validation. Existing-task routes also require `expectedRevision`. `dryRun` defaults to `true`; apply occurs only with `dryRun: false`.
+All mutation routes require `idempotencyKey`. The Bridge reserves the key atomically before native dispatch and binds it to the canonical request: an identical replay returns the recorded result, while reuse for different input returns HTTP 409 with `idempotency_key_reused` before later payload validation. Concurrent identical callers join the same in-flight result instead of dispatching twice. Existing-task routes also require `expectedRevision`. `dryRun` defaults to `true`; apply occurs only with `dryRun: false`.
 
 Every mutation destination is validated without normalization at both the MCP and Bridge boundaries. `targetPath` must be an exact vault-relative Markdown path; `targetFolder` must be an exact vault-relative folder path. Leading or trailing whitespace, backslashes, absolute paths, empty segments, trailing separators, `.` and `..` are rejected before any call to the task engine.
 
@@ -90,27 +95,69 @@ Responses use:
   "requested": {},
   "after": {},
   "retryable": false,
+  "recoveryRequired": false,
+  "planDigest": "optional sealed-plan digest",
+  "recoveryRef": "optional same-plan recovery reference",
+  "nativeProof": {},
   "source": "operon-live",
   "stale": false
 }
 ```
 
-For Operon 3.2.0, the Bridge sends the exact preview plan to `apply`; it never reconstructs or retries a plan after the host reports `outcome-unknown`. The response carries `recoveryRef`, `planDigest`, and `mutationMayHaveApplied` when recovery is required. The Bridge waits for Operon's index to return to a verified idle state before proving `after`. If the final state cannot be proven, it records `failed/outcome_unverified` and does not invite a blind retry. A Bridge apply is bounded at 120 seconds; a timeout is uncertain, not a permission to retry.
+For official Operon, the Bridge sends the exact preview plan to `apply`; it never reconstructs or retries a plan after the host reports `outcome-unknown`. Task Workflow results are validated as a strict V1 discriminated result: terminal status, side-effect flags, group results, sealed receipt digest and postflight status must agree. Any malformed or contradictory result becomes non-retryable `outcome-unknown`. `nativeProof` is a bounded proof projection of the validated native result, not the unrestricted Operon payload. The response carries `recoveryRef`, `planDigest`, `recoveryRequired` and `mutationMayHaveApplied` when recovery is required. The Bridge waits for Operon's index to return to a verified idle state before proving `after`. If the final state cannot be proven, it records `failed/outcome_unverified` and does not invite a blind retry. A Bridge apply is bounded at 120 seconds; a timeout is uncertain, not a permission to retry.
+
+### Local Bridge idempotency journal
+
+Bridge 0.8 persists its version-1 journal in local Obsidian plugin data before dispatch. It retains at most 500 entries and only entries updated during the last 30 days. On restart, a persisted `in-progress` reservation is projected to non-retryable `outcome-unknown` with `recoveryRequired: true`; callers must inspect pending recoveries and recover the same native plan. This is a bounded local replay/restart guarantee, not permanent storage: there is no promise after expiry, eviction, plugin-data loss/reset, failed persistence, or movement to another vault/device. If the reservation cannot be persisted before dispatch, no native mutation is sent.
 
 ### `GET /mutations/pending-recoveries`
 
 Returns the durable recovery references currently owned by this Bridge consumer. It is read-only and requires the official Developer API recovery surface.
+
+When `OPERON_MUTATION_ALLOWED_PATH_PREFIXES` is non-empty, this listing fails
+closed. Recovery records do not expose a canonical route that the MCP can prove
+against the path allowlist, so it must not return an unscoped inventory.
 
 ### `POST /mutations/recover`
 
 ```json
 {
   "idempotencyKey": "recovery-001",
-  "recoveryRef": "dvr1_..."
+  "recoveryRef": "dvr1_...",
+  "recovery": {
+    "kind": "developer-api"
+  }
 }
 ```
 
-This calls Operon's official `mutations.recover({ recoveryRef })` for the same plan. It never accepts a new mutation spec and never uses Markdown or private APIs. Recovery keeps the same two opt-ins and is restricted to the full MCP write mode.
+For a Task Workflow recovery, the public request instead uses the nested union:
+
+```json
+{
+  "idempotencyKey": "recovery-002",
+  "recoveryRef": "twr1_...",
+  "recovery": {
+    "kind": "adopt",
+    "planDigest": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+  }
+}
+```
+
+`recovery.kind` is mandatory and prevents the Bridge from guessing which native
+recovery surface owns the reference. `developer-api` uses Developer API V1
+recovery and its object must contain only `kind`. The three Task Workflow kinds
+(`adopt`, `periodic-create`, and `periodic-update`) accept optional `planDigest`.
+It must be an exact lowercase SHA-256 digest and binds the request to the sealed
+receipt/replay. Without it, the Bridge dispatches only if
+the same digest can be proven from `pendingRecoveries`; it does not guess or
+derive a digest from `recoveryRef`. Top-level `kind` and `planDigest` fields are
+not part of the public wire contract; that flat representation exists only as
+an internal candidate/legacy migration shape. When
+`OPERON_MUTATION_ALLOWED_PATH_PREFIXES` is non-empty, apply also fails closed
+before native dispatch because the recovery reference has no canonical route
+that can be proved inside the allowlist. Recovery never accepts a new mutation
+spec, never uses Markdown or private APIs, keeps the same two opt-ins, and is
+restricted to the full MCP write mode.
 
 ### `POST /tasks/adopt`
 
@@ -149,6 +196,14 @@ Adoption upgrades one existing checkbox in place through Operon. `line` is one-b
 Creation uses Operon's Task Creator paths, template resolution, identity generation, indexing, dependency reconciliation, aggregates, and workflow transition logic. Official Operon 3.2.0 maps the MCP payload to its typed create plan; unmanaged properties and arbitrary `targetFolder` placement are rejected because they are not part of the official Developer API contract.
 
 `statusId` is preferred over `fields.status`: it remains stable when a vault translates the displayed pipeline and status labels. Supplying both is rejected. `targetDateKey` is projected to the official `dateDue` field; destination selection remains governed by the configured Operon target policy. An explicit inline `targetPath` remains available for vault-specific layouts.
+
+### `POST /tasks/periodic`
+
+Creates exactly one task through Operon's Daily/Weekly Note workflow. `priorityId` is checked against the stable priority projected by the postflight task, not only the display label. If native apply succeeds but periodic creation cannot identify one unique created task, the Bridge preserves `outcome-unknown`; it does not turn an ambiguous creation into success or retry it.
+
+### `POST /tasks/:operonId/periodic-update`
+
+Sets or clears the exact task's scheduled date through Operon's periodic-update workflow. Operon owns retain/detach/realign semantics. The Bridge verifies the final scheduling projection and never treats the route as an implicit Markdown move.
 
 ### `POST /tasks/:operonId/update`
 

--- a/docs/runtime-capability-matrix.fr.md
+++ b/docs/runtime-capability-matrix.fr.md
@@ -8,6 +8,13 @@ Docs liées : [README](../README.fr.md), [Guide d’exploitation](../OPERATIONS.
 
 Optimike Obsidian MCP possède cinq contrats runtime. Les modes headless tournent au-dessus d’un vault Markdown synchronisé. Ils ne lancent pas Obsidian Desktop, ne chargent pas les plugins communautaires, n’exposent pas la palette de commandes et ne donnent pas l’état live de l’interface.
 
+En 3.1, `OBSIDIAN_STARTUP_BLOCKING` vaut `false` par défaut. Un processus MCP
+live ou hybrid reste donc actif lorsque Codex démarre avant Obsidian Desktop ;
+les outils live restent temporairement indisponibles et échouent fermés jusqu’à
+ce que Local REST réponde. Régler la variable à `true` uniquement si un
+déploiement live doit faire échouer son propre démarrage après les tentatives
+bornées du contrôle initial.
+
 ## Usage recommandé
 
 | Mode runtime                 | Idéal pour                                             | Obsidian Desktop                       | Local REST API                                                | Écritures                                                                                                | Bases                                        | Posture par défaut        |
@@ -21,33 +28,33 @@ Optimike Obsidian MCP possède cinq contrats runtime. Les modes headless tournen
 
 ## Tableau des capacités
 
-| Capacité                               | `live`                    | `hybrid` API disponible                    | `hybrid` API indisponible | `headless-readonly`             | `headless-guarded`                  | `headless-filesystem`                                                      |
-| -------------------------------------- | ------------------------- | ------------------------------------------ | ------------------------- | ------------------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
-| Démarrer sans `OBSIDIAN_API_KEY`       | Non                       | Oui                                        | Oui                       | Oui                             | Oui                                 | Oui                                                                        |
-| Démarrer sans Obsidian Desktop         | Non                       | Oui                                        | Oui                       | Oui                             | Oui                                 | Oui                                                                        |
-| Cache filesystem                       | Optionnel                 | Oui                                        | Oui                       | Requis                          | Requis                              | Requis                                                                     |
-| Politique d’exclusion du vault         | Oui pour les scans cache  | Oui pour les scans cache                   | Oui                       | Oui                             | Oui                                 | Oui                                                                        |
-| Lire/lister/rechercher                 | REST/cache                | REST/cache                                 | Cache/filesystem          | Cache/filesystem                | Cache/filesystem                    | Cache/filesystem                                                           |
-| Tasks list/query                       | Cache/filesystem          | Cache/filesystem                           | Cache/filesystem          | Cache/filesystem                | Cache/filesystem                    | Cache/filesystem                                                           |
-| Recherche sémantique Smart Connections | `.smart-env` + embedder   | `.smart-env` + embedder compatible         | `.smart-env` + embedder   | `.smart-env` + embedder         | `.smart-env` + embedder             | `.smart-env` + embedder                                                    |
-| Status/maintenance runtime             | Oui                       | Oui                                        | Oui                       | Oui                             | Oui                                 | Oui                                                                        |
-| Racines documentaires externes         | Config locale optionnelle | Config locale optionnelle                  | Config locale optionnelle | Config locale optionnelle       | Config locale optionnelle           | Config locale optionnelle                                                  |
-| Scan/plan des références externes      | Stdio local               | Stdio local                                | Stdio local               | Stdio local                     | Stdio local                         | Stdio local                                                                |
-| Apply/rollback de move externe         | Non                       | Non                                        | Non                       | Non                             | Non                                 | Stdio local + `full` + opt-ins move/racine                                 |
-| Validation de format                   | Markdown/Base/Canvas      | Markdown/Base/Canvas                       | Markdown/Base/Canvas      | Markdown/Base/Canvas            | Markdown/Base/Canvas                | Markdown/Base/Canvas                                                       |
-| Update note                            | Outil REST complet        | Outil REST complet                         | Non                       | Non                             | Append/prepend seulement            | Append/prepend seulement                                                   |
-| Remplacement atomique gouverné         | CAS Atomic Write Bridge   | Idem tant que l’API et le Bridge répondent | Non                       | Non                             | Non                                 | Non                                                                        |
-| Search/replace                         | Outil REST complet        | Outil REST complet                         | Non                       | Non                             | Remplacements exacts par `filePath` | Remplacements exacts par `filePath`                                        |
-| Frontmatter                            | Outil REST complet        | Outil REST complet                         | Non                       | Non                             | `set` d’une clé unique              | `set`, batch frontmatter dry-run/apply, et rows Bases                      |
-| Tags                                   | Outil REST complet        | Outil REST complet                         | Non                       | Non                             | Non                                 | Tags frontmatter, tags inline, index/audit local, rename avec dry-run      |
-| Admin filesystem                       | Non                       | Non                                        | Non                       | Non                             | Non                                 | Archive, batch move, batch delete en dry-run par défaut                    |
-| Suppression de note                    | Suppression REST          | Suppression REST                           | Non                       | Non                             | Non                                 | Suppression filesystem avec `expectedHash` ou `expectedMtime`              |
-| Déplacement/renommage                  | Non                       | Non                                        | Non                       | Non                             | Non                                 | Déplacement filesystem avec `expectedHash` ou `expectedMtime`              |
-| Active file / UI / commandes           | Via Desktop/plugin        | Via Desktop/plugin tant que l’API répond   | Non                       | Non                             | Non                                 | Non                                                                        |
-| Bases list/schema/query                | Bases Bridge REST         | Bases Bridge REST                          | Non                       | Fallback local en lecture seule | Fallback local en lecture seule     | Fallback local avec filtres simples (`eq`, `contains`, `in`, comparaisons) |
-| Bases create/upsert                    | Bases Bridge REST         | Bases Bridge REST                          | Non                       | Non                             | Non                                 | `.base` YAML create/config + rows -> frontmatter `set`                     |
-| JSON Canvas create/edit                | CAS graphe gouverné       | Idem tant que l’API/Bridge répondent       | Non                       | Non                             | Non                                 | `.canvas` direct minimal : create, text node, edge, validate               |
-| Parité plugins Obsidian                | Plugins Desktop           | Plugins Desktop tant que l’API répond      | Non                       | Non                             | Non                                 | Non                                                                        |
+| Capacité                               | `live`                       | `hybrid` API disponible                    | `hybrid` API indisponible | `headless-readonly`             | `headless-guarded`                  | `headless-filesystem`                                                      |
+| -------------------------------------- | ---------------------------- | ------------------------------------------ | ------------------------- | ------------------------------- | ----------------------------------- | -------------------------------------------------------------------------- |
+| Démarrer sans `OBSIDIAN_API_KEY`       | Non                          | Oui                                        | Oui                       | Oui                             | Oui                                 | Oui                                                                        |
+| Démarrer sans Obsidian Desktop         | Oui ; outils live en attente | Oui                                        | Oui                       | Oui                             | Oui                                 | Oui                                                                        |
+| Cache filesystem                       | Optionnel                    | Oui                                        | Oui                       | Requis                          | Requis                              | Requis                                                                     |
+| Politique d’exclusion du vault         | Oui pour les scans cache     | Oui pour les scans cache                   | Oui                       | Oui                             | Oui                                 | Oui                                                                        |
+| Lire/lister/rechercher                 | REST/cache                   | REST/cache                                 | Cache/filesystem          | Cache/filesystem                | Cache/filesystem                    | Cache/filesystem                                                           |
+| Tasks list/query                       | Cache/filesystem             | Cache/filesystem                           | Cache/filesystem          | Cache/filesystem                | Cache/filesystem                    | Cache/filesystem                                                           |
+| Recherche sémantique Smart Connections | `.smart-env` + embedder      | `.smart-env` + embedder compatible         | `.smart-env` + embedder   | `.smart-env` + embedder         | `.smart-env` + embedder             | `.smart-env` + embedder                                                    |
+| Status/maintenance runtime             | Oui                          | Oui                                        | Oui                       | Oui                             | Oui                                 | Oui                                                                        |
+| Racines documentaires externes         | Config locale optionnelle    | Config locale optionnelle                  | Config locale optionnelle | Config locale optionnelle       | Config locale optionnelle           | Config locale optionnelle                                                  |
+| Scan/plan des références externes      | Stdio local                  | Stdio local                                | Stdio local               | Stdio local                     | Stdio local                         | Stdio local                                                                |
+| Apply/rollback de move externe         | Non                          | Non                                        | Non                       | Non                             | Non                                 | Stdio local + `full` + opt-ins move/racine                                 |
+| Validation de format                   | Markdown/Base/Canvas         | Markdown/Base/Canvas                       | Markdown/Base/Canvas      | Markdown/Base/Canvas            | Markdown/Base/Canvas                | Markdown/Base/Canvas                                                       |
+| Update note                            | Outil REST complet           | Outil REST complet                         | Non                       | Non                             | Append/prepend seulement            | Append/prepend seulement                                                   |
+| Remplacement atomique gouverné         | CAS Atomic Write Bridge      | Idem tant que l’API et le Bridge répondent | Non                       | Non                             | Non                                 | Non                                                                        |
+| Search/replace                         | Outil REST complet           | Outil REST complet                         | Non                       | Non                             | Remplacements exacts par `filePath` | Remplacements exacts par `filePath`                                        |
+| Frontmatter                            | Outil REST complet           | Outil REST complet                         | Non                       | Non                             | `set` d’une clé unique              | `set`, batch frontmatter dry-run/apply, et rows Bases                      |
+| Tags                                   | Outil REST complet           | Outil REST complet                         | Non                       | Non                             | Non                                 | Tags frontmatter, tags inline, index/audit local, rename avec dry-run      |
+| Admin filesystem                       | Non                          | Non                                        | Non                       | Non                             | Non                                 | Archive, batch move, batch delete en dry-run par défaut                    |
+| Suppression de note                    | Suppression REST             | Suppression REST                           | Non                       | Non                             | Non                                 | Suppression filesystem avec `expectedHash` ou `expectedMtime`              |
+| Déplacement/renommage                  | Non                          | Non                                        | Non                       | Non                             | Non                                 | Déplacement filesystem avec `expectedHash` ou `expectedMtime`              |
+| Active file / UI / commandes           | Via Desktop/plugin           | Via Desktop/plugin tant que l’API répond   | Non                       | Non                             | Non                                 | Non                                                                        |
+| Bases list/schema/query                | Bases Bridge REST            | Bases Bridge REST                          | Non                       | Fallback local en lecture seule | Fallback local en lecture seule     | Fallback local avec filtres simples (`eq`, `contains`, `in`, comparaisons) |
+| Bases create/upsert                    | Bases Bridge REST            | Bases Bridge REST                          | Non                       | Non                             | Non                                 | `.base` YAML create/config + rows -> frontmatter `set`                     |
+| JSON Canvas create/edit                | CAS graphe gouverné          | Idem tant que l’API/Bridge répondent       | Non                       | Non                             | Non                                 | `.canvas` direct minimal : create, text node, edge, validate               |
+| Parité plugins Obsidian                | Plugins Desktop              | Plugins Desktop tant que l’API répond      | Non                       | Non                             | Non                                 | Non                                                                        |
 
 ## Registre des tools par mode
 
@@ -64,18 +71,27 @@ Scan, plan et status sont read-only. Apply et rollback exigent en plus
 `MCP_WRITE_MODE=full`, `MCP_EXTERNAL_MOVE_ENABLED=true`, la capacité `move` de
 la racine et un backend qui expose `obsidian_search_replace` conditionnel.
 
-Tous les modes enregistrent aussi les 23 outils du contrat Operon :
+Tous les modes enregistrent aussi les 25 outils du contrat Operon :
 `operon_status`, `operon_get_configuration`, `operon_list_tasks`,
 `operon_get_task`, `operon_query_tasks`, `operon_query_saved_filter`,
 `operon_validate`, `operon_get_diagnostics`, `operon_find_tasks`,
 `operon_resolve_task`, `operon_get_relationships`, `operon_build_context`,
 `operon_get_timer_state`, `operon_adopt_task`, `operon_create_task`,
+`operon_create_periodic_task`, `operon_update_periodic_scheduling`,
 `operon_update_task`, `operon_transition_task`, `operon_set_relationships`,
 `operon_update_recurrence`, `operon_convert_task`,
 `operon_relocate_task`, `operon_list_pending_recoveries` et
 `operon_recover_mutation`. Hors mode live, ils restent limités aux snapshots
 validés en lecture seule ; toute mutation échoue fermée. L’enregistrement ne
-garantit pas la disponibilité runtime : Operon officiel `3.2.x` exécute les
+garantit pas la disponibilité runtime : Operon officiel `3.5.2` expose
+l’exécution des filtres après son grant de lecture exact, mais le Bridge masque
+les mutations même si les grants adoption ou Daily/Weekly existent. Seul le
+build local attesté `3.5.240438` peut exercer ces workflows de mutation. Cette candidate patchée a passé le canary live 3.1
+le 2026-08-24 ; la release stock reste `compatible-provisional` jusqu’à la
+publication de ses correctifs upstream requis et au passage du même gate par
+l’artefact officiel. Un grant optionnel absent désactive uniquement sa
+route, sans fallback Markdown. Operon reste propriétaire du plan opaque scellé
+et de sa récupération same-plan. Operon officiel `3.2.x` exécute les
 filtres sauvegardés après un grant exact `tasks.filter-query`, mais ne publie pas
 leur catalogue ; l’adoption reste indisponible. Les relations et la récurrence
 ont passé le pilote live dédié 3.2.0. Les limites bornées #99/#101 et #139

--- a/docs/runtime-capability-matrix.md
+++ b/docs/runtime-capability-matrix.md
@@ -8,6 +8,12 @@ Related docs: [README](../README.md), [Operations](../OPERATIONS.md), [Governed 
 
 Optimike Obsidian MCP has five runtime contracts. Headless modes run over a synchronized Markdown vault. They do not run Obsidian Desktop, load community plugins, expose the command palette, or provide live UI state.
 
+In 3.1, `OBSIDIAN_STARTUP_BLOCKING` defaults to `false`. A live or hybrid MCP
+process therefore stays up when Codex starts before Obsidian Desktop; live tools
+remain temporarily unavailable and fail closed until Local REST becomes
+reachable. Set the variable to `true` only when a live deployment must fail its
+own startup after the bounded initial health-check retries.
+
 The live REST adapter requires Local REST API 5.0.2 or later within the
 supported 5.x line. Its targeted writes use the native JSON PATCH instruction
 contract. Deprecated 1.x PATCH headers and the removed core `/periodic/...`
@@ -31,7 +37,7 @@ Periodic Notes API extension is outside the core MCP contract.
 | Capability                       | `live`                  | `hybrid` API available                  | `hybrid` API unavailable | `headless-readonly`     | `headless-guarded`               | `headless-filesystem`                                                    |
 | -------------------------------- | ----------------------- | --------------------------------------- | ------------------------ | ----------------------- | -------------------------------- | ------------------------------------------------------------------------ |
 | Start without `OBSIDIAN_API_KEY` | No                      | Yes                                     | Yes                      | Yes                     | Yes                              | Yes                                                                      |
-| Start without Obsidian Desktop   | No                      | Yes                                     | Yes                      | Yes                     | Yes                              | Yes                                                                      |
+| Start without Obsidian Desktop   | Yes; live tools wait    | Yes                                     | Yes                      | Yes                     | Yes                              | Yes                                                                      |
 | Filesystem cache                 | Optional                | Yes                                     | Yes                      | Required                | Required                         | Required                                                                 |
 | Vault exclusion policy           | Yes for cache scans     | Yes                                     | Yes                      | Yes                     | Yes                              | Yes                                                                      |
 | List/read/search                 | REST/cache              | REST/cache                              | Cache/filesystem         | Cache/filesystem        | Cache/filesystem                 | Cache/filesystem                                                         |
@@ -72,18 +78,26 @@ Scan, plan and status are read-only. Apply and rollback additionally require
 capability, and a backend mode that exposes conditional
 `obsidian_search_replace`.
 
-Every mode also registers the 23 Operon contract tools:
+Every mode also registers the 25 Operon contract tools:
 `operon_status`, `operon_get_configuration`, `operon_list_tasks`,
 `operon_get_task`, `operon_query_tasks`, `operon_query_saved_filter`,
 `operon_validate`, `operon_get_diagnostics`, `operon_find_tasks`,
 `operon_resolve_task`, `operon_get_relationships`, `operon_build_context`,
 `operon_get_timer_state`, `operon_adopt_task`, `operon_create_task`,
+`operon_create_periodic_task`, `operon_update_periodic_scheduling`,
 `operon_update_task`, `operon_transition_task`, `operon_set_relationships`,
 `operon_update_recurrence`, `operon_convert_task`,
 `operon_relocate_task`, `operon_list_pending_recoveries`, and
 `operon_recover_mutation`. In non-live modes they remain limited to validated
 read-only snapshots; mutation calls fail closed. Registration does not imply
-runtime availability: official Operon `3.2.x` exposes saved-filter evaluation
+runtime availability: official Operon `3.5.2` exposes saved-filter evaluation
+after its exact read grant, but Bridge mutations stay masked even when adoption
+or Daily/Weekly grants exist. Only the locally attested `3.5.240438` build may
+exercise those mutation workflows. That patched candidate passed the live 3.1 canary on 2026-08-24; the stock
+release remains `compatible-provisional` until its required upstream fixes ship
+and the official artifact passes the same gate. Missing optional grants disable only their dependent routes; they do
+not create a Markdown fallback. Operon owns the opaque sealed plan and same-plan
+recovery. Earlier official Operon `3.2.x` exposes saved-filter evaluation
 after an exact `tasks.filter-query` grant, but not catalog discovery; adoption
 remains unavailable. Relationship and recurrence apply passed the dedicated
 3.2.0 live pilot. The bounded upstream limits in #99/#101 and #139 remain.

--- a/docs/tool-surface-profiles.fr.md
+++ b/docs/tool-surface-profiles.fr.md
@@ -15,10 +15,10 @@ Les profils réduisent le volume des schémas et l’ambiguïté de routage. Ils
 | ----------- | ----------------------------------------------------------------------- | ---------------------------: |
 | `standard`  | Lecture/recherche générale et travail courant gouverné Note/Frontmatter |                    19 outils |
 | `authoring` | `standard` + tags, authoring Bases borné/formules et authoring Canvas   |                    30 outils |
-| `tasks`     | Compatibilité Markdown Tasks + contrat MCP Operon live complet          |                    31 outils |
-| `full`      | Surface complète/admin explicite du runtime actif                       |                    70 outils |
+| `tasks`     | Compatibilité Markdown Tasks + contrat MCP Operon live complet          |                    33 outils |
+| `full`      | Surface complète/admin explicite du runtime actif                       |                    72 outils |
 
-Ces nombres sont des projections du registre actuel et peuvent être plus faibles dans les runtimes restreints. `full` signifie tous les outils structurellement enregistrés par le runtime actif, pas toujours 70 outils. Le registre canonique couvre 74 noms uniques entre tous les runtimes, dont quatre n’existent qu’en `headless-filesystem`.
+Ces nombres sont des projections du registre actuel et peuvent être plus faibles dans les runtimes restreints. `full` signifie tous les outils structurellement enregistrés par le runtime actif, pas toujours 72 outils. Le registre canonique couvre 76 noms uniques entre tous les runtimes, dont quatre n’existent qu’en `headless-filesystem`. Les deux ajouts 3.1 sont les opérations Operon Daily/Weekly bornées par capacité ; leur visibilité ne remplace jamais un grant live.
 
 ## Noms réservés à la compatibilité
 

--- a/docs/tool-surface-profiles.md
+++ b/docs/tool-surface-profiles.md
@@ -15,10 +15,10 @@ Profiles reduce schema volume and routing ambiguity. They are not an authorizati
 | ----------- | --------------------------------------------------------------------------- | -----------------------: |
 | `standard`  | General vault reading/search and common governed note/Frontmatter work      |                 19 tools |
 | `authoring` | `standard` plus tags, bounded Bases authoring/formulas and Canvas authoring |                 30 tools |
-| `tasks`     | Markdown Tasks compatibility plus the complete live Operon MCP contract     |                 31 tools |
-| `full`      | Explicit complete/admin surface for the active runtime                      |                 70 tools |
+| `tasks`     | Markdown Tasks compatibility plus the complete live Operon MCP contract     |                 33 tools |
+| `full`      | Explicit complete/admin surface for the active runtime                      |                 72 tools |
 
-Counts are projections of the current registry and may be lower in restricted runtimes. `full` means all tools structurally registered by the active runtime, not always 70 tools. The canonical registry covers 74 unique names across all runtimes because four names exist only in `headless-filesystem`.
+Counts are projections of the current registry and may be lower in restricted runtimes. `full` means all tools structurally registered by the active runtime, not always 72 tools. The canonical registry covers 76 unique names across all runtimes because four names exist only in `headless-filesystem`. The two 3.1 additions are capability-gated Operon Daily/Weekly operations; visibility never substitutes for a live grant.
 
 ## Compatibility-only names
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optimike-obsidian-mcp",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optimike-obsidian-mcp",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@hono/node-server": "^2.0.12",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optimike-obsidian-mcp",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "Unified Obsidian MCP server with shared local cache, Operon and Tasks tools, Bases support, semantic search, runtime observability, and degraded read mode for durable agent workflows.",
   "main": "dist/index.js",
   "files": [
@@ -112,7 +112,7 @@
     "test:headless-long-run": "node scripts/long-run-headless-server.mjs",
     "snapshot:vault": "node scripts/snapshot-vault.mjs",
     "check:vault-exclusions": "node scripts/check-vault-exclusion-policy.mjs",
-    "test:runtime": "npm run build && npm run smoke:headless-readonly && npm run smoke:hybrid-unavailable && npm run smoke:hybrid-api-available && npm run smoke:headless-guarded && npm run smoke:headless-filesystem && npm run smoke:headless-status && npm run test:local-rest-api-compat",
+    "test:runtime": "npm run build && npm run test:operon-startup-order-offline && npm run smoke:headless-readonly && npm run smoke:hybrid-unavailable && npm run smoke:hybrid-api-available && npm run smoke:headless-guarded && npm run smoke:headless-filesystem && npm run smoke:headless-status && npm run test:local-rest-api-compat",
     "audit:production": "npm audit --omit=dev --audit-level=high",
     "verify:code": "npm run audit:production && npm run build",
     "rebuild": "npx ts-node --esm scripts/clean.ts && npm run build",
@@ -137,6 +137,8 @@
     "check:atomic-write": "npm run build && node scripts/test-modified-time-settlement.mjs && node scripts/test-modified-time-canary-helpers.mjs && node scripts/test-obsidian-note-replace-operation.mjs && npm --prefix plugins/obsidian-atomic-write-bridge run check",
     "smoke:operon-mutations": "node scripts/smoke-operon-mutations.mjs",
     "smoke:operon-rich-mutations": "node scripts/smoke-operon-rich-mutations.mjs",
+    "smoke:operon-35-live": "node scripts/smoke-operon-35-live.mjs",
+    "test:operon-startup-order-offline": "node scripts/smoke-operon-35-live.mjs --offline-startup-order-contract",
     "test:profiles": "node scripts/test-elysia-task-profile.mjs",
     "test:tool-annotations": "node scripts/test-tool-annotations.mjs",
     "test:tool-routing": "npm run build && node scripts/test-tool-routing-contract.mjs && node scripts/smoke-headless-readonly.mjs",

--- a/plugins/obsidian-operon-bridge/README.md
+++ b/plugins/obsidian-operon-bridge/README.md
@@ -16,7 +16,7 @@ If both plugins are enabled, the Bridge refuses to choose an owner. Disable one 
 - Obsidian Desktop
 - Operon `2.4.0` or `2.5.0` for legacy reads
 - Operon exposing the negotiated Developer API V1 contract (`contractVersion: 1`, `runtimeApi: 1`)
-- certified Developer API releases: `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, and `3.2.1`; Operon `3.3.2` is the current validated baseline and remains admitted provisionally by contract rather than product-version allowlist
+- certified Developer API releases: `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, and `3.2.1`; Operon `3.3.2` is the current live-validated official baseline. A patched `3.5.2` acceptance candidate passed the Bridge `0.8.0` disposable-vault pilot on 2026-08-24, but stock `3.5.2` remains provisional until the required upstream fixes ship and are revalidated
 - Kairélys `2.5.1` through `2.5.3` (based on Operon `2.5.0`) and Kairélys `2.6.1` through `2.6.3`
   (based on Operon `2.6.0`) with Public API v1 for mutations
 - Obsidian Local REST API
@@ -33,11 +33,23 @@ API V1 accessor. Its complete live pilot passed the separate Developer API,
 schema, index, capability, readiness, saved-filter, transition, restoration,
 and recovery gates with Bridge `0.7.0`. Operon `3.3.2` restores the Settings
 grant controls, rejects implicit File Task renames, and fixes the unscoped
-Project Serial transition edge. Adoption remains unavailable through the
-official Developer API and is tracked in
-[#140](https://github.com/hasanyilmaz/operon/issues/140). Uncertain outcomes
+Project Serial transition edge. Uncertain outcomes
 remain fail-closed; the Bridge never retries blindly or falls back to
 Markdown/private APIs.
+
+Bridge `0.8.0` adds bounded support for Operon `3.5.2`'s separate
+task-workflow Developer API sessions. Adoption, daily/weekly periodic-note
+creation, and periodic-note-aware updates each negotiate their own exact grant;
+a pending or malformed optional grant cannot revoke the established core read
+or mutation sessions. Apply receives the exact opaque plan handle returned by
+preview, and recovery accepts only the matching durable `recoveryRef` and
+workflow kind. The Bridge converts its public one-based adoption line to the
+official zero-based locator exactly once. `taskType` and `taskImage` remain
+scalars, while `taskGallery` crosses the Bridge as an ordered `string[]`; the
+Bridge never guesses media boundaries by splitting a string. Operon `3.5.2`
+continues to report `compatible-provisional`. The patched acceptance candidate
+passed the live gate, but the official artifact is not promoted until the
+required upstream fixes are released and the stock build passes that same gate.
 
 Compatibility is reported explicitly:
 
@@ -68,8 +80,10 @@ Prefix: `/extensions/optimike-operon-bridge/v1`
 - `POST /tasks/filter`
 - `GET /validate`
 - `POST /tasks/adopt`
+- `POST /tasks/periodic`
 - `POST /tasks`
 - `POST /tasks/:operonId/update`
+- `POST /tasks/:operonId/periodic-update`
 - `POST /tasks/:operonId/transition`
 - `POST /tasks/:operonId/convert`
 - `POST /tasks/:operonId/relocate`
@@ -77,8 +91,10 @@ Prefix: `/extensions/optimike-operon-bridge/v1`
 - `POST /tasks/:operonId/recurrence`
 - `GET /mutations/pending-recoveries`
 - `POST /mutations/recover`
+- `GET /task-workflows/pending-recoveries`
+- `POST /task-workflows/recover`
 
-All routes inherit Local REST API authentication and local TLS settings. Saved filters run through Operon's native filter evaluator with an exact caller-supplied `filterSetId`; the official task-workflow API does not list saved filters. Mutations require idempotency; an idempotency key is bound to one canonical request and conflicting reuse is rejected before later payload validation. Existing-task mutations require the live revision; in-place adoption instead requires an exact one-based line plus `expectedLine` on engines that advertise it. Dry-run is the default.
+All routes inherit Local REST API authentication and local TLS settings. Saved filters run through Operon's native filter evaluator with an exact caller-supplied `filterSetId`; the official task-workflow API does not list saved filters. Mutations require idempotency; an idempotency key is bound to one canonical request and conflicting reuse is rejected before later payload validation. Existing-task mutations require the live revision; in-place adoption instead requires an exact one-based line plus `expectedLine` on engines that advertise it. Periodic creation requires `periodicKind: daily | weekly` and may include an exact ISO `routeDate`; periodic updates keep the existing task identity and let Operon seal the retain/detach/realign routing decision. Dry-run is the default.
 
 Mutation paths are strict, exact vault-relative paths. The MCP and Bridge reject leading or trailing whitespace, backslashes, absolute paths, empty segments, traversal, and non-Markdown `targetPath` values; they never trim or rewrite an invalid destination into a valid one.
 

--- a/plugins/obsidian-operon-bridge/manifest.json
+++ b/plugins/obsidian-operon-bridge/manifest.json
@@ -1,7 +1,7 @@
 {
   "id": "optimike-operon-bridge",
   "name": "Optimike Kairélys / Operon Bridge",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "minAppVersion": "1.7.2",
   "description": "Versioned Local REST API bridge from Kairélys or Operon's live task engine to Optimike Obsidian MCP.",
   "author": "Optimike",

--- a/plugins/obsidian-operon-bridge/package-lock.json
+++ b/plugins/obsidian-operon-bridge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "optimike-operon-bridge",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "optimike-operon-bridge",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "devDependencies": {
         "@types/node": "^22.0.0",
         "esbuild": "^0.25.0",

--- a/plugins/obsidian-operon-bridge/package.json
+++ b/plugins/obsidian-operon-bridge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "optimike-operon-bridge",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "private": true,
   "type": "module",
   "scripts": {

--- a/plugins/obsidian-operon-bridge/src/contract.test.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.test.ts
@@ -1,5 +1,9 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { build } from "esbuild";
 import {
 	OPERON_BRIDGE_BLOCKED_MUTATIONS,
 	OPERON_BRIDGE_DENIED_DEVELOPER_API_VERSIONS,
@@ -8,23 +12,325 @@ import {
 	isCanonicalVaultMarkdownPath,
 	isCanonicalVaultRelativePath,
 	isCertifiedDeveloperApiVersion,
-	isIndexReady,
+  isIndexReady,
+  managedFieldOutcomeMatches,
+  MutationReservationRegistry,
   isVersionCompatible,
   normalizeTask,
   resolvePriorityStableId,
   resolveOperonCompatibility,
+  isMutationAdmittedDeveloperApiVersion,
   paginateTasks,
   queryTasks,
   resolveWorkflow,
   resolveWorkflowStatus,
   workflowStatusMatches,
-	settingsSignature,
+  settingsSignature,
+  stablePriorityOutcomeMatches,
 	shouldAttemptIndexValidation,
   mutationPathValidationError,
+  normalizeExpectedManagedFieldValue,
   resolveMutationPreflight,
+  interruptedMutationPayload,
   type OperonBridgeTask,
   type RuntimeIndexedTask,
 } from "./contract";
+
+let bridgePluginClassPromise: Promise<any> | undefined;
+
+function loadBridgePluginClassForTest(): Promise<any> {
+  bridgePluginClassPromise ??= (async () => {
+    const bundle = await build({
+      entryPoints: [fileURLToPath(new URL("./main.ts", import.meta.url))],
+      bundle: true,
+      format: "cjs",
+      platform: "node",
+      target: "node22",
+      external: ["obsidian"],
+      write: false,
+      logLevel: "silent",
+    });
+    const loadedModule = { exports: {} as Record<string, unknown> };
+    const nativeRequire = createRequire(import.meta.url);
+    const obsidianStub = {
+      Plugin: class {},
+      PluginSettingTab: class {},
+      Setting: class {},
+      TFile: class {},
+    };
+    const testRequire = (id: string) =>
+      id === "obsidian" ? obsidianStub : nativeRequire(id);
+    new Function("module", "exports", "require", bundle.outputFiles[0].text)(
+      loadedModule,
+      loadedModule.exports,
+      testRequire,
+    );
+    return (loadedModule.exports as { default: any }).default;
+  })();
+  return bridgePluginClassPromise;
+}
+
+test("stable task reads retry one transient generation or settings change", async () => {
+  const BridgePlugin = await loadBridgePluginClassForTest();
+  const oneTask = BridgePlugin.prototype.oneTask as Function;
+
+  for (const scenario of ["generation", "settings"] as const) {
+    const generations =
+      scenario === "generation" ? [1, 2, 2, 2] : [1, 1, 1, 1];
+    const signatures =
+      scenario === "settings" ? ["a", "b", "b", "b"] : ["a", "a", "a", "a"];
+    let taskReads = 0;
+    const runtime = {
+      indexer: {
+        getTask: () => {
+          taskReads += 1;
+          return { operonId: "task-1" };
+        },
+      },
+    };
+    const fake = {
+      requireRuntime: () => runtime,
+      indexState: async () => ({
+        ready: true,
+        generation: generations.shift(),
+      }),
+      currentSettingsSignature: () => signatures.shift(),
+      normalizeRuntimeTask: (_runtime: unknown, task: unknown) => task,
+    };
+
+    const result = await oneTask.call(fake, "task-1", true);
+    assert.equal(result.task.operonId, "task-1");
+    assert.equal(result.generation, scenario === "generation" ? 2 : 1);
+    assert.equal(result.settingsSignature, scenario === "settings" ? "b" : "a");
+    assert.equal(taskReads, 2);
+  }
+});
+
+test("stable task collections retry one transient settings change", async () => {
+  const BridgePlugin = await loadBridgePluginClassForTest();
+  const allTasksSnapshot = BridgePlugin.prototype.allTasksSnapshot as Function;
+  const signatures = ["a", "b", "b", "b"];
+  let taskReads = 0;
+  const runtime = {
+    indexer: {
+      getAllTasks: () => {
+        taskReads += 1;
+        return [{ operonId: "task-1" }];
+      },
+    },
+  };
+  const fake = {
+    requireRuntime: () => runtime,
+    indexState: async () => ({
+      ready: true,
+      generation: 7,
+      diagnostics: { taskCount: 1 },
+    }),
+    currentSettingsSignature: () => signatures.shift(),
+    normalizeRuntimeTask: (_runtime: unknown, task: unknown) => task,
+  };
+
+  const result = await allTasksSnapshot.call(fake, true);
+  assert.equal(result.generation, 7);
+  assert.equal(result.settingsSignature, "b");
+  assert.deepEqual(result.tasks, [{ operonId: "task-1" }]);
+  assert.equal(taskReads, 2);
+});
+
+test("continuous snapshot churn fails not-ready before native dispatch", async () => {
+  const BridgePlugin = await loadBridgePluginClassForTest();
+  const oneTask = BridgePlugin.prototype.oneTask as Function;
+  const executeExistingMutation = BridgePlugin.prototype
+    .executeExistingMutation as Function;
+  const failReservedMutation = BridgePlugin.prototype
+    .failReservedMutation as Function;
+  let nativeDispatches = 0;
+  let fallbackDispatches = 0;
+  const generations = [1, 2, 3, 4];
+  const runtime = {
+    developerApi: {
+      executeMutation: async () => {
+        nativeDispatches += 1;
+        return { ok: true };
+      },
+    },
+    indexer: { getTask: () => ({ operonId: "task-1" }) },
+  };
+  const reservation = {
+    operationId: "operation-1",
+    requested: { description: "updated" },
+    signature: "signature-1",
+  };
+  const fake: Record<string, any> = {
+    mutationPreflight: async () => ({ kind: "continue" }),
+    requireMutationRuntime: () => runtime,
+    requireRuntime: () => runtime,
+    indexState: async () => ({
+      ready: true,
+      generation: generations.shift(),
+    }),
+    currentSettingsSignature: () => "settings-1",
+    normalizeRuntimeTask: (_runtime: unknown, task: unknown) => task,
+    mutationReservations: { get: () => reservation },
+    cacheMutation: () => undefined,
+  };
+  fake.oneTask = (...args: unknown[]) => oneTask.call(fake, ...args);
+
+  let churnError: unknown;
+  try {
+    await executeExistingMutation.call(
+      fake,
+      "update",
+      "task-1",
+      { idempotencyKey: "key-1", expectedRevision: "revision-1" },
+      { description: "updated" },
+      async () => {
+        fallbackDispatches += 1;
+        return { ok: true };
+      },
+    );
+  } catch (error) {
+    churnError = error;
+  }
+  assert.match(String(churnError), /generation or settings changed/);
+  assert.equal(nativeDispatches, 0);
+  assert.equal(fallbackDispatches, 0);
+
+  const failed = failReservedMutation.call(
+    fake,
+    { idempotencyKey: "key-1" },
+    churnError,
+  );
+  assert.equal(failed.httpStatus, 503);
+  assert.equal(failed.payload.status, "not-ready");
+  assert.equal(failed.payload.error.code, "mutation_unavailable");
+  assert.equal(failed.payload.retryable, true);
+  assert.equal(failed.payload.mutationMayHaveApplied, false);
+});
+
+test("generic REST mutations expose only the adapter's bounded native proof", () => {
+  const mainSource = readFileSync(new URL("./main.ts", import.meta.url), "utf8");
+  const executeStart = mainSource.indexOf(
+    "private async executeExistingMutation(",
+  );
+  const executeEnd = mainSource.indexOf(
+    "private async executeCreateMutation(",
+    executeStart,
+  );
+  assert.notEqual(executeStart, -1);
+  assert.notEqual(executeEnd, -1);
+  const executeSource = mainSource.slice(executeStart, executeEnd);
+  const proofProjection =
+    /\.\.\.\(native\.nativeProof \? \{ nativeProof: native\.nativeProof \} : \{\}\)/g;
+
+  // Refusal/outcome-unknown, unreadable postflight, and the final typed-update
+  // response all use the same already-validated, closed adapter projection.
+  assert.equal([...executeSource.matchAll(proofProjection)].length, 3);
+
+  const dryRunEnd = executeSource.indexOf("if (!native.ok || !native.operonId)");
+  const postDispatchStart = executeSource.indexOf(
+    "if (!native.ok || !native.operonId)",
+  );
+  const postDispatchEnd = executeSource.indexOf("let afterRead:", postDispatchStart);
+  const finalPayloadStart = executeSource.indexOf(
+    "const payload = {",
+    executeSource.indexOf("const applied ="),
+  );
+  assert.equal(executeSource.slice(0, dryRunEnd).includes("nativeProof"), false);
+  assert.match(
+    executeSource.slice(postDispatchStart, postDispatchEnd),
+    /recoveryRef[\s\S]+planDigest[\s\S]+nativeProof/,
+  );
+  assert.match(
+    executeSource.slice(finalPayloadStart),
+    /planDigest[\s\S]+recoveryRef[\s\S]+nativeProof/,
+  );
+  assert.match(executeSource, /native\.plan\s*\?/);
+  assert.equal(
+    /native\.plan\s*\?/.test(executeSource.slice(postDispatchStart)),
+    false,
+  );
+});
+
+test("managed field postflight preserves null clears instead of stringifying them", () => {
+  assert.equal(normalizeExpectedManagedFieldValue(null), null);
+  assert.equal(normalizeExpectedManagedFieldValue(undefined), null);
+  assert.equal(normalizeExpectedManagedFieldValue("null"), "null");
+  assert.deepEqual(normalizeExpectedManagedFieldValue(["one", "two"]), [
+    "one",
+    "two",
+  ]);
+  assert.equal(managedFieldOutcomeMatches(undefined, null), true);
+  assert.equal(managedFieldOutcomeMatches(undefined, "null"), false);
+  assert.equal(managedFieldOutcomeMatches("2026-08-25", null), false);
+});
+
+test("periodic create postflight compares the requested stable priority id", () => {
+  assert.equal(stablePriorityOutcomeMatches("priority-a", "priority-a"), true);
+  assert.equal(stablePriorityOutcomeMatches("priority-b", "priority-a"), false);
+  assert.equal(stablePriorityOutcomeMatches(null, undefined), true);
+});
+
+test("concurrent identical mutations join one atomic reservation", async () => {
+  const registry = new MutationReservationRegistry();
+  const first = registry.reserve({
+    idempotencyKey: "same-key",
+    signature: "same-signature",
+    operationId: "operation-one",
+    requested: { fields: { dateScheduled: "2026-08-25" } },
+    startedAt: "2026-08-24T00:00:00.000Z",
+  });
+  const second = registry.reserve({
+    idempotencyKey: "same-key",
+    signature: "same-signature",
+    operationId: "operation-two",
+    requested: {},
+    startedAt: "2026-08-24T00:00:01.000Z",
+  });
+  const conflict = registry.reserve({
+    idempotencyKey: "same-key",
+    signature: "different-signature",
+    operationId: "operation-three",
+    requested: {},
+    startedAt: "2026-08-24T00:00:02.000Z",
+  });
+  assert.equal(first.kind, "reserved");
+  assert.equal(second.kind, "join");
+  assert.equal(conflict.kind, "conflict");
+  assert.equal(second.reservation.operationId, "operation-one");
+  const terminal = { ok: true, operationId: "operation-one", status: "applied" };
+  registry.complete("same-key", "same-signature", terminal);
+  assert.equal(await second.reservation.promise, terminal);
+});
+
+test("durable terminal replay preserves HTTP and interrupted reservations recover uncertainty", () => {
+  const replay = resolveMutationPreflight({
+    cached: {
+      signature: "signature",
+      payload: { ok: false, operationId: "operation-one", status: "outcome-unknown" },
+      httpStatus: 500,
+    },
+    idempotencyKey: "same-key",
+    signature: "signature",
+    requested: {},
+    validate: () => null,
+    operationId: () => "unused",
+  });
+  assert.equal(replay.kind, "response");
+  if (replay.kind === "response") {
+    assert.equal(replay.response.httpStatus, 500);
+    assert.equal(replay.response.payload.operationId, "operation-one");
+    assert.equal(replay.response.payload.replayed, true);
+  }
+  const interrupted = interruptedMutationPayload({
+    idempotencyKey: "same-key",
+    operationId: "operation-one",
+    requested: { operonId: "task123" },
+  });
+  assert.equal(interrupted.status, "outcome-unknown");
+  assert.equal(interrupted.mutationMayHaveApplied, true);
+  assert.equal(interrupted.recoveryRequired, true);
+});
 
 test("resolves a requested priority label to the stable id used by postflight", () => {
   const priorities = [
@@ -499,6 +805,125 @@ test("normalization preserves canonical/custom fields and unmanaged file propert
   assert.equal(value.fields.custom, "signal");
   assert.deepEqual(value.properties, { north_star: true, rang: 4 });
   assert.match(value.revision, /^fnv1a32:[0-9a-f]{8}$/u);
+});
+
+test("provisional mutation admission is explicit and build-attested", () => {
+	assert.equal(isMutationAdmittedDeveloperApiVersion("3.2.1"), true);
+	assert.equal(isMutationAdmittedDeveloperApiVersion("3.3.2"), true);
+	assert.equal(isMutationAdmittedDeveloperApiVersion("3.5.2"), false);
+	assert.equal(
+		isMutationAdmittedDeveloperApiVersion("3.5.240438"),
+		true,
+	);
+	assert.equal(isMutationAdmittedDeveloperApiVersion("3.5.3"), false);
+});
+
+test("every direct mutation guard fails closed for an unattested runtime", async () => {
+  const BridgePlugin = await loadBridgePluginClassForTest();
+  const assertMutationRuntimeAdmitted = BridgePlugin.prototype
+    .assertMutationRuntimeAdmitted as Function;
+  const guards: Array<[string, Function, unknown[]]> = [
+    [
+      "mutation",
+      BridgePlugin.prototype.requireMutationRuntime as Function,
+      ["update"],
+    ],
+    [
+      "task workflow",
+      BridgePlugin.prototype.requireTaskWorkflowRuntime as Function,
+      ["periodic-update"],
+    ],
+    [
+      "recovery",
+      BridgePlugin.prototype.requireDeveloperApiMutationRuntime as Function,
+      [],
+    ],
+  ];
+
+  for (const [label, guard, args] of guards) {
+    const runtime = {
+      version: "3.5.2",
+      developerApi: { hasTaskWorkflowCapability: () => true },
+    };
+    const fake = {
+      settings: { mutationsEnabled: true },
+      requireRuntime: () => runtime,
+      assertMutationRuntimeAdmitted: (candidate: unknown) =>
+        assertMutationRuntimeAdmitted.call(fake, candidate),
+    };
+    assert.throws(
+      () => guard.call(fake, ...args),
+      /3\.5\.2 is not admitted for Bridge mutations/u,
+      label,
+    );
+  }
+
+  const admittedRuntime = {
+    version: "3.5.240438",
+    developerApi: { hasTaskWorkflowCapability: () => true },
+  };
+  const admitted = {
+    settings: { mutationsEnabled: true },
+    requireRuntime: () => admittedRuntime,
+    assertMutationRuntimeAdmitted: (candidate: unknown) =>
+      assertMutationRuntimeAdmitted.call(admitted, candidate),
+  };
+  assert.equal(
+    BridgePlugin.prototype.requireTaskWorkflowRuntime.call(
+      admitted,
+      "periodic-update",
+    ),
+    admittedRuntime,
+  );
+});
+
+test("normalization and filtering preserve ordered list fields without scalar coercion", () => {
+  const listTask: RuntimeIndexedTask = {
+    ...task,
+    operonId: "lst1234",
+    fieldValues: {
+      ...task.fieldValues,
+      taskType: "article",
+      taskImage: "[[Cover.png]]",
+      taskGallery: ["[[A;B.png]]", "[[Second.png]]"],
+    },
+  };
+  const normalized = normalizeTask({
+    task: listTask,
+    pipelines,
+    keyMappings: [
+      { canonicalKey: "status", visiblePropertyName: "status" },
+      { canonicalKey: "priority", visiblePropertyName: "priority" },
+      { canonicalKey: "taskType", visiblePropertyName: "Task Type" },
+      { canonicalKey: "taskImage", visiblePropertyName: "Task Image" },
+      { canonicalKey: "taskGallery", visiblePropertyName: "Task Gallery" },
+    ],
+    operonVersion: "3.5.2",
+    bridgeVersion: "0.8.0",
+    includeProperties: false,
+  });
+  assert.deepEqual(normalized.fields.taskGallery, [
+    "[[A;B.png]]",
+    "[[Second.png]]",
+  ]);
+  assert.equal(
+    filterTasks([normalized], {
+      fieldEquals: {
+        taskGallery: ["[[A;B.png]]", "[[Second.png]]"],
+      },
+    }).length,
+    1,
+  );
+  assert.equal(
+    filterTasks([normalized], {
+      fieldEquals: {
+        taskGallery: ["[[Second.png]]", "[[A;B.png]]"],
+      },
+    }).length,
+    0,
+    "taskGallery order is semantic and must be compared exactly",
+  );
+  assert.equal(filterTasks([normalized], { search: "A;B.png" }).length, 1);
 });
 
 test("filtering supports paths, tags, fields, properties, dates, and search", () => {

--- a/plugins/obsidian-operon-bridge/src/contract.test.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.test.ts
@@ -208,6 +208,64 @@ test("continuous snapshot churn fails not-ready before native dispatch", async (
   assert.equal(failed.payload.mutationMayHaveApplied, false);
 });
 
+test("lookup and revision validation complete durable mutation reservations", async () => {
+  const BridgePlugin = await loadBridgePluginClassForTest();
+  const executeExistingMutation = BridgePlugin.prototype
+    .executeExistingMutation as Function;
+
+  for (const scenario of ["missing-task", "missing-revision"] as const) {
+    let terminal:
+      | {
+          idempotencyKey: string;
+          signature: string;
+          payload: Record<string, unknown>;
+          httpStatus: number;
+        }
+      | undefined;
+    const task =
+      scenario === "missing-task"
+        ? null
+        : { operonId: "task-1", revision: "revision-1" };
+    const fake = {
+      mutationPreflight: async () => ({ kind: "continue" }),
+      requireMutationRuntime: () => ({}),
+      oneTask: async () => ({ task }),
+      mutationOperationId: () => "fallback-operation",
+      mutationReservations: {
+        get: () => ({ operationId: "reserved-operation" }),
+      },
+      cacheMutation: (
+        idempotencyKey: string,
+        signature: string,
+        payload: Record<string, unknown>,
+        httpStatus: number,
+      ) => {
+        terminal = { idempotencyKey, signature, payload, httpStatus };
+      },
+    };
+    const result = await executeExistingMutation.call(
+      fake,
+      "update",
+      "task-1",
+      {
+        idempotencyKey: `key-${scenario}`,
+        ...(scenario === "missing-task"
+          ? { expectedRevision: "revision-1" }
+          : {}),
+      },
+      { description: "updated" },
+      async () => ({ ok: true }),
+    );
+
+    assert.equal(result.httpStatus, scenario === "missing-task" ? 404 : 400);
+    assert.equal(terminal?.httpStatus, result.httpStatus);
+    assert.equal(terminal?.idempotencyKey, `key-${scenario}`);
+    assert.equal(terminal?.payload.operationId, "reserved-operation");
+    assert.equal(terminal?.payload.mutationMayHaveApplied, false);
+    assert.equal(terminal?.payload.status, "rejected");
+  }
+});
+
 test("generic REST mutations expose only the adapter's bounded native proof", () => {
   const mainSource = readFileSync(new URL("./main.ts", import.meta.url), "utf8");
   const executeStart = mainSource.indexOf(

--- a/plugins/obsidian-operon-bridge/src/contract.test.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.test.ts
@@ -295,6 +295,39 @@ test("periodic update validates lookup and revision before durable reservation",
   }
 });
 
+test("legacy adoption validates the source file before durable reservation", async () => {
+  const BridgePlugin = await loadBridgePluginClassForTest();
+  const executeAdoptMutation = BridgePlugin.prototype.executeAdoptMutation as Function;
+  let reservationCalls = 0;
+  const fake = {
+    mutationResults: { get: () => undefined },
+    mutationPreflight: async () => {
+      reservationCalls += 1;
+      return { kind: "continue" };
+    },
+    mutationOperationId: () => "adoption-operation",
+    requireRuntime: () => ({}),
+    indexState: async () => undefined,
+    requireMutationRuntime: () => ({ developerApi: null, api: {} }),
+    app: {
+      vault: {
+        getAbstractFileByPath: () => null,
+      },
+    },
+  };
+  const result = await executeAdoptMutation.call(fake, {
+    idempotencyKey: "legacy-adoption-missing-file",
+    adoption: {
+      targetPath: "Missing.md",
+      line: 1,
+      expectedLine: "- [ ] Missing task",
+    },
+  });
+
+  assert.equal(result.httpStatus, 404);
+  assert.equal(reservationCalls, 0);
+});
+
 test("task-workflow replay identities survive plugin-data persistence", async () => {
   const BridgePlugin = await loadBridgePluginClassForTest();
   const restore = BridgePlugin.prototype.restoreTaskWorkflowIdentities as Function;

--- a/plugins/obsidian-operon-bridge/src/contract.test.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.test.ts
@@ -254,6 +254,86 @@ test("lookup and revision validation happen before durable reservation", async (
   }
 });
 
+test("periodic update validates lookup and revision before durable reservation", async () => {
+  const BridgePlugin = await loadBridgePluginClassForTest();
+  const executePeriodicUpdateMutation = BridgePlugin.prototype
+    .executePeriodicUpdateMutation as Function;
+
+  for (const scenario of ["missing-task", "missing-revision"] as const) {
+    let reservationCalls = 0;
+    let taskReads = 0;
+    const task =
+      scenario === "missing-task"
+        ? null
+        : { operonId: "task-1", revision: "revision-1" };
+    const fake = {
+      mutationResults: { get: () => undefined },
+      mutationPreflight: async () => {
+        reservationCalls += 1;
+        return { kind: "continue" };
+      },
+      mutationOperationId: () => "periodic-operation",
+      requireRuntime: () => ({}),
+      indexState: async () => undefined,
+      requireTaskWorkflowRuntime: () => ({}),
+      oneTask: async () => {
+        taskReads += 1;
+        return { task };
+      },
+    };
+    const result = await executePeriodicUpdateMutation.call(fake, "task-1", {
+      idempotencyKey: `periodic-${scenario}`,
+      ...(scenario === "missing-task"
+        ? { expectedRevision: "revision-1" }
+        : {}),
+      patch: { fields: { dateScheduled: "2026-08-25" } },
+    });
+
+    assert.equal(result.httpStatus, scenario === "missing-task" ? 404 : 400);
+    assert.equal(reservationCalls, 0);
+    assert.equal(taskReads, scenario === "missing-task" ? 1 : 0);
+  }
+});
+
+test("task-workflow replay identities survive plugin-data persistence", async () => {
+  const BridgePlugin = await loadBridgePluginClassForTest();
+  const restore = BridgePlugin.prototype.restoreTaskWorkflowIdentities as Function;
+  const entries = BridgePlugin.prototype.taskWorkflowIdentityEntries as Function;
+  const identityStore = BridgePlugin.prototype.taskWorkflowIdentityStore as Function;
+  const persist = BridgePlugin.prototype.persistPluginData as Function;
+  const key = `periodic-create:${"a".repeat(64)}`;
+  const updatedAt = new Date().toISOString();
+  const fake: Record<string, any> = {
+    settings: { mutationsEnabled: true },
+    taskWorkflowIdentities: new Map(),
+    dataWriteChain: Promise.resolve(),
+    dataWriteFailed: false,
+    mutationJournalEntries: () => [],
+    queuePersistPluginData() {
+      this.dataWriteChain = Promise.resolve();
+    },
+    saveData: async (value: unknown) => {
+      fake.saved = value;
+    },
+  };
+
+  restore.call(fake, {
+    version: 1,
+    entries: [{ key, operonId: "day1234", updatedAt }],
+  });
+  assert.equal(fake.taskWorkflowIdentities.get(key)?.operonId, "day1234");
+  fake.taskWorkflowIdentityEntries = () => entries.call(fake);
+  await persist.call(fake);
+  assert.deepEqual(fake.saved.taskWorkflowIdentities.entries, [
+    { key, operonId: "day1234", updatedAt },
+  ]);
+
+  const store = identityStore.call(fake);
+  const secondKey = `adopt:${"b".repeat(64)}`;
+  await store.set(secondKey, "adp1234");
+  assert.equal(store.get(secondKey), "adp1234");
+});
+
 test("generic REST mutations expose only the adapter's bounded native proof", () => {
   const mainSource = readFileSync(new URL("./main.ts", import.meta.url), "utf8");
   const executeStart = mainSource.indexOf(

--- a/plugins/obsidian-operon-bridge/src/contract.test.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.test.ts
@@ -162,6 +162,7 @@ test("continuous snapshot churn fails not-ready before native dispatch", async (
     signature: "signature-1",
   };
   const fake: Record<string, any> = {
+    mutationResults: { get: () => undefined },
     mutationPreflight: async () => ({ kind: "continue" }),
     requireMutationRuntime: () => runtime,
     requireRuntime: () => runtime,
@@ -208,40 +209,30 @@ test("continuous snapshot churn fails not-ready before native dispatch", async (
   assert.equal(failed.payload.mutationMayHaveApplied, false);
 });
 
-test("lookup and revision validation complete durable mutation reservations", async () => {
+test("lookup and revision validation happen before durable reservation", async () => {
   const BridgePlugin = await loadBridgePluginClassForTest();
   const executeExistingMutation = BridgePlugin.prototype
     .executeExistingMutation as Function;
 
   for (const scenario of ["missing-task", "missing-revision"] as const) {
-    let terminal:
-      | {
-          idempotencyKey: string;
-          signature: string;
-          payload: Record<string, unknown>;
-          httpStatus: number;
-        }
-      | undefined;
+    let reservationCalls = 0;
+    let taskReads = 0;
     const task =
       scenario === "missing-task"
         ? null
         : { operonId: "task-1", revision: "revision-1" };
     const fake = {
-      mutationPreflight: async () => ({ kind: "continue" }),
+      mutationResults: { get: () => undefined },
+      mutationPreflight: async () => {
+        reservationCalls += 1;
+        return { kind: "continue" };
+      },
       requireMutationRuntime: () => ({}),
-      oneTask: async () => ({ task }),
+      oneTask: async () => {
+        taskReads += 1;
+        return { task };
+      },
       mutationOperationId: () => "fallback-operation",
-      mutationReservations: {
-        get: () => ({ operationId: "reserved-operation" }),
-      },
-      cacheMutation: (
-        idempotencyKey: string,
-        signature: string,
-        payload: Record<string, unknown>,
-        httpStatus: number,
-      ) => {
-        terminal = { idempotencyKey, signature, payload, httpStatus };
-      },
     };
     const result = await executeExistingMutation.call(
       fake,
@@ -258,11 +249,8 @@ test("lookup and revision validation complete durable mutation reservations", as
     );
 
     assert.equal(result.httpStatus, scenario === "missing-task" ? 404 : 400);
-    assert.equal(terminal?.httpStatus, result.httpStatus);
-    assert.equal(terminal?.idempotencyKey, `key-${scenario}`);
-    assert.equal(terminal?.payload.operationId, "reserved-operation");
-    assert.equal(terminal?.payload.mutationMayHaveApplied, false);
-    assert.equal(terminal?.payload.status, "rejected");
+    assert.equal(reservationCalls, 0);
+    assert.equal(taskReads, scenario === "missing-task" ? 1 : 0);
   }
 });
 
@@ -932,6 +920,24 @@ test("every direct mutation guard fails closed for an unattested runtime", async
       "periodic-update",
     ),
     admittedRuntime,
+  );
+
+  const legacyRuntime = {
+    version: "2.6.0",
+    api: {
+      capabilities: () => ({ ready: true, update: true }),
+    },
+  };
+  const legacy = {
+    settings: { mutationsEnabled: true },
+    requireRuntime: () => legacyRuntime,
+    assertMutationRuntimeAdmitted: () => {
+      throw new Error("Developer API admission must not gate legacy Public API");
+    },
+  };
+  assert.equal(
+    BridgePlugin.prototype.requireMutationRuntime.call(legacy, "update"),
+    legacyRuntime,
   );
 });
 

--- a/plugins/obsidian-operon-bridge/src/contract.ts
+++ b/plugins/obsidian-operon-bridge/src/contract.ts
@@ -32,6 +32,11 @@ export const OPERON_BRIDGE_DENIED_DEVELOPER_API_VERSIONS: Readonly<
 		"Operon 3.0.0 predates the accepted Developer API V1 integration baseline.",
 };
 
+export const OPERON_BRIDGE_PROVISIONAL_MUTATION_VERSIONS = [
+	"3.3.2",
+	"3.5.240438",
+] as const;
+
 export type OperonCompatibilityState =
 	| "certified"
 	| "compatible-provisional"
@@ -61,7 +66,19 @@ export const OPERON_BRIDGE_BLOCKED_MUTATIONS = {
 } as const;
 
 export function isCertifiedDeveloperApiVersion(version: string): boolean {
-	return (OPERON_BRIDGE_DEVELOPER_API_VERSIONS as readonly string[]).includes(version.trim());
+	return (OPERON_BRIDGE_DEVELOPER_API_VERSIONS as readonly string[]).includes(
+		version.trim(),
+	);
+}
+
+export function isMutationAdmittedDeveloperApiVersion(version: string): boolean {
+	const normalized = version.trim();
+	return (
+		isCertifiedDeveloperApiVersion(normalized) ||
+		(OPERON_BRIDGE_PROVISIONAL_MUTATION_VERSIONS as readonly string[]).includes(
+			normalized,
+		)
+	);
 }
 
 export function resolveOperonCompatibility(options: {
@@ -95,7 +112,9 @@ export function resolveOperonCompatibility(options: {
 	}
 
 	if (
-		(OPERON_BRIDGE_LEGACY_VERSIONS[options.pluginId] as readonly string[]).includes(version)
+		(
+			OPERON_BRIDGE_LEGACY_VERSIONS[options.pluginId] as readonly string[]
+		).includes(version)
 	) {
 		return {
 			state: "certified",
@@ -128,12 +147,18 @@ export function isCanonicalVaultRelativePath(value: unknown): value is string {
 	const segments = value.split("/");
 	return segments.every(
 		(segment) =>
-			segment.length > 0 && segment === segment.trim() && segment !== "." && segment !== "..",
+			segment.length > 0 &&
+			segment === segment.trim() &&
+			segment !== "." &&
+			segment !== "..",
 	);
 }
 
 export function isCanonicalVaultMarkdownPath(value: unknown): value is string {
-	return isCanonicalVaultRelativePath(value) && value.toLocaleLowerCase().endsWith(".md");
+	return (
+		isCanonicalVaultRelativePath(value) &&
+		value.toLocaleLowerCase().endsWith(".md")
+	);
 }
 
 export function mutationPathValidationError(
@@ -147,15 +172,22 @@ export function mutationPathValidationError(
 		| "relocate",
 	requested: Record<string, unknown>,
 ): string | null {
-	const has = (key: string): boolean => Object.prototype.hasOwnProperty.call(requested, key);
+	const has = (key: string): boolean =>
+		Object.prototype.hasOwnProperty.call(requested, key);
 	if (capability === "create") {
 		if (requested.source !== "inline" && requested.source !== "file") {
 			return "source must be either inline or file.";
 		}
-		if (has("targetPath") && !isCanonicalVaultMarkdownPath(requested.targetPath)) {
+		if (
+			has("targetPath") &&
+			!isCanonicalVaultMarkdownPath(requested.targetPath)
+		) {
 			return "targetPath must be an exact canonical vault-relative Markdown path.";
 		}
-		if (has("targetFolder") && !isCanonicalVaultRelativePath(requested.targetFolder)) {
+		if (
+			has("targetFolder") &&
+			!isCanonicalVaultRelativePath(requested.targetFolder)
+		) {
 			return "targetFolder must be an exact canonical vault-relative folder path.";
 		}
 		if (requested.source === "file" && has("targetPath")) {
@@ -169,10 +201,16 @@ export function mutationPathValidationError(
 		if (requested.target !== "inline" && requested.target !== "file") {
 			return "target must be either inline or file.";
 		}
-		if (has("targetPath") && !isCanonicalVaultMarkdownPath(requested.targetPath)) {
+		if (
+			has("targetPath") &&
+			!isCanonicalVaultMarkdownPath(requested.targetPath)
+		) {
 			return "targetPath must be an exact canonical vault-relative Markdown path.";
 		}
-		if (has("targetFolder") && !isCanonicalVaultRelativePath(requested.targetFolder)) {
+		if (
+			has("targetFolder") &&
+			!isCanonicalVaultRelativePath(requested.targetFolder)
+		) {
 			return "targetFolder must be an exact canonical vault-relative folder path.";
 		}
 		if (requested.target === "inline" && !has("targetPath")) {
@@ -185,7 +223,10 @@ export function mutationPathValidationError(
 			return "targetPath is supported only for file-to-inline conversion.";
 		}
 	}
-	if (capability === "relocate" && !isCanonicalVaultMarkdownPath(requested.targetPath)) {
+	if (
+		capability === "relocate" &&
+		!isCanonicalVaultMarkdownPath(requested.targetPath)
+	) {
 		return "targetPath must be an exact canonical vault-relative Markdown path.";
 	}
 	return null;
@@ -194,6 +235,100 @@ export function mutationPathValidationError(
 export interface CachedMutation {
 	signature: string;
 	payload: Record<string, unknown>;
+	httpStatus?: number;
+}
+
+export interface MutationReservation {
+	signature: string;
+	operationId: string;
+	requested: Record<string, unknown>;
+	startedAt: string;
+	promise: Promise<Record<string, unknown>>;
+	resolve: (payload: Record<string, unknown>) => void;
+}
+
+export type MutationReservationDecision =
+	| { kind: "reserved"; reservation: MutationReservation }
+	| { kind: "join"; reservation: MutationReservation }
+	| { kind: "conflict"; reservation: MutationReservation };
+
+export class MutationReservationRegistry {
+	private readonly active = new Map<string, MutationReservation>();
+
+	reserve(options: {
+		idempotencyKey: string;
+		signature: string;
+		operationId: string;
+		requested: Record<string, unknown>;
+		startedAt: string;
+	}): MutationReservationDecision {
+		const current = this.active.get(options.idempotencyKey);
+		if (current) {
+			return current.signature === options.signature
+				? { kind: "join", reservation: current }
+				: { kind: "conflict", reservation: current };
+		}
+		let resolve!: (payload: Record<string, unknown>) => void;
+		const promise = new Promise<Record<string, unknown>>((done) => {
+			resolve = done;
+		});
+		const reservation: MutationReservation = {
+			signature: options.signature,
+			operationId: options.operationId,
+			requested: structuredClone(options.requested),
+			startedAt: options.startedAt,
+			promise,
+			resolve,
+		};
+		this.active.set(options.idempotencyKey, reservation);
+		return { kind: "reserved", reservation };
+	}
+
+	complete(
+		idempotencyKey: string,
+		signature: string,
+		payload: Record<string, unknown>,
+	): void {
+		const current = this.active.get(idempotencyKey);
+		if (!current || current.signature !== signature) return;
+		this.active.delete(idempotencyKey);
+		current.resolve(payload);
+	}
+
+	get(idempotencyKey: string): MutationReservation | undefined {
+		return this.active.get(idempotencyKey);
+	}
+
+	entries(): IterableIterator<[string, MutationReservation]> {
+		return this.active.entries();
+	}
+}
+
+export function interruptedMutationPayload(options: {
+	idempotencyKey: string;
+	operationId: string;
+	requested: Record<string, unknown>;
+}): Record<string, unknown> {
+	return {
+		ok: false,
+		contractVersion: OPERON_BRIDGE_CONTRACT_VERSION,
+		operationId: options.operationId,
+		idempotencyKey: options.idempotencyKey,
+		status: "outcome-unknown",
+		before: null,
+		requested: options.requested,
+		after: null,
+		error: {
+			code: "interrupted_in_progress",
+			message:
+				"The Bridge restarted while this mutation was in progress; inspect Operon pending recoveries and recover the same native plan before retrying.",
+		},
+		retryable: false,
+		mutationMayHaveApplied: true,
+		recoveryRequired: true,
+		source: "operon-live",
+		stale: false,
+	};
 }
 
 export type MutationPreflightDecision =
@@ -217,7 +352,7 @@ export function resolveMutationPreflight(options: {
 		return {
 			kind: "response",
 			response: {
-				httpStatus: 200,
+				httpStatus: cached.httpStatus ?? 200,
 				payload: { ...cached.payload, replayed: true },
 			},
 		};
@@ -238,7 +373,8 @@ export function resolveMutationPreflight(options: {
 					after: null,
 					error: {
 						code: "idempotency_key_reused",
-						message: "idempotencyKey was already used for a different mutation request.",
+						message:
+							"idempotencyKey was already used for a different mutation request.",
 					},
 					retryable: false,
 					source: "operon-live",
@@ -257,6 +393,7 @@ export type OperonTaskSource = "inline" | "file";
 export type OperonCheckboxState = "open" | "done" | "cancelled";
 export type OperonTier = "hot" | "warm" | "cold";
 export type SortDirection = "asc" | "desc";
+export type OperonFieldValue = string | string[];
 
 export interface RuntimeTaskLocation {
 	filePath: string;
@@ -268,7 +405,7 @@ export interface RuntimeIndexedTask {
 	operonId: string;
 	description: string;
 	checkbox: OperonCheckboxState;
-	fieldValues: Record<string, string>;
+	fieldValues: Record<string, OperonFieldValue>;
 	tags: string[];
 	primary: RuntimeTaskLocation;
 	datetimeModified: string;
@@ -314,7 +451,9 @@ export function resolvePriorityStableId(
 	const normalized = String(value ?? "").trim();
 	if (!normalized) return null;
 	const matches = priorities
-		.filter((priority) => priority.id === normalized || priority.label === normalized)
+		.filter(
+			(priority) => priority.id === normalized || priority.label === normalized,
+		)
 		.map((priority) => priority.id)
 		.filter((id): id is string => Boolean(id));
 	const unique = [...new Set(matches)];
@@ -353,7 +492,10 @@ export function resolveWorkflowStatus(
 }
 
 export function workflowStatusMatches(
-	actual: Pick<OperonBridgeTask, "status" | "statusId" | "statusLabel" | "pipeline" | "pipelineId">,
+	actual: Pick<
+		OperonBridgeTask,
+		"status" | "statusId" | "statusLabel" | "pipeline" | "pipelineId"
+	>,
 	requested: unknown,
 	pipelines: readonly RuntimePipeline[],
 ): boolean {
@@ -366,7 +508,8 @@ export function workflowStatusMatches(
 	return (
 		actual.status === resolved.value ||
 		(resolved.id !== null && actual.statusId === resolved.id) ||
-		(actual.pipeline === resolved.pipeline && actual.statusLabel === resolved.label)
+		(actual.pipeline === resolved.pipeline &&
+			actual.statusLabel === resolved.label)
 	);
 }
 
@@ -528,7 +671,7 @@ export interface OperonBridgeTask {
 	blocking: string[];
 	blockedBy: string[];
 	dates: OperonTaskDates;
-	fields: Record<string, string>;
+	fields: Record<string, OperonFieldValue>;
 	properties?: Record<string, unknown>;
 	plainCheckboxProgress?: {
 		total: number;
@@ -593,7 +736,7 @@ export interface OperonTaskQuery {
 	tagsAll?: string[];
 	parentTask?: string | null;
 	dates?: OperonDateFilter[];
-	fieldEquals?: Record<string, string>;
+	fieldEquals?: Record<string, OperonFieldValue>;
 	propertyEquals?: Record<string, unknown>;
 	sort?: OperonTaskSort[];
 	includeProperties?: boolean;
@@ -620,8 +763,13 @@ export interface OperonTaskPage {
 const DEFAULT_LIMIT = 100;
 const MAX_LIMIT = 500;
 
-export function isVersionCompatible(pluginId: "kairelys" | "operon", version: string): boolean {
-	return (OPERON_BRIDGE_SUPPORTED_VERSIONS[pluginId] as readonly string[]).includes(version.trim());
+export function isVersionCompatible(
+	pluginId: "kairelys" | "operon",
+	version: string,
+): boolean {
+	return (
+		OPERON_BRIDGE_SUPPORTED_VERSIONS[pluginId] as readonly string[]
+	).includes(version.trim());
 }
 
 export interface RuntimeIndexDiagnostics {
@@ -668,12 +816,47 @@ export function isIndexReady(options: {
 	);
 }
 
-export function parseListValue(value: string | undefined): string[] {
+export function parseListValue(value: OperonFieldValue | undefined): string[] {
+	if (Array.isArray(value))
+		return value.map((item) => item.trim()).filter(Boolean);
 	if (!value?.trim()) return [];
 	return value
 		.split(/[;,]/u)
 		.map((item) => item.trim())
 		.filter(Boolean);
+}
+
+export function normalizeExpectedManagedFieldValue(
+	value: unknown,
+): OperonFieldValue | null {
+	if (value === null || value === undefined) return null;
+	return Array.isArray(value) ? value.map(String) : String(value);
+}
+
+export function managedFieldOutcomeMatches(
+	actual: OperonFieldValue | undefined,
+	requested: unknown,
+): boolean {
+	return (
+		stableStringify(actual ?? null) ===
+		stableStringify(normalizeExpectedManagedFieldValue(requested))
+	);
+}
+
+export function stablePriorityOutcomeMatches(
+	actualPriorityId: string | null,
+	requestedPriorityId: unknown,
+): boolean {
+	return (
+		typeof requestedPriorityId !== "string" ||
+		actualPriorityId === requestedPriorityId.trim()
+	);
+}
+
+function scalarFieldValue(
+	value: OperonFieldValue | undefined,
+): string | undefined {
+	return typeof value === "string" ? value : undefined;
 }
 
 export function resolveWorkflow(
@@ -775,11 +958,21 @@ export function normalizeTask(options: {
 	includeProperties: boolean;
 }): OperonBridgeTask {
 	const { task } = options;
-	const fields = { ...task.fieldValues };
-	const status = fields.status?.trim() || null;
+	const fields = Object.fromEntries(
+		Object.entries(task.fieldValues).map(([key, value]) => [
+			key,
+			Array.isArray(value) ? [...value] : value,
+		]),
+	) as Record<string, OperonFieldValue>;
+	const status = scalarFieldValue(fields.status)?.trim() || null;
 	const workflow = resolveWorkflow(status ?? undefined, options.pipelines);
-	const canonicalProperties = normalizeProperties(options.frontmatter, options.keyMappings);
-	const properties = options.includeProperties ? canonicalProperties : undefined;
+	const canonicalProperties = normalizeProperties(
+		options.frontmatter,
+		options.keyMappings,
+	);
+	const properties = options.includeProperties
+		? canonicalProperties
+		: undefined;
 	const normalized: Omit<OperonBridgeTask, "revision"> = {
 		operonId: task.operonId,
 		source: task.primary.format === "yaml" ? "file" : "inline",
@@ -793,24 +986,29 @@ export function normalizeTask(options: {
 		statusLabel: workflow.statusLabel,
 		pipeline: workflow.pipeline,
 		pipelineId: workflow.pipelineId,
-		priority: fields.priority?.trim() || null,
+		priority: scalarFieldValue(fields.priority)?.trim() || null,
 		tier: task.tier,
 		tags: [
-			...new Set(task.tags.map((tag) => tag.replace(/^#/u, "").trim()).filter(Boolean)),
+			...new Set(
+				task.tags.map((tag) => tag.replace(/^#/u, "").trim()).filter(Boolean),
+			),
 		].sort(),
-		parentTask: fields.parentTask?.trim() || null,
+		parentTask: scalarFieldValue(fields.parentTask)?.trim() || null,
 		blocking: parseListValue(fields.blocking),
 		blockedBy: parseListValue(fields.blockedBy),
 		dates: {
-			due: fields.dateDue?.trim() || null,
-			scheduled: fields.dateScheduled?.trim() || null,
-			started: fields.dateStarted?.trim() || null,
-			completed: fields.dateCompleted?.trim() || null,
-			cancelled: fields.dateCancelled?.trim() || null,
-			datetimeStart: fields.datetimeStart?.trim() || null,
-			datetimeEnd: fields.datetimeEnd?.trim() || null,
-			created: fields.datetimeCreated?.trim() || null,
-			modified: fields.datetimeModified?.trim() || task.datetimeModified?.trim() || null,
+			due: scalarFieldValue(fields.dateDue)?.trim() || null,
+			scheduled: scalarFieldValue(fields.dateScheduled)?.trim() || null,
+			started: scalarFieldValue(fields.dateStarted)?.trim() || null,
+			completed: scalarFieldValue(fields.dateCompleted)?.trim() || null,
+			cancelled: scalarFieldValue(fields.dateCancelled)?.trim() || null,
+			datetimeStart: scalarFieldValue(fields.datetimeStart)?.trim() || null,
+			datetimeEnd: scalarFieldValue(fields.datetimeEnd)?.trim() || null,
+			created: scalarFieldValue(fields.datetimeCreated)?.trim() || null,
+			modified:
+				scalarFieldValue(fields.datetimeModified)?.trim() ||
+				task.datetimeModified?.trim() ||
+				null,
 		},
 		fields,
 		...(properties ? { properties } : {}),
@@ -838,6 +1036,20 @@ function normalizeNeedle(value: unknown): string {
 		.toLocaleLowerCase();
 }
 
+function fieldValueMatches(
+	actual: OperonFieldValue | undefined,
+	expected: OperonFieldValue,
+): boolean {
+	if (Array.isArray(actual) || Array.isArray(expected)) {
+		if (!Array.isArray(actual) || !Array.isArray(expected)) return false;
+		return (
+			stableStringify(actual.map(normalizeNeedle)) ===
+			stableStringify(expected.map(normalizeNeedle))
+		);
+	}
+	return normalizeNeedle(actual) === normalizeNeedle(expected);
+}
+
 function includesEvery(haystack: string[], needles: string[]): boolean {
 	const normalized = new Set(haystack.map(normalizeNeedle));
 	return needles.every((needle) => normalized.has(normalizeNeedle(needle)));
@@ -860,7 +1072,10 @@ function propertyValue(task: OperonBridgeTask, key: string): unknown {
 	return task.properties?.[key];
 }
 
-export function filterTasks(tasks: OperonBridgeTask[], query: OperonTaskQuery): OperonBridgeTask[] {
+export function filterTasks(
+	tasks: OperonBridgeTask[],
+	query: OperonTaskQuery,
+): OperonBridgeTask[] {
 	const search = normalizeNeedle(query.search);
 	const operonIds = new Set(query.operonIds ?? []);
 	const sources = new Set(query.sources ?? []);
@@ -876,15 +1091,24 @@ export function filterTasks(tasks: OperonBridgeTask[], query: OperonTaskQuery): 
 		if (operonIds.size > 0 && !operonIds.has(task.operonId)) return false;
 		if (sources.size > 0 && !sources.has(task.source)) return false;
 		if (checkboxes.size > 0 && !checkboxes.has(task.checkbox)) return false;
-		if (statuses.size > 0 && !statuses.has(normalizeNeedle(task.status))) return false;
-		if (statusIds.size > 0 && !statusIds.has(normalizeNeedle(task.statusId))) return false;
-		if (pipelines.size > 0 && !pipelines.has(normalizeNeedle(task.pipeline))) return false;
-		if (pipelineIds.size > 0 && !pipelineIds.has(normalizeNeedle(task.pipelineId))) return false;
-		if (priorities.size > 0 && !priorities.has(normalizeNeedle(task.priority))) return false;
+		if (statuses.size > 0 && !statuses.has(normalizeNeedle(task.status)))
+			return false;
+		if (statusIds.size > 0 && !statusIds.has(normalizeNeedle(task.statusId)))
+			return false;
+		if (pipelines.size > 0 && !pipelines.has(normalizeNeedle(task.pipeline)))
+			return false;
+		if (
+			pipelineIds.size > 0 &&
+			!pipelineIds.has(normalizeNeedle(task.pipelineId))
+		)
+			return false;
+		if (priorities.size > 0 && !priorities.has(normalizeNeedle(task.priority)))
+			return false;
 		if (tiers.size > 0 && !tiers.has(task.tier)) return false;
 		if (
 			(query.pathIncludes ?? []).some(
-				(needle) => !normalizeNeedle(task.path).includes(normalizeNeedle(needle)),
+				(needle) =>
+					!normalizeNeedle(task.path).includes(normalizeNeedle(needle)),
 			)
 		) {
 			return false;
@@ -896,18 +1120,32 @@ export function filterTasks(tasks: OperonBridgeTask[], query: OperonTaskQuery): 
 		) {
 			return false;
 		}
-		if ((query.tagsAny?.length ?? 0) > 0 && !includesAny(task.tags, query.tagsAny ?? []))
+		if (
+			(query.tagsAny?.length ?? 0) > 0 &&
+			!includesAny(task.tags, query.tagsAny ?? [])
+		)
 			return false;
-		if ((query.tagsAll?.length ?? 0) > 0 && !includesEvery(task.tags, query.tagsAll ?? []))
+		if (
+			(query.tagsAll?.length ?? 0) > 0 &&
+			!includesEvery(task.tags, query.tagsAll ?? [])
+		)
 			return false;
-		if (query.parentTask !== undefined && task.parentTask !== query.parentTask) return false;
-		if ((query.dates ?? []).some((filter) => !matchesDate(task.dates[filter.field], filter)))
+		if (query.parentTask !== undefined && task.parentTask !== query.parentTask)
+			return false;
+		if (
+			(query.dates ?? []).some(
+				(filter) => !matchesDate(task.dates[filter.field], filter),
+			)
+		)
 			return false;
 		for (const [key, expected] of Object.entries(query.fieldEquals ?? {})) {
-			if (normalizeNeedle(task.fields[key]) !== normalizeNeedle(expected)) return false;
+			if (!fieldValueMatches(task.fields[key], expected)) return false;
 		}
 		for (const [key, expected] of Object.entries(query.propertyEquals ?? {})) {
-			if (stableStringify(propertyValue(task, key)) !== stableStringify(expected)) return false;
+			if (
+				stableStringify(propertyValue(task, key)) !== stableStringify(expected)
+			)
+				return false;
 		}
 		if (search) {
 			const searchable = [
@@ -922,7 +1160,9 @@ export function filterTasks(tasks: OperonBridgeTask[], query: OperonTaskQuery): 
 				task.priority,
 				task.parentTask,
 				...task.tags,
-				...Object.values(task.fields),
+				...Object.values(task.fields).flatMap((value) =>
+					Array.isArray(value) ? value : [value],
+				),
 				...(task.properties ? [stableStringify(task.properties)] : []),
 			]
 				.map(normalizeNeedle)
@@ -933,7 +1173,10 @@ export function filterTasks(tasks: OperonBridgeTask[], query: OperonTaskQuery): 
 	});
 }
 
-function sortValue(task: OperonBridgeTask, field: OperonTaskSort["field"]): string | number {
+function sortValue(
+	task: OperonBridgeTask,
+	field: OperonTaskSort["field"],
+): string | number {
 	switch (field) {
 		case "description":
 			return task.description;
@@ -997,7 +1240,13 @@ export function paginateTasks(
 	query: Pick<OperonTaskQuery, "cursor" | "limit">,
 ): Omit<
 	OperonTaskPage,
-	"contractVersion" | "source" | "stale" | "generation" | "settingsSignature" | "limitations" | "ok"
+	| "contractVersion"
+	| "source"
+	| "stale"
+	| "generation"
+	| "settingsSignature"
+	| "limitations"
+	| "ok"
 > {
 	const offset = parseCursor(query.cursor);
 	const limit = Math.max(1, Math.min(MAX_LIMIT, query.limit ?? DEFAULT_LIMIT));
@@ -1018,11 +1267,19 @@ export function queryTasks(
 	query: OperonTaskQuery,
 ): Omit<
 	OperonTaskPage,
-	"contractVersion" | "source" | "stale" | "generation" | "settingsSignature" | "limitations" | "ok"
+	| "contractVersion"
+	| "source"
+	| "stale"
+	| "generation"
+	| "settingsSignature"
+	| "limitations"
+	| "ok"
 > {
 	return paginateTasks(sortTasks(filterTasks(tasks, query), query.sort), query);
 }
 
-export function settingsSignature(configuration: OperonSemanticConfiguration): string {
+export function settingsSignature(
+	configuration: OperonSemanticConfiguration,
+): string {
 	return `fnv1a32:${fnv1a32(stableStringify(configuration))}`;
 }

--- a/plugins/obsidian-operon-bridge/src/developer-api-adapter.test.ts
+++ b/plugins/obsidian-operon-bridge/src/developer-api-adapter.test.ts
@@ -1899,6 +1899,17 @@ test("Operon 3.5 negotiates exact additive workflow grants and keeps opaque plan
   const appliedBeforeInvalidPlans = appliedHandles.length;
   nextWorkflowPlan = {
     ...validPeriodicUpdatePlan,
+    recoveryRef: `twr1_${"c".repeat(48)}`,
+  };
+  const inventedWorkflowRecoveryFamily = await adapter.executeTaskWorkflow(
+    "periodic-update",
+    { operonId: "adp1234", fields: { dateScheduled: "2026-08-27" } },
+    false,
+  );
+  assert.equal(inventedWorkflowRecoveryFamily.code, "failed");
+  assert.equal(inventedWorkflowRecoveryFamily.mutationMayHaveApplied, false);
+  nextWorkflowPlan = {
+    ...validPeriodicUpdatePlan,
     planDigest: workflowDigests["periodic-update"].toUpperCase(),
   };
   const uppercasePlanDigest = await adapter.executeTaskWorkflow(

--- a/plugins/obsidian-operon-bridge/src/developer-api-adapter.test.ts
+++ b/plugins/obsidian-operon-bridge/src/developer-api-adapter.test.ts
@@ -6,7 +6,7 @@ const consumer = {
   manifest: {
     id: "optimike-operon-bridge",
     name: "Optimike Operon Bridge",
-    version: "0.7.0",
+    version: "0.8.0",
   },
 };
 
@@ -192,12 +192,19 @@ test("Operon 3.2 adapter evaluates saved filters through the additive task-workf
       _candidate: unknown,
       request: { requestedCapabilities: readonly string[] },
     ) => ({
+      contractVersion: 1,
+      kind: "task-workflow-developer-api-access-result",
       ok: request.requestedCapabilities[0] === "tasks.filter-query",
       api: {
+        contractVersion: 1,
+        runtimeApi: 1,
         tasks: {
           filterQuery: async (input: Record<string, unknown>) => {
             filterRequest = input;
             return {
+              contractVersion: 1,
+              kind: "task-filter-query-result",
+              requestId: input.requestId,
               ok: true,
               tasks: [],
               page: {
@@ -288,7 +295,10 @@ test("an unavailable Operon 3.2 filter accessor does not hide approved core read
       }),
     },
     mutations: {
-      preview: async () => ({ ok: true, plan: { planDigest: "filter-pending" } }),
+      preview: async () => ({
+        ok: true,
+        plan: { planDigest: "filter-pending" },
+      }),
       apply: async () => ({ status: "applied" as const }),
     },
   };
@@ -297,7 +307,9 @@ test("an unavailable Operon 3.2 filter accessor does not hide approved core read
       _candidate: unknown,
       request: { requestedCapabilities: readonly string[] },
     ) => ({
-      ok: request.requestedCapabilities.every((capability) => granted.has(capability)),
+      ok: request.requestedCapabilities.every((capability) =>
+        granted.has(capability),
+      ),
       status: {
         ...readyStatus(),
         admission: { reads: true, writes: true },
@@ -310,6 +322,8 @@ test("an unavailable Operon 3.2 filter accessor does not hide approved core read
       api,
     }),
     getTaskWorkflowDeveloperApiV1: () => ({
+      contractVersion: 1,
+      kind: "task-workflow-developer-api-access-result",
       ok: false,
       error: {
         code: "authority-insufficient",
@@ -594,6 +608,55 @@ test("Operon 3 Developer API adapter previews and applies an exact typed update 
   };
   let previewInput: Record<string, unknown> | null = null;
   let appliedPlan: unknown = null;
+  let nextExecution: Record<string, unknown> | null = null;
+  const updatePlanDigest = "a".repeat(64);
+  const updateRecoveryRef = `dvr1_${"a".repeat(48)}`;
+  const validExecution = {
+    contractVersion: 1,
+    kind: "developer-mutation-execution-result",
+    requestId: "base-update-apply-1",
+    status: "applied",
+    mutationMayHaveApplied: true,
+    retryAllowed: false,
+    groupResults: [
+      {
+        groupId: "update-task-source",
+        status: "committed",
+        resourceRevisions: [
+          {
+            resourceKind: "task-source",
+            resourceKey: "Projects/Bridge.md",
+            revision: "sha256:updated",
+            privateValue: "must-not-cross-bridge",
+          },
+        ],
+      },
+    ],
+    receipt: {
+      contractVersion: 1,
+      terminalOutcome: "applied",
+      planDigest: updatePlanDigest,
+      mutationKind: "task.update",
+      targetDigest: "b".repeat(64),
+      effectiveAt: "2026-08-24T00:00:01.000Z",
+      completedAt: "2026-08-24T00:00:02.000Z",
+      expiresAt: "2026-08-24T00:05:00.000Z",
+      privateBody: "must-not-cross-bridge",
+    },
+    postflight: {
+      status: "verified",
+      observedAt: "2026-08-24T00:00:02.000Z",
+      contextRevision: { privateFingerprint: "must-not-cross-bridge" },
+    },
+  };
+  const typedUpdateRequest = {
+    description: "Updated bridge",
+    fields: {
+      taskType: "article",
+      taskImage: "[[Cover.png]]",
+      taskGallery: ["[[One.png]]", "[[Two.png]]"],
+    },
+  };
   const api = {
     hasCapability: (name: string) =>
       [
@@ -658,8 +721,8 @@ test("Operon 3 Developer API adapter previews and applies an exact typed update 
         return {
           ok: true,
           plan: {
-            planDigest: "plan-update-1",
-            recoveryRef: "recovery-update-1",
+            planDigest: updatePlanDigest,
+            recoveryRef: updateRecoveryRef,
             capability: "tasks.update.preview",
             mutationKind: "task.update",
           },
@@ -667,12 +730,9 @@ test("Operon 3 Developer API adapter previews and applies an exact typed update 
       },
       apply: async ({ plan }: { plan: unknown }) => {
         appliedPlan = plan;
-        return {
-          status: "applied" as const,
-          mutationMayHaveApplied: true,
-          retryAllowed: false,
-          receipt: { terminalOutcome: "applied", planDigest: "plan-update-1" },
-        };
+        const result = nextExecution ?? validExecution;
+        nextExecution = null;
+        return result;
       },
     },
   };
@@ -708,12 +768,24 @@ test("Operon 3 Developer API adapter previews and applies an exact typed update 
   const result = await adapter.executeMutation(
     "update",
     "abc1234",
-    { description: "Updated bridge" },
+    typedUpdateRequest,
     false,
   );
   assert.equal(result.ok, true);
   assert.equal(result.code, "applied");
-  assert.equal(result.planDigest, "plan-update-1");
+  assert.equal(result.planDigest, updatePlanDigest);
+  assert.equal(result.nativeProof?.kind, "mutation-result");
+  assert.equal(result.nativeProof?.receipt?.mutationKind, "task.update");
+  assert.equal("privateBody" in (result.nativeProof?.receipt ?? {}), false);
+  assert.equal(
+    "contextRevision" in (result.nativeProof?.postflight ?? {}),
+    false,
+  );
+  assert.equal(
+    "privateValue" in
+      (result.nativeProof?.groupResults[0]?.resourceRevisions?.[0] ?? {}),
+    false,
+  );
   assert.deepEqual(previewInput, {
     capability: "tasks.update.preview",
     mutationKind: "task.update",
@@ -729,15 +801,70 @@ test("Operon 3 Developer API adapter previews and applies an exact typed update 
       operation: "update",
       changes: [
         { field: "description", valueType: "text", value: "Updated bridge" },
+        { field: "taskType", valueType: "text", value: "article" },
+        { field: "taskImage", valueType: "text", value: "[[Cover.png]]" },
+        {
+          field: "taskGallery",
+          valueType: "list",
+          value: ["[[One.png]]", "[[Two.png]]"],
+        },
       ],
     },
   });
   assert.deepEqual(appliedPlan, {
-    planDigest: "plan-update-1",
-    recoveryRef: "recovery-update-1",
+    planDigest: updatePlanDigest,
+    recoveryRef: updateRecoveryRef,
     capability: "tasks.update.preview",
     mutationKind: "task.update",
   });
+  const { postflight: _postflight, ...withoutPostflight } = validExecution;
+  nextExecution = {
+    ...withoutPostflight,
+    requestId: "base-update-missing-postflight",
+  };
+  const missingPostflight = await adapter.executeMutation(
+    "update",
+    "abc1234",
+    typedUpdateRequest,
+    false,
+  );
+  assert.equal(missingPostflight.code, "outcome-unknown");
+  assert.equal(missingPostflight.recoveryRef, updateRecoveryRef);
+  assert.equal(missingPostflight.planDigest, updatePlanDigest);
+  assert.equal(missingPostflight.mutationMayHaveApplied, true);
+  assert.equal(missingPostflight.nativeProof, undefined);
+  nextExecution = {
+    ...validExecution,
+    requestId: "base-update-wrong-digest",
+    receipt: { ...validExecution.receipt, planDigest: "c".repeat(64) },
+  };
+  const wrongDigest = await adapter.executeMutation(
+    "update",
+    "abc1234",
+    typedUpdateRequest,
+    false,
+  );
+  assert.equal(wrongDigest.code, "outcome-unknown");
+  assert.equal(wrongDigest.recoveryRef, updateRecoveryRef);
+  assert.equal(wrongDigest.planDigest, updatePlanDigest);
+  assert.equal(wrongDigest.mutationMayHaveApplied, true);
+  assert.equal(wrongDigest.nativeProof, undefined);
+  nextExecution = {
+    ...validExecution,
+    requestId: "base-update-empty-groups",
+    groupResults: [],
+  };
+  const emptyCommittedGroups = await adapter.executeMutation(
+    "update",
+    "abc1234",
+    typedUpdateRequest,
+    false,
+  );
+  assert.equal(emptyCommittedGroups.code, "outcome-unknown");
+  assert.equal(emptyCommittedGroups.recoveryRef, updateRecoveryRef);
+  assert.equal(emptyCommittedGroups.planDigest, updatePlanDigest);
+  assert.equal(emptyCommittedGroups.mutationMayHaveApplied, true);
+  assert.equal(emptyCommittedGroups.nativeProof, undefined);
 });
 
 test("Operon 3 Developer API adapter recovers the same durable mutation plan", async () => {
@@ -1207,4 +1334,873 @@ test("Operon 3 Developer API adapter refuses an explicitly truncated page withou
     (await adapter.indexer.getIndexV8Diagnostics()).health,
     "degraded",
   );
+});
+
+test("Operon 3.5 preserves scalar task media fields and ordered taskGallery arrays", async () => {
+  const api = {
+    hasCapability: (name: string) =>
+      [
+        "system.health",
+        "system.capabilities",
+        "catalog.read",
+        "tasks.read",
+        "tasks.query",
+      ].includes(name),
+    channel: { status: readyStatus },
+    system: {
+      health: async () => ({
+        ok: true,
+        contextRevision: { index: { ramGeneration: 35 } },
+      }),
+      capabilities: () => [],
+      diagnostics: async () => ({ ok: true }),
+    },
+    catalog: {
+      snapshot: async () => ({
+        ok: true,
+        taxonomy: { pipelines: [], priorities: [] },
+        fields: [
+          {
+            canonicalKey: "taskType",
+            displayName: "Task Type",
+            valueType: "text",
+            source: "built-in",
+            mappingStatus: "mapped",
+            mutationClass: "general-update",
+            readable: true,
+          },
+          {
+            canonicalKey: "taskImage",
+            displayName: "Task Image",
+            valueType: "text",
+            source: "built-in",
+            mappingStatus: "mapped",
+            mutationClass: "general-update",
+            readable: true,
+          },
+          {
+            canonicalKey: "taskGallery",
+            displayName: "Task Gallery",
+            valueType: "list",
+            source: "built-in",
+            mappingStatus: "mapped",
+            mutationClass: "general-update",
+            readable: true,
+          },
+        ],
+        policies: { creation: {} },
+      }),
+    },
+    tasks: {
+      query: async () => ({
+        ok: true,
+        tasks: [
+          {
+            identity: { operonId: "med1234" },
+            description: "Media task",
+            representation: "inline",
+            locator: {
+              representation: "inline",
+              filePath: "Projects/Media.md",
+              lineNumber: 2,
+            },
+            checkbox: "open",
+            writableFields: [
+              {
+                canonicalKey: "taskType",
+                valueType: "text",
+                present: true,
+                value: "article",
+              },
+              {
+                canonicalKey: "taskImage",
+                valueType: "text",
+                present: true,
+                value: "[[Cover.png]]",
+              },
+              {
+                canonicalKey: "taskGallery",
+                valueType: "list",
+                present: true,
+                value: ["[[A;B.png]]", "https://example.test/two.png"],
+              },
+            ],
+          },
+        ],
+        page: { truncated: false },
+        contextRevision: { index: { ramGeneration: 35 } },
+      }),
+    },
+  };
+  const adapter = new OperonDeveloperApiRuntimeAdapter(consumer, {
+    getDeveloperApiV1: () => ({ ok: true, status: readyStatus(), api }),
+  });
+  assert.equal(await adapter.refresh(), true);
+  const task = adapter.indexer.getTask("med1234");
+  assert.equal(task?.fieldValues.taskType, "article");
+  assert.equal(task?.fieldValues.taskImage, "[[Cover.png]]");
+  assert.deepEqual(task?.fieldValues.taskGallery, [
+    "[[A;B.png]]",
+    "https://example.test/two.png",
+  ]);
+});
+
+test("Operon 3.5 negotiates exact additive workflow grants and keeps opaque plans session-bound", async () => {
+  const requestedCapabilitySets: string[][] = [];
+  const previewInputs: Record<string, unknown>[] = [];
+  const previewHandles: unknown[] = [];
+  const appliedHandles: unknown[] = [];
+  let pendingRecoveryCalls = 0;
+  let recoveryCalls = 0;
+  let nextWorkflowResult: Record<string, unknown> | null = null;
+  let nextWorkflowPlan: Record<string, unknown> | null = null;
+  let nextWorkflowPreviewError: Record<string, unknown> | null = null;
+  const rawTasks: Record<string, unknown>[] = [];
+  const workflowDigests = {
+    adopt: "a".repeat(64),
+    "periodic-create": "b".repeat(64),
+    "periodic-update": "c".repeat(64),
+  } as const;
+  const workflowRecoveryRefs = {
+    adopt: `dvr1_${"a".repeat(48)}`,
+    "periodic-create": `dvr1_${"b".repeat(48)}`,
+    "periodic-update": `dvr1_${"c".repeat(48)}`,
+  } as const;
+  const workflowCapabilities = {
+    adopt: "tasks.adopt.preview",
+    "periodic-create": "tasks.create.periodic-note.preview",
+    "periodic-update": "tasks.update.periodic-note.preview",
+  } as const;
+  const workflowMutationKinds = {
+    adopt: "task.adopt",
+    "periodic-create": "task.create",
+    "periodic-update": "task.update",
+  } as const;
+  const api = {
+    hasCapability: (name: string) =>
+      [
+        "system.health",
+        "system.capabilities",
+        "catalog.read",
+        "tasks.read",
+        "tasks.query",
+      ].includes(name),
+    channel: { status: readyStatus },
+    system: {
+      health: async () => ({
+        ok: true,
+        contextRevision: { index: { ramGeneration: 350 } },
+      }),
+      capabilities: () => [],
+      diagnostics: async () => ({ ok: true }),
+    },
+    catalog: {
+      snapshot: async () => ({
+        ok: true,
+        taxonomy: { pipelines: [], priorities: [] },
+        fields: [],
+        policies: { creation: {} },
+      }),
+    },
+    tasks: {
+      query: async () => ({
+        ok: true,
+        tasks: rawTasks,
+        page: { truncated: false },
+        contextRevision: { index: { ramGeneration: 350 } },
+      }),
+    },
+  };
+  const makeMethods = (
+    kind: "adopt" | "periodic-create" | "periodic-update",
+  ) => ({
+    preview: async (input: Record<string, unknown>) => {
+      previewInputs.push(input);
+      if (nextWorkflowPreviewError) {
+        const error = nextWorkflowPreviewError;
+        nextWorkflowPreviewError = null;
+        return {
+          contractVersion: 1,
+          kind: "task-workflow-developer-mutation-preview-result",
+          requestId: `preview-${kind}-${previewInputs.length}`,
+          ok: false,
+          warnings: [],
+          error,
+        };
+      }
+      const plan = nextWorkflowPlan ?? {
+        contractVersion: 1,
+        kind: "task-workflow-developer-mutation-plan",
+        recoveryRef: workflowRecoveryRefs[kind],
+        planDigest: workflowDigests[kind],
+        createdAt: "2026-08-23T00:00:00.000Z",
+        expiresAt: "2026-08-23T00:05:00.000Z",
+        riskLevel: "routine",
+        requiresConsent: false,
+      };
+      nextWorkflowPlan = null;
+      previewHandles.push(plan);
+      return {
+        contractVersion: 1,
+        kind: "task-workflow-developer-mutation-preview-result",
+        requestId: `preview-${kind}-${previewInputs.length}`,
+        ok: true,
+        plan,
+        warnings: [],
+      };
+    },
+    apply: async ({ plan }: { plan: unknown }) => {
+      appliedHandles.push(plan);
+      if (nextWorkflowResult) {
+        const result = nextWorkflowResult;
+        nextWorkflowResult = null;
+        return result;
+      }
+      if (kind === "adopt") {
+        rawTasks.push({
+          identity: { operonId: "adp1234" },
+          description: "Adopt me",
+          representation: "inline",
+          locator: {
+            representation: "inline",
+            filePath: "Inbox.md",
+            lineNumber: 4,
+          },
+          checkbox: "open",
+        });
+      }
+      if (kind === "periodic-create") {
+        rawTasks.push(
+          {
+            identity: { operonId: "day1234" },
+            description: "Same periodic task",
+            representation: "inline",
+            locator: {
+              representation: "inline",
+              filePath: "Daily/2026-08-24.md",
+              lineNumber: 4,
+            },
+            checkbox: "open",
+            priority: { id: "priority-a", label: "A" },
+          },
+          {
+            identity: { operonId: "week123" },
+            description: "Same periodic task",
+            representation: "inline",
+            locator: {
+              representation: "inline",
+              filePath: "Weekly/2026-W35.md",
+              lineNumber: 4,
+            },
+            checkbox: "open",
+            priority: { id: "priority-b", label: "B" },
+          },
+        );
+      }
+      const planDigest = (plan as { planDigest: string }).planDigest;
+      return {
+        contractVersion: 1,
+        kind: "task-workflow-developer-mutation-execution-result",
+        requestId: `apply-${kind}-${appliedHandles.length}`,
+        status: "applied",
+        mutationMayHaveApplied: true,
+        retryAllowed: false,
+        receipt: {
+          contractVersion: 1,
+          planDigest,
+          mutationKind: workflowMutationKinds[kind],
+          targetDigest: "d".repeat(64),
+          terminalOutcome: "applied",
+          effectiveAt: "2026-08-23T00:00:01.000Z",
+          completedAt: "2026-08-23T00:00:02.000Z",
+          expiresAt: "2026-08-23T00:05:00.000Z",
+          secretBody: "must-not-cross-bridge",
+        },
+        postflight: {
+          status: "verified",
+          observedAt: "2026-08-23T00:00:02.000Z",
+          contextRevision: { privateFingerprint: "must-not-cross-bridge" },
+        },
+        groupResults: [
+          {
+            groupId: `group-${kind}`,
+            status: "committed",
+            error: { message: "must-not-cross-bridge" },
+            ...(kind === "periodic-create"
+              ? {
+                  resourceRevisions: [
+                    {
+                      resourceKind: "task-source",
+                      resourceKey: "Daily/2026-08-24.md",
+                      revision: "sha256:daily",
+                      privateValue: "must-not-cross-bridge",
+                    },
+                  ],
+                }
+              : {}),
+          },
+        ],
+      };
+    },
+    recover: async ({ recoveryRef }: { recoveryRef: string }) => {
+      recoveryCalls += 1;
+      return {
+        contractVersion: 1,
+        kind: "task-workflow-developer-mutation-execution-result",
+        requestId: `recover-${kind}-${recoveryCalls}`,
+        status: "already-applied",
+        mutationMayHaveApplied: true,
+        retryAllowed: false,
+        receipt: {
+          contractVersion: 1,
+          planDigest: workflowDigests[kind],
+          mutationKind: workflowMutationKinds[kind],
+          targetDigest: "d".repeat(64),
+          terminalOutcome: "already-applied",
+          effectiveAt: "2026-08-23T00:00:01.000Z",
+          completedAt: "2026-08-23T00:00:02.000Z",
+          expiresAt: "2026-08-23T00:05:00.000Z",
+        },
+        postflight: { status: "receipt-replay" },
+        groupResults: [],
+      };
+    },
+    pendingRecoveries: async () => {
+      pendingRecoveryCalls += 1;
+      return {
+        contractVersion: 1,
+        kind: "task-workflow-developer-pending-recoveries-result",
+        ok: true,
+        recoveries: [
+          {
+            recoveryRef: workflowRecoveryRefs[kind],
+            planDigest: workflowDigests[kind],
+            createdAt: "2026-08-23T00:00:00.000Z",
+            expiresAt: "2026-08-23T00:05:00.000Z",
+          },
+        ],
+      };
+    },
+  });
+  const methods = {
+    adopt: makeMethods("adopt"),
+    createPeriodicNote: makeMethods("periodic-create"),
+    updatePeriodicNote: makeMethods("periodic-update"),
+  };
+  const taskWorkflowAccess = (tasks: Record<string, unknown>) => ({
+    contractVersion: 1,
+    kind: "task-workflow-developer-api-access-result",
+    ok: true,
+    api: { contractVersion: 1, runtimeApi: 1, tasks },
+  });
+  const operon = {
+    getDeveloperApiV1: () => ({ ok: true, status: readyStatus(), api }),
+    getTaskWorkflowDeveloperApiV1: (
+      _candidate: unknown,
+      request: { requestedCapabilities: readonly string[] },
+    ) => {
+      requestedCapabilitySets.push([...request.requestedCapabilities]);
+      if (request.requestedCapabilities[0] === "tasks.filter-query") {
+        return taskWorkflowAccess({
+          filterQuery: async (input: Record<string, unknown>) => ({
+            contractVersion: 1,
+            kind: "task-filter-query-result",
+            requestId: input.requestId,
+            ok: true,
+            tasks: [],
+          }),
+        });
+      }
+      if (request.requestedCapabilities[0] === "tasks.adopt.preview") {
+        return taskWorkflowAccess({ adopt: methods.adopt });
+      }
+      if (
+        request.requestedCapabilities[0] ===
+        "tasks.create.periodic-note.preview"
+      ) {
+        return taskWorkflowAccess({
+          createPeriodicNote: methods.createPeriodicNote,
+        });
+      }
+      return taskWorkflowAccess({
+        updatePeriodicNote: methods.updatePeriodicNote,
+      });
+    },
+  };
+  const adapter = new OperonDeveloperApiRuntimeAdapter(consumer, operon);
+  assert.equal(await adapter.refresh(true), true);
+  assert.equal(adapter.hasTaskWorkflowCapability("adopt"), true);
+  assert.equal(adapter.hasTaskWorkflowCapability("periodic-create"), true);
+  assert.equal(adapter.hasTaskWorkflowCapability("periodic-update"), true);
+  assert.deepEqual(requestedCapabilitySets.slice(-3), [
+    ["tasks.adopt.preview", "tasks.adopt.apply"],
+    ["tasks.create.periodic-note.preview", "tasks.create.periodic-note.apply"],
+    ["tasks.update.periodic-note.preview", "tasks.update.periodic-note.apply"],
+  ]);
+  const adopted = await adapter.executeTaskWorkflow(
+    "adopt",
+    {
+      targetPath: "Inbox.md",
+      line: 5,
+      expectedLine: "- [ ] Adopt me",
+    },
+    false,
+  );
+  assert.equal(adopted.ok, true);
+  assert.equal(adopted.operonId, "adp1234");
+  assert.deepEqual(previewInputs[0], {
+    operation: "adopt-inline",
+    source: {
+      filePath: "Inbox.md",
+      lineNumber: 4,
+      expectedLine: "- [ ] Adopt me",
+    },
+  });
+  assert.equal(appliedHandles[0], previewHandles[0]);
+  const periodicCreate = await adapter.executeTaskWorkflow(
+    "periodic-create",
+    {
+      description: "Daily focus",
+      periodicKind: "daily",
+      routeDate: "2026-08-23",
+      priorityId: "priority-a",
+      fields: { taskGallery: ["[[One;A.png]]", "[[Two.png]]"] },
+    },
+    true,
+  );
+  assert.equal(periodicCreate.code, "planned");
+  assert.deepEqual(
+    (previewInputs[1]?.items as Record<string, unknown>[])[0]?.target,
+    {
+      representation: "inline",
+      mode: "periodic-note",
+      periodicKind: "daily",
+      routeDate: "2026-08-23",
+    },
+  );
+  assert.deepEqual(
+    (previewInputs[1]?.items as Record<string, unknown>[])[0]?.fields,
+    [
+      {
+        kind: "list",
+        field: "taskGallery",
+        value: ["[[One;A.png]]", "[[Two.png]]"],
+      },
+    ],
+  );
+  assert.equal(
+    (previewInputs[1]?.items as Record<string, unknown>[])[0]?.priorityId,
+    "priority-a",
+  );
+  const periodicUpdate = await adapter.executeTaskWorkflow(
+    "periodic-update",
+    {
+      operonId: "adp1234",
+      fields: { dateScheduled: "2026-08-25" },
+    },
+    true,
+  );
+  assert.equal(periodicUpdate.code, "planned");
+  assert.equal(previewInputs[2]?.operation, "update-periodic-note");
+  assert.deepEqual(previewInputs[2]?.changes, [
+    {
+      field: "dateScheduled",
+      valueType: "date",
+      value: "2026-08-25",
+    },
+  ]);
+  const periodicDetach = await adapter.executeTaskWorkflow(
+    "periodic-update",
+    {
+      operonId: "adp1234",
+      fields: { dateScheduled: null },
+    },
+    true,
+  );
+  assert.equal(periodicDetach.code, "planned");
+  assert.deepEqual(previewInputs[3]?.changes, [
+    {
+      operation: "clear",
+      field: "dateScheduled",
+      valueType: "date",
+    },
+  ]);
+  const extraPeriodicField = await adapter.executeTaskWorkflow(
+    "periodic-update",
+    {
+      operonId: "adp1234",
+      fields: {
+        dateScheduled: "2026-08-26",
+        taskGallery: ["[[Nope.png]]"],
+      },
+    },
+    true,
+  );
+  assert.equal(extraPeriodicField.code, "invalid-input");
+  assert.equal(previewInputs.length, 4);
+  const appliedBeforeStalePreview = appliedHandles.length;
+  nextWorkflowPreviewError = {
+    code: "stale-source",
+    reason: "The exact inline source line changed before preview.",
+  };
+  const staleAdoption = await adapter.executeTaskWorkflow(
+    "adopt",
+    {
+      targetPath: "Inbox.md",
+      line: 5,
+      expectedLine: "- [ ] Adopt me",
+    },
+    false,
+  );
+  assert.equal(staleAdoption.code, "conflict");
+  assert.equal(staleAdoption.mutationMayHaveApplied, undefined);
+  assert.equal(appliedHandles.length, appliedBeforeStalePreview);
+  nextWorkflowPreviewError = {
+    code: "authority-insufficient",
+    reason: "The exact task-workflow grant is no longer active.",
+  };
+  const revokedAdoption = await adapter.executeTaskWorkflow(
+    "adopt",
+    {
+      targetPath: "Inbox.md",
+      line: 5,
+      expectedLine: "- [ ] Adopt me",
+    },
+    false,
+  );
+  assert.equal(revokedAdoption.code, "not-ready");
+  assert.equal(appliedHandles.length, appliedBeforeStalePreview);
+  const appliedBeforeRevisionConflict = appliedHandles.length;
+  const revisionConflict = await adapter.executeTaskWorkflow(
+    "periodic-update",
+    {
+      operonId: "adp1234",
+      fields: { dateScheduled: "2026-08-27" },
+    },
+    false,
+    async () => ({
+      ok: false,
+      message: "fixture revision changed after preview",
+    }),
+  );
+  assert.equal(revisionConflict.code, "conflict");
+  assert.equal(revisionConflict.mutationMayHaveApplied, false);
+  assert.equal(appliedHandles.length, appliedBeforeRevisionConflict);
+  const validPeriodicUpdatePlan = {
+    contractVersion: 1,
+    kind: "task-workflow-developer-mutation-plan",
+    recoveryRef: workflowRecoveryRefs["periodic-update"],
+    planDigest: workflowDigests["periodic-update"],
+    createdAt: "2026-08-23T00:00:00.000Z",
+    expiresAt: "2026-08-23T00:05:00.000Z",
+    riskLevel: "routine",
+    requiresConsent: false,
+  };
+  const appliedBeforeInvalidPlans = appliedHandles.length;
+  nextWorkflowPlan = {
+    ...validPeriodicUpdatePlan,
+    planDigest: workflowDigests["periodic-update"].toUpperCase(),
+  };
+  const uppercasePlanDigest = await adapter.executeTaskWorkflow(
+    "periodic-update",
+    { operonId: "adp1234", fields: { dateScheduled: "2026-08-27" } },
+    false,
+  );
+  assert.equal(uppercasePlanDigest.code, "failed");
+  assert.equal(uppercasePlanDigest.mutationMayHaveApplied, false);
+  nextWorkflowPlan = { ...validPeriodicUpdatePlan, spec: { private: true } };
+  const privatePlanField = await adapter.executeTaskWorkflow(
+    "periodic-update",
+    { operonId: "adp1234", fields: { dateScheduled: "2026-08-27" } },
+    false,
+  );
+  assert.equal(privatePlanField.code, "failed");
+  nextWorkflowPlan = {
+    ...validPeriodicUpdatePlan,
+    targets: [
+      {
+        operonId: "adp1234",
+        locator: {
+          representation: "inline",
+          filePath: "Daily/2026-08-23.md",
+          lineNumber: 7,
+          privateOffset: 42,
+        },
+      },
+    ],
+  };
+  const privateTargetField = await adapter.executeTaskWorkflow(
+    "periodic-update",
+    { operonId: "adp1234", fields: { dateScheduled: "2026-08-27" } },
+    false,
+  );
+  assert.equal(privateTargetField.code, "failed");
+  assert.equal(privateTargetField.mutationMayHaveApplied, false);
+  assert.equal(appliedHandles.length, appliedBeforeInvalidPlans);
+  const invalidTerminalBase = {
+    contractVersion: 1,
+    kind: "task-workflow-developer-mutation-execution-result",
+    requestId: "invalid-terminal-fixture",
+    status: "applied",
+    mutationMayHaveApplied: true,
+    retryAllowed: false,
+    receipt: {
+      contractVersion: 1,
+      planDigest: workflowDigests["periodic-update"],
+      mutationKind: "task.update",
+      targetDigest: "d".repeat(64),
+      terminalOutcome: "applied",
+      effectiveAt: "2026-08-23T00:00:01.000Z",
+      completedAt: "2026-08-23T00:00:02.000Z",
+      expiresAt: "2026-08-23T00:05:00.000Z",
+    },
+    groupResults: [{ groupId: "periodic-update", status: "committed" }],
+  };
+  nextWorkflowResult = invalidTerminalBase;
+  const missingPostflight = await adapter.executeTaskWorkflow(
+    "periodic-update",
+    { operonId: "adp1234", fields: { dateScheduled: "2026-08-28" } },
+    false,
+  );
+  assert.equal(missingPostflight.code, "outcome-unknown");
+  assert.equal(missingPostflight.mutationMayHaveApplied, true);
+  nextWorkflowResult = {
+    ...invalidTerminalBase,
+    receipt: {
+      ...invalidTerminalBase.receipt,
+      planDigest: "f".repeat(64),
+    },
+    postflight: {
+      status: "verified",
+      observedAt: "2026-08-23T00:00:02.000Z",
+    },
+  };
+  const substitutedDigest = await adapter.executeTaskWorkflow(
+    "periodic-update",
+    { operonId: "adp1234", fields: { dateScheduled: "2026-08-29" } },
+    false,
+  );
+  assert.equal(substitutedDigest.code, "outcome-unknown");
+  nextWorkflowResult = {
+    ...invalidTerminalBase,
+    postflight: {
+      status: "verified",
+      observedAt: "2026-08-23T00:00:02.000Z",
+    },
+    groupResults: [{ groupId: "periodic-update", status: "failed" }],
+  };
+  const incoherentGroups = await adapter.executeTaskWorkflow(
+    "periodic-update",
+    { operonId: "adp1234", fields: { dateScheduled: "2026-08-30" } },
+    false,
+  );
+  assert.equal(incoherentGroups.code, "outcome-unknown");
+  nextWorkflowResult = {
+    ...invalidTerminalBase,
+    kind: "mutation-result",
+    postflight: {
+      status: "verified",
+      observedAt: "2026-08-23T00:00:02.000Z",
+    },
+  };
+  const privateCoreDiscriminator = await adapter.executeTaskWorkflow(
+    "periodic-update",
+    { operonId: "adp1234", fields: { dateScheduled: "2026-08-31" } },
+    false,
+  );
+  assert.equal(privateCoreDiscriminator.code, "outcome-unknown");
+  assert.match(
+    privateCoreDiscriminator.message ?? "",
+    /task-workflow-developer-mutation-execution-result/u,
+  );
+  nextWorkflowResult = {
+    contractVersion: 1,
+    kind: "task-workflow-developer-mutation-execution-result",
+    requestId: "failed-union-fixture",
+    status: "failed",
+    mutationMayHaveApplied: false,
+    retryAllowed: false,
+    groupResults: [{ groupId: "periodic-update", status: "failed" }],
+    error: { code: "conflict", reason: "official failed union" },
+  };
+  const officialFailedUnion = await adapter.executeTaskWorkflow(
+    "periodic-update",
+    { operonId: "adp1234", fields: { dateScheduled: "2026-09-01" } },
+    false,
+  );
+  assert.equal(officialFailedUnion.code, "conflict");
+  nextWorkflowResult = {
+    contractVersion: 1,
+    kind: "task-workflow-developer-mutation-execution-result",
+    requestId: "uncertain-union-fixture",
+    status: "outcome-unknown",
+    mutationMayHaveApplied: true,
+    retryAllowed: false,
+    groupResults: [
+      { groupId: "periodic-update", status: "outcome-unknown" },
+    ],
+    error: {
+      code: "outcome-unknown",
+      reason: "official uncertain union",
+      retryable: false,
+      action: "recover-same-plan",
+    },
+    recovery: {
+      required: true,
+      action: "recover-same-plan",
+      mutationMayHaveApplied: true,
+      recoveryRef: workflowRecoveryRefs["periodic-update"],
+      planDigest: workflowDigests["periodic-update"],
+      plan: validPeriodicUpdatePlan,
+    },
+  };
+  const officialUncertainUnion = await adapter.executeTaskWorkflow(
+    "periodic-update",
+    { operonId: "adp1234", fields: { dateScheduled: "2026-09-02" } },
+    false,
+  );
+  assert.equal(officialUncertainUnion.code, "outcome-unknown");
+  assert.equal(
+    officialUncertainUnion.recoveryRef,
+    workflowRecoveryRefs["periodic-update"],
+  );
+  const routedPeriodicCreate = await adapter.executeTaskWorkflow(
+    "periodic-create",
+    {
+      description: "Same periodic task",
+      periodicKind: "daily",
+      routeDate: "2026-08-24",
+      priorityId: "priority-a",
+    },
+    false,
+  );
+  assert.equal(routedPeriodicCreate.code, "applied");
+  assert.equal(routedPeriodicCreate.operonId, "day1234");
+  assert.equal(
+    "secretBody" in (routedPeriodicCreate.nativeProof?.receipt ?? {}),
+    false,
+  );
+  assert.equal(
+    "contextRevision" in (routedPeriodicCreate.nativeProof?.postflight ?? {}),
+    false,
+  );
+  assert.equal(
+    "error" in (routedPeriodicCreate.nativeProof?.groupResults[0] ?? {}),
+    false,
+  );
+  assert.equal(
+    "privateValue" in
+      (routedPeriodicCreate.nativeProof?.groupResults[0]?.resourceRevisions?.[0] ??
+        {}),
+    false,
+  );
+  const lossyGallery = await adapter.executeTaskWorkflow(
+    "periodic-create",
+    {
+      description: "Unsafe gallery",
+      periodicKind: "weekly",
+      fields: { taskGallery: "[[One;A.png]]; [[Two.png]]" },
+    },
+    true,
+  );
+  assert.equal(lossyGallery.code, "invalid-input");
+  const pending = await adapter.pendingTaskWorkflowRecoveries("adopt");
+  assert.equal(pending.ok, true);
+  assert.equal(pending.recoveries[0]?.workflowKind, "adopt");
+  const pendingBeforeInvalidDigest = pendingRecoveryCalls;
+  const recoverBeforeInvalidDigest = recoveryCalls;
+  const invalidRecoveryDigest = await adapter.recoverTaskWorkflow(
+    "adopt",
+    workflowRecoveryRefs.adopt,
+    workflowDigests.adopt.toUpperCase(),
+  );
+  assert.equal(invalidRecoveryDigest.code, "invalid-input");
+  assert.equal(pendingRecoveryCalls, pendingBeforeInvalidDigest);
+  assert.equal(recoveryCalls, recoverBeforeInvalidDigest);
+  const recovered = await adapter.recoverTaskWorkflow(
+    "adopt",
+    workflowRecoveryRefs.adopt,
+  );
+  assert.equal(recovered.code, "already-applied");
+});
+
+test("a rejected Operon 3.5 workflow grant does not revoke another workflow or core reads", async () => {
+  const api = {
+    hasCapability: (name: string) =>
+      [
+        "system.health",
+        "system.capabilities",
+        "catalog.read",
+        "tasks.read",
+        "tasks.query",
+      ].includes(name),
+    channel: { status: readyStatus },
+    system: {
+      health: async () => ({
+        ok: true,
+        contextRevision: { index: { ramGeneration: 351 } },
+      }),
+      capabilities: () => [],
+      diagnostics: async () => ({ ok: true }),
+    },
+    catalog: {
+      snapshot: async () => ({
+        ok: true,
+        taxonomy: { pipelines: [], priorities: [] },
+        fields: [],
+        policies: { creation: {} },
+      }),
+    },
+    tasks: {
+      query: async () => ({
+        ok: true,
+        tasks: [],
+        page: { truncated: false },
+        contextRevision: { index: { ramGeneration: 351 } },
+      }),
+    },
+  };
+  const adoption = {
+    preview: async () => ({
+      ok: true,
+      plan: { recoveryRef: "r", planDigest: "p" },
+    }),
+    apply: async () => ({ status: "applied" }),
+  };
+  const adapter = new OperonDeveloperApiRuntimeAdapter(consumer, {
+    getDeveloperApiV1: () => ({ ok: true, status: readyStatus(), api }),
+    getTaskWorkflowDeveloperApiV1: (
+      _candidate: unknown,
+      request: { requestedCapabilities: readonly string[] },
+    ) => {
+      if (request.requestedCapabilities[0] === "tasks.adopt.preview") {
+        return {
+          contractVersion: 1,
+          kind: "task-workflow-developer-api-access-result",
+          ok: true,
+          api: {
+            contractVersion: 1,
+            runtimeApi: 1,
+            tasks: { adopt: adoption },
+          },
+        };
+      }
+      if (
+        request.requestedCapabilities[0] ===
+        "tasks.create.periodic-note.preview"
+      ) {
+        throw new Error("periodic grant pending");
+      }
+      return {
+        contractVersion: 1,
+        kind: "task-workflow-developer-api-access-result",
+        ok: false,
+        error: { code: "authority-insufficient" },
+      };
+    },
+  });
+  assert.equal(await adapter.refresh(true), true);
+  assert.equal(adapter.indexer.getGeneration(), 351);
+  assert.equal(adapter.hasTaskWorkflowCapability("adopt"), true);
+  assert.equal(adapter.hasTaskWorkflowCapability("periodic-create"), false);
 });

--- a/plugins/obsidian-operon-bridge/src/developer-api-adapter.test.ts
+++ b/plugins/obsidian-operon-bridge/src/developer-api-adapter.test.ts
@@ -2160,6 +2160,14 @@ test("Operon 3.5 negotiates exact additive workflow grants and keeps opaque plan
   assert.equal(invalidRecoveryDigest.code, "invalid-input");
   assert.equal(pendingRecoveryCalls, pendingBeforeInvalidDigest);
   assert.equal(recoveryCalls, recoverBeforeInvalidDigest);
+  const wrongRecoveryDigest = await adapter.recoverTaskWorkflow(
+    "adopt",
+    workflowRecoveryRefs.adopt,
+    "f".repeat(64),
+  );
+  assert.equal(wrongRecoveryDigest.code, "invalid-input");
+  assert.equal(pendingRecoveryCalls, pendingBeforeInvalidDigest + 1);
+  assert.equal(recoveryCalls, recoverBeforeInvalidDigest);
   const recovered = await adapter.recoverTaskWorkflow(
     "adopt",
     workflowRecoveryRefs.adopt,

--- a/plugins/obsidian-operon-bridge/src/developer-api-adapter.test.ts
+++ b/plugins/obsidian-operon-bridge/src/developer-api-adapter.test.ts
@@ -1743,7 +1743,18 @@ test("Operon 3.5 negotiates exact additive workflow grants and keeps opaque plan
       });
     },
   };
-  const adapter = new OperonDeveloperApiRuntimeAdapter(consumer, operon);
+  const persistedTaskWorkflowIdentities = new Map<string, string>();
+  const taskWorkflowIdentityStore = {
+    get: (key: string) => persistedTaskWorkflowIdentities.get(key),
+    set: async (key: string, operonId: string) => {
+      persistedTaskWorkflowIdentities.set(key, operonId);
+    },
+  };
+  const adapter = new OperonDeveloperApiRuntimeAdapter(
+    consumer,
+    operon,
+    taskWorkflowIdentityStore,
+  );
   assert.equal(await adapter.refresh(true), true);
   assert.equal(adapter.hasTaskWorkflowCapability("adopt"), true);
   assert.equal(adapter.hasTaskWorkflowCapability("periodic-create"), true);
@@ -2203,9 +2214,25 @@ test("Operon 3.5 negotiates exact additive workflow grants and keeps opaque plan
   assert.equal(replayedPeriodicCreate.code, "already-applied");
   assert.equal(replayedPeriodicCreate.operonId, "day1234");
 
+  const originalPeriodicTask = rawTasks.find(
+    (task) =>
+      (task.identity as { operonId?: string } | undefined)?.operonId ===
+      "day1234",
+  );
+  assert.ok(originalPeriodicTask);
+  rawTasks.push({
+    ...originalPeriodicTask,
+    identity: { operonId: "dup1234" },
+    locator: {
+      representation: "inline",
+      filePath: "Daily/2026-08-25.md",
+      lineNumber: 4,
+    },
+  });
   const restartedAdapter = new OperonDeveloperApiRuntimeAdapter(
     consumer,
     operon,
+    taskWorkflowIdentityStore,
   );
   assert.equal(await restartedAdapter.refresh(true), true);
   nextWorkflowResult = alreadyAppliedResult("periodic-create");

--- a/plugins/obsidian-operon-bridge/src/developer-api-adapter.test.ts
+++ b/plugins/obsidian-operon-bridge/src/developer-api-adapter.test.ts
@@ -1582,6 +1582,14 @@ test("Operon 3.5 negotiates exact additive workflow grants and keeps opaque plan
             },
             checkbox: "open",
             priority: { id: "priority-a", label: "A" },
+            writableFields: [
+              {
+                canonicalKey: "tags",
+                valueType: "list",
+                present: true,
+                value: ["work", "focus"],
+              },
+            ],
           },
           {
             identity: { operonId: "week123" },
@@ -1594,6 +1602,14 @@ test("Operon 3.5 negotiates exact additive workflow grants and keeps opaque plan
             },
             checkbox: "open",
             priority: { id: "priority-b", label: "B" },
+            writableFields: [
+              {
+                canonicalKey: "tags",
+                valueType: "list",
+                present: true,
+                value: ["work", "focus"],
+              },
+            ],
           },
         );
       }
@@ -2082,11 +2098,16 @@ test("Operon 3.5 negotiates exact additive workflow grants and keeps opaque plan
       periodicKind: "daily",
       routeDate: "2026-08-24",
       priorityId: "priority-a",
+      tags: ["work", "#work", " #focus ", "#focus"],
     },
     false,
   );
   assert.equal(routedPeriodicCreate.code, "applied");
   assert.equal(routedPeriodicCreate.operonId, "day1234");
+  assert.deepEqual(
+    (previewInputs.at(-1)?.items as Record<string, unknown>[])[0]?.tags,
+    ["work", "focus"],
+  );
   assert.equal(
     "secretBody" in (routedPeriodicCreate.nativeProof?.receipt ?? {}),
     false,
@@ -2133,6 +2154,74 @@ test("Operon 3.5 negotiates exact additive workflow grants and keeps opaque plan
     workflowRecoveryRefs.adopt,
   );
   assert.equal(recovered.code, "already-applied");
+
+  const alreadyAppliedResult = (
+    kind: "adopt" | "periodic-create",
+  ): Record<string, unknown> => ({
+    contractVersion: 1,
+    kind: "task-workflow-developer-mutation-execution-result",
+    requestId: `replay-${kind}`,
+    status: "already-applied",
+    mutationMayHaveApplied: true,
+    retryAllowed: false,
+    receipt: {
+      contractVersion: 1,
+      planDigest: workflowDigests[kind],
+      mutationKind: workflowMutationKinds[kind],
+      targetDigest: "d".repeat(64),
+      terminalOutcome: "already-applied",
+      effectiveAt: "2026-08-23T00:00:01.000Z",
+      completedAt: "2026-08-23T00:00:02.000Z",
+      expiresAt: "2026-08-23T00:05:00.000Z",
+    },
+    postflight: { status: "receipt-replay" },
+    groupResults: [],
+  });
+  nextWorkflowResult = alreadyAppliedResult("adopt");
+  const replayedAdoption = await adapter.executeTaskWorkflow(
+    "adopt",
+    {
+      targetPath: "Inbox.md",
+      line: 5,
+      expectedLine: "- [ ] Adopt me",
+    },
+    false,
+  );
+  assert.equal(replayedAdoption.code, "already-applied");
+  assert.equal(replayedAdoption.operonId, "adp1234");
+  nextWorkflowResult = alreadyAppliedResult("periodic-create");
+  const replayedPeriodicCreate = await adapter.executeTaskWorkflow(
+    "periodic-create",
+    {
+      description: "Same periodic task",
+      periodicKind: "daily",
+      routeDate: "2026-08-24",
+      priorityId: "priority-a",
+    },
+    false,
+  );
+  assert.equal(replayedPeriodicCreate.code, "already-applied");
+  assert.equal(replayedPeriodicCreate.operonId, "day1234");
+
+  const restartedAdapter = new OperonDeveloperApiRuntimeAdapter(
+    consumer,
+    operon,
+  );
+  assert.equal(await restartedAdapter.refresh(true), true);
+  nextWorkflowResult = alreadyAppliedResult("periodic-create");
+  const replayedPeriodicCreateAfterRestart =
+    await restartedAdapter.executeTaskWorkflow(
+      "periodic-create",
+      {
+        description: "Same periodic task",
+        periodicKind: "daily",
+        routeDate: "2026-08-24",
+        priorityId: "priority-a",
+      },
+      false,
+    );
+  assert.equal(replayedPeriodicCreateAfterRestart.code, "already-applied");
+  assert.equal(replayedPeriodicCreateAfterRestart.operonId, "day1234");
 });
 
 test("a rejected Operon 3.5 workflow grant does not revoke another workflow or core reads", async () => {

--- a/plugins/obsidian-operon-bridge/src/developer-api-adapter.ts
+++ b/plugins/obsidian-operon-bridge/src/developer-api-adapter.ts
@@ -1179,6 +1179,7 @@ export class OperonDeveloperApiRuntimeAdapter {
     TaskWorkflowDeveloperApiV1
   >();
   private readonly taskWorkflowRecoveryDigests = new Map<string, string>();
+  private readonly taskWorkflowIdentityByPlanDigest = new Map<string, string>();
   private grantedCapabilities: ReadonlySet<string> | null = null;
   private refreshInFlight: Promise<boolean> | null = null;
   private contractState: "unverified" | "valid" | "invalid" = "unverified";
@@ -2366,9 +2367,18 @@ export class OperonDeveloperApiRuntimeAdapter {
       const lineNumber = Number(requested.line) - 1;
       try {
         const live = await this.reloadLiveTasks();
+        const replayedIdentity =
+          execution.status === "already-applied"
+            ? this.taskWorkflowIdentityByPlanDigest.get(
+                `${kind}:${preview.plan.planDigest}`,
+              )
+            : undefined;
         const adopted = live.rawTasks.filter(
           (task) =>
-            !beforeIds.has(task.identity.operonId) &&
+            (replayedIdentity
+              ? task.identity.operonId === replayedIdentity
+              : execution.status === "already-applied" ||
+                !beforeIds.has(task.identity.operonId)) &&
             task.representation === "inline" &&
             task.locator.representation === "inline" &&
             task.locator.filePath === targetPath &&
@@ -2379,6 +2389,11 @@ export class OperonDeveloperApiRuntimeAdapter {
             "no unique adopted task is visible at the sealed source line",
           );
         }
+        this.rememberTaskWorkflowIdentity(
+          kind,
+          preview.plan.planDigest,
+          adopted[0]!.identity.operonId,
+        );
         return { ...terminal, operonId: adopted[0]!.identity.operonId };
       } catch (error) {
         return this.mutationFailure(
@@ -2398,20 +2413,34 @@ export class OperonDeveloperApiRuntimeAdapter {
     if (kind === "periodic-create") {
       try {
         const live = await this.reloadLiveTasks();
-        const description = String(requested.description ?? "").trim();
         const provenResourceKeys = this.taskWorkflowResourceKeys(execution);
+        const replayedIdentity =
+          execution.status === "already-applied"
+            ? this.taskWorkflowIdentityByPlanDigest.get(
+                `${kind}:${preview.plan.planDigest}`,
+              )
+            : undefined;
         const created = live.rawTasks.filter(
           (task) =>
-            !beforeIds.has(task.identity.operonId) &&
             task.representation === "inline" &&
-            task.description === description &&
-            provenResourceKeys.has(task.locator.filePath),
+            this.periodicCreatedTaskMatchesRequest(task, requested) &&
+            (execution.status === "already-applied"
+              ? replayedIdentity
+                ? task.identity.operonId === replayedIdentity
+                : beforeIds.has(task.identity.operonId)
+              : !beforeIds.has(task.identity.operonId) &&
+                provenResourceKeys.has(task.locator.filePath)),
         );
         if (created.length !== 1) {
           throw new Error(
             "no unique periodic task is linked to the committed native resource evidence",
           );
         }
+        this.rememberTaskWorkflowIdentity(
+          kind,
+          preview.plan.planDigest,
+          created[0]!.identity.operonId,
+        );
         return { ...terminal, operonId: created[0]!.identity.operonId };
       } catch (error) {
         return this.mutationFailure(
@@ -3131,6 +3160,67 @@ export class OperonDeveloperApiRuntimeAdapter {
       }
     }
     return keys;
+  }
+
+  private rememberTaskWorkflowIdentity(
+    kind: DeveloperApiTaskWorkflowKind,
+    planDigest: string,
+    operonId: string,
+  ): void {
+    const key = `${kind}:${planDigest}`;
+    this.taskWorkflowIdentityByPlanDigest.delete(key);
+    this.taskWorkflowIdentityByPlanDigest.set(key, operonId);
+    if (this.taskWorkflowIdentityByPlanDigest.size <= 512) return;
+    const oldest = this.taskWorkflowIdentityByPlanDigest.keys().next().value;
+    if (typeof oldest === "string")
+      this.taskWorkflowIdentityByPlanDigest.delete(oldest);
+  }
+
+  private periodicCreatedTaskMatchesRequest(
+    task: DeveloperApiTask,
+    requested: Record<string, unknown>,
+  ): boolean {
+    if (task.description !== String(requested.description ?? "").trim())
+      return false;
+    const fields = isRecord(requested.fields) ? requested.fields : {};
+    const requestedPriorityId =
+      String(requested.priorityId ?? "").trim() ||
+      (Object.prototype.hasOwnProperty.call(fields, "priority")
+        ? this.resolvePriorityId(fields.priority)
+        : null);
+    if (requestedPriorityId && task.priority?.id !== requestedPriorityId)
+      return false;
+    const requestedStatusId =
+      String(requested.statusId ?? "").trim() ||
+      (Object.prototype.hasOwnProperty.call(fields, "status")
+        ? this.resolveStatusId(fields.status)
+        : null);
+    if (requestedStatusId && task.workflow?.status.id !== requestedStatusId)
+      return false;
+    const runtime = toRuntimeTask(task);
+    if (Array.isArray(requested.tags)) {
+      const normalizeTags = (values: readonly unknown[]) =>
+        [
+          ...new Set(
+            values
+              .map(String)
+              .map((tag) => tag.trim().replace(/^#/u, "").trim())
+              .filter(Boolean),
+          ),
+        ].sort();
+      if (
+        JSON.stringify(normalizeTags(runtime.tags)) !==
+        JSON.stringify(normalizeTags(requested.tags))
+      ) return false;
+    }
+    for (const [field, value] of Object.entries(fields)) {
+      if (field === "priority" || field === "status") continue;
+      const canonical = this.canonicalField(field);
+      const expected = fieldValue(value);
+      const actual = runtime.fieldValues[canonical];
+      if (JSON.stringify(actual) !== JSON.stringify(expected)) return false;
+    }
+    return true;
   }
 
   private taskWorkflowResultViolation(
@@ -4046,10 +4136,14 @@ export class OperonDeveloperApiRuntimeAdapter {
       });
     }
     if (Array.isArray(requested.tags)) {
-      const tags = requested.tags
-        .map(String)
-        .map((tag) => tag.replace(/^#/u, "").trim())
-        .filter(Boolean);
+      const tags = [
+        ...new Set(
+          requested.tags
+            .map(String)
+            .map((tag) => tag.trim().replace(/^#/u, "").trim())
+            .filter(Boolean),
+        ),
+      ];
       return {
         capability: "tasks.create.preview",
         mutationKind: "task.create",

--- a/plugins/obsidian-operon-bridge/src/developer-api-adapter.ts
+++ b/plugins/obsidian-operon-bridge/src/developer-api-adapter.ts
@@ -25,6 +25,11 @@ export interface DeveloperApiConsumerPlugin {
   };
 }
 
+export interface TaskWorkflowIdentityStore {
+  get(key: string): string | undefined;
+  set(key: string, operonId: string): void | Promise<void>;
+}
+
 interface DeveloperApiError {
   readonly code?: string;
   readonly reason?: string;
@@ -1187,6 +1192,7 @@ export class OperonDeveloperApiRuntimeAdapter {
   constructor(
     private readonly consumerPlugin: DeveloperApiConsumerPlugin,
     operonPlugin: unknown,
+    private readonly taskWorkflowIdentityStore?: TaskWorkflowIdentityStore,
   ) {
     this.accessor = isDeveloperApiAccessor(operonPlugin) ? operonPlugin : null;
     this.taskWorkflowAccessor = isTaskWorkflowDeveloperApiAccessor(operonPlugin)
@@ -2369,8 +2375,9 @@ export class OperonDeveloperApiRuntimeAdapter {
         const live = await this.reloadLiveTasks();
         const replayedIdentity =
           execution.status === "already-applied"
-            ? this.taskWorkflowIdentityByPlanDigest.get(
-                `${kind}:${preview.plan.planDigest}`,
+            ? this.taskWorkflowIdentity(
+                kind,
+                preview.plan.planDigest,
               )
             : undefined;
         const adopted = live.rawTasks.filter(
@@ -2389,7 +2396,7 @@ export class OperonDeveloperApiRuntimeAdapter {
             "no unique adopted task is visible at the sealed source line",
           );
         }
-        this.rememberTaskWorkflowIdentity(
+        await this.rememberTaskWorkflowIdentity(
           kind,
           preview.plan.planDigest,
           adopted[0]!.identity.operonId,
@@ -2397,7 +2404,7 @@ export class OperonDeveloperApiRuntimeAdapter {
         return { ...terminal, operonId: adopted[0]!.identity.operonId };
       } catch (error) {
         return this.mutationFailure(
-          "failed",
+          "outcome-unknown",
           `Operon applied adoption, but the adopted identity could not be proven: ${error instanceof Error ? error.message : String(error)}`,
           null,
           false,
@@ -2416,8 +2423,9 @@ export class OperonDeveloperApiRuntimeAdapter {
         const provenResourceKeys = this.taskWorkflowResourceKeys(execution);
         const replayedIdentity =
           execution.status === "already-applied"
-            ? this.taskWorkflowIdentityByPlanDigest.get(
-                `${kind}:${preview.plan.planDigest}`,
+            ? this.taskWorkflowIdentity(
+                kind,
+                preview.plan.planDigest,
               )
             : undefined;
         const created = live.rawTasks.filter(
@@ -2436,7 +2444,7 @@ export class OperonDeveloperApiRuntimeAdapter {
             "no unique periodic task is linked to the committed native resource evidence",
           );
         }
-        this.rememberTaskWorkflowIdentity(
+        await this.rememberTaskWorkflowIdentity(
           kind,
           preview.plan.planDigest,
           created[0]!.identity.operonId,
@@ -3162,12 +3170,27 @@ export class OperonDeveloperApiRuntimeAdapter {
     return keys;
   }
 
-  private rememberTaskWorkflowIdentity(
+  private taskWorkflowIdentity(
+    kind: DeveloperApiTaskWorkflowKind,
+    planDigest: string,
+  ): string | undefined {
+    const key = `${kind}:${planDigest}`;
+    return (
+      this.taskWorkflowIdentityStore?.get(key) ??
+      this.taskWorkflowIdentityByPlanDigest.get(key)
+    );
+  }
+
+  private async rememberTaskWorkflowIdentity(
     kind: DeveloperApiTaskWorkflowKind,
     planDigest: string,
     operonId: string,
-  ): void {
+  ): Promise<void> {
     const key = `${kind}:${planDigest}`;
+    if (this.taskWorkflowIdentityStore) {
+      await this.taskWorkflowIdentityStore.set(key, operonId);
+      return;
+    }
     this.taskWorkflowIdentityByPlanDigest.delete(key);
     this.taskWorkflowIdentityByPlanDigest.set(key, operonId);
     if (this.taskWorkflowIdentityByPlanDigest.size <= 512) return;

--- a/plugins/obsidian-operon-bridge/src/developer-api-adapter.ts
+++ b/plugins/obsidian-operon-bridge/src/developer-api-adapter.ts
@@ -2578,7 +2578,6 @@ export class OperonDeveloperApiRuntimeAdapter {
       );
     }
     let planDigest =
-      suppliedPlanDigest ||
       this.taskWorkflowRecoveryDigests.get(`${kind}:${normalizedRecoveryRef}`) ||
       "";
     if (planDigest && !SHA256_HEX.test(planDigest)) {
@@ -2593,10 +2592,57 @@ export class OperonDeveloperApiRuntimeAdapter {
         },
       );
     }
-    if (!planDigest && methods.pendingRecoveries) {
+    if (suppliedPlanDigest) {
+      if (!methods.pendingRecoveries) {
+        return this.mutationFailure(
+          "not-ready",
+          "The supplied planDigest cannot be proven because pending recovery state is unavailable; native recovery was not dispatched.",
+          null,
+          true,
+          { recoveryRef: normalizedRecoveryRef, mutationMayHaveApplied: true },
+        );
+      }
       try {
         const pending = await methods.pendingRecoveries();
-        if (this.taskWorkflowPendingViolation(pending)) {
+        if (this.taskWorkflowPendingViolation(pending) || !pending.ok) {
+          throw new Error("invalid task-workflow pending recovery result");
+        }
+        const match = (pending.recoveries ?? []).find(
+          (candidate) => candidate.recoveryRef === normalizedRecoveryRef,
+        );
+        const pendingPlanDigest = String(match?.planDigest ?? "").trim();
+        if (!pendingPlanDigest || !SHA256_HEX.test(pendingPlanDigest)) {
+          return this.mutationFailure(
+            "not-ready",
+            "The recovery reference is not present with a valid digest in pending recovery state; native recovery was not dispatched.",
+            null,
+            true,
+            { recoveryRef: normalizedRecoveryRef, mutationMayHaveApplied: true },
+          );
+        }
+        if (pendingPlanDigest !== suppliedPlanDigest) {
+          return this.mutationFailure(
+            "invalid-input",
+            "planDigest does not match the pending native recovery; native recovery was not dispatched.",
+            null,
+            false,
+            { recoveryRef: normalizedRecoveryRef, mutationMayHaveApplied: true },
+          );
+        }
+        planDigest = pendingPlanDigest;
+      } catch {
+        return this.mutationFailure(
+          "not-ready",
+          "The supplied planDigest could not be proven from pending recovery state; native recovery was not dispatched.",
+          null,
+          true,
+          { recoveryRef: normalizedRecoveryRef, mutationMayHaveApplied: true },
+        );
+      }
+    } else if (!planDigest && methods.pendingRecoveries) {
+      try {
+        const pending = await methods.pendingRecoveries();
+        if (this.taskWorkflowPendingViolation(pending) || !pending.ok) {
           throw new Error("invalid task-workflow pending recovery result");
         }
         const match = (pending.recoveries ?? []).find(

--- a/plugins/obsidian-operon-bridge/src/developer-api-adapter.ts
+++ b/plugins/obsidian-operon-bridge/src/developer-api-adapter.ts
@@ -1,11 +1,12 @@
 import {
-	OPERON_BRIDGE_DEVELOPER_API_CONTRACT,
+  OPERON_BRIDGE_DEVELOPER_API_CONTRACT,
   type OperonSemanticConfiguration,
   type RuntimeIndexDiagnostics,
   type RuntimeIndexedTask,
   type RuntimeKeyMapping,
   type RuntimePipeline,
   type RuntimePriorityDefinition,
+  type OperonFieldValue,
   isCanonicalVaultRelativePath,
   resolvePriorityStableId,
 } from "./contract";
@@ -46,6 +47,11 @@ export interface DeveloperApiChannelStatus {
   };
   readonly error?: DeveloperApiError;
   readonly [key: string]: unknown;
+}
+
+export interface TaskWorkflowBeforeApplyGateResult {
+  readonly ok: boolean;
+  readonly message?: string;
 }
 
 interface DeveloperApiTaskLocator {
@@ -177,6 +183,9 @@ interface DeveloperApiMutationPreviewResult {
 }
 
 interface DeveloperApiMutationExecutionResult {
+  readonly contractVersion?: number;
+  readonly kind?: string;
+  readonly requestId?: string;
   readonly status?:
     | "applied"
     | "already-applied"
@@ -185,11 +194,36 @@ interface DeveloperApiMutationExecutionResult {
     | "outcome-unknown";
   readonly mutationMayHaveApplied?: boolean;
   readonly retryAllowed?: boolean;
+  readonly groupResults?: readonly {
+    readonly groupId?: string;
+    readonly status?: string;
+    readonly resourceRevisions?: readonly {
+      readonly resourceKind?: string;
+      readonly resourceKey?: string;
+      readonly revision?: string;
+    }[];
+    readonly error?: DeveloperApiError;
+  }[];
   readonly receipt?: {
+    readonly contractVersion?: number;
     readonly terminalOutcome?: string;
     readonly planDigest?: string;
+    readonly mutationKind?: string;
+    readonly targetDigest?: string;
+    readonly effectiveAt?: string;
+    readonly completedAt?: string;
+    readonly expiresAt?: string;
+    readonly [key: string]: unknown;
+  };
+  readonly postflight?: {
+    readonly status?: string;
+    readonly observedAt?: string;
+    readonly [key: string]: unknown;
   };
   readonly recovery?: {
+    readonly required?: boolean;
+    readonly action?: string;
+    readonly mutationMayHaveApplied?: boolean;
     readonly recoveryRef?: string;
     readonly planDigest?: string;
     readonly plan?: DeveloperApiMutationPlan;
@@ -208,6 +242,8 @@ interface DeveloperApiPendingRecovery {
 }
 
 interface DeveloperApiPendingRecoveriesResult {
+  readonly contractVersion?: number;
+  readonly kind?: string;
   readonly ok: boolean;
   readonly recoveries?: readonly DeveloperApiPendingRecovery[];
   readonly error?: DeveloperApiError;
@@ -326,6 +362,9 @@ interface DeveloperApiAccessor {
 }
 
 interface TaskWorkflowFilterResult {
+  readonly contractVersion?: number;
+  readonly kind?: string;
+  readonly requestId?: string;
   readonly ok: boolean;
   readonly tasks?: readonly DeveloperApiTask[];
   readonly page?: {
@@ -339,12 +378,152 @@ interface TaskWorkflowFilterResult {
   readonly error?: DeveloperApiError;
 }
 
+export type DeveloperApiTaskWorkflowKind =
+  | "adopt"
+  | "periodic-create"
+  | "periodic-update";
+
+interface TaskWorkflowDeveloperMutationPlan {
+  readonly contractVersion: 1;
+  readonly kind: "task-workflow-developer-mutation-plan";
+  readonly recoveryRef: string;
+  readonly planDigest: string;
+  readonly createdAt: string;
+  readonly expiresAt: string;
+  readonly riskLevel: "none" | "routine" | "elevated" | "destructive";
+  readonly requiresConsent: boolean;
+}
+
+interface TaskWorkflowDeveloperMutationPreviewResult {
+  readonly contractVersion?: number;
+  readonly kind?: string;
+  readonly requestId?: string;
+  readonly ok: boolean;
+  readonly plan?: TaskWorkflowDeveloperMutationPlan;
+  readonly warnings?: readonly unknown[];
+  readonly error?: DeveloperApiError;
+}
+
+interface TaskWorkflowDeveloperMutationExecutionResult {
+  readonly contractVersion?: number;
+  readonly kind?: string;
+  readonly requestId?: string;
+  readonly status?:
+    | "applied"
+    | "already-applied"
+    | "partial"
+    | "failed"
+    | "outcome-unknown";
+  readonly mutationMayHaveApplied?: boolean;
+  readonly retryAllowed?: boolean;
+  readonly groupResults?: readonly {
+    readonly groupId?: string;
+    readonly status?: string;
+    readonly resourceRevisions?: readonly {
+      readonly resourceKind?: string;
+      readonly resourceKey?: string;
+      readonly revision?: string;
+    }[];
+  }[];
+  readonly receipt?: {
+    readonly contractVersion?: number;
+    readonly planDigest?: string;
+    readonly mutationKind?: string;
+    readonly targetDigest?: string;
+    readonly terminalOutcome?: string;
+    readonly effectiveAt?: string;
+    readonly completedAt?: string;
+    readonly expiresAt?: string;
+  };
+  readonly postflight?: {
+    readonly status?: string;
+    readonly observedAt?: string;
+  };
+  readonly recovery?: {
+    readonly required?: boolean;
+    readonly action?: string;
+    readonly mutationMayHaveApplied?: boolean;
+    readonly recoveryRef?: string;
+    readonly planDigest?: string;
+    readonly plan?: TaskWorkflowDeveloperMutationPlan;
+  };
+  readonly error?: DeveloperApiError;
+}
+
+export interface DeveloperApiTaskWorkflowNativeProof {
+  readonly contractVersion: 1;
+  readonly kind: "mutation-result";
+  readonly status:
+    | "applied"
+    | "already-applied"
+    | "partial"
+    | "failed"
+    | "outcome-unknown";
+  readonly mutationMayHaveApplied: boolean;
+  readonly retryAllowed: boolean;
+  readonly groupResults: readonly {
+    readonly groupId: string;
+    readonly status: "committed" | "failed" | "outcome-unknown";
+    readonly resourceRevisions?: readonly {
+      readonly resourceKind:
+        | "timer"
+        | "repeat-series"
+        | "active-tracker"
+        | "pinned"
+        | "project-serial"
+        | "task-source";
+      readonly resourceKey: string;
+      readonly revision: string;
+    }[];
+  }[];
+  readonly receipt?: {
+    readonly contractVersion: 1;
+    readonly planDigest: string;
+    readonly mutationKind: string;
+    readonly targetDigest: string;
+    readonly terminalOutcome: "applied" | "already-applied";
+    readonly effectiveAt: string;
+    readonly completedAt: string;
+    readonly expiresAt: string;
+  };
+  readonly postflight?: {
+    readonly status: "verified" | "receipt-replay";
+    readonly observedAt?: string;
+  };
+}
+
+interface TaskWorkflowDeveloperMutationMethods {
+  readonly preview?: (
+    input: Record<string, unknown>,
+  ) => Promise<TaskWorkflowDeveloperMutationPreviewResult>;
+  readonly apply?: (input: {
+    readonly plan: TaskWorkflowDeveloperMutationPlan;
+  }) => Promise<TaskWorkflowDeveloperMutationExecutionResult>;
+  readonly recover?: (input: {
+    readonly recoveryRef: string;
+  }) => Promise<TaskWorkflowDeveloperMutationExecutionResult>;
+  readonly pendingRecoveries?: () => Promise<DeveloperApiPendingRecoveriesResult>;
+}
+
 interface TaskWorkflowDeveloperApiV1 {
+  readonly contractVersion?: number;
+  readonly runtimeApi?: number;
   readonly tasks: {
-    readonly filterQuery: (
+    readonly filterQuery?: (
       request: Record<string, unknown>,
     ) => Promise<TaskWorkflowFilterResult>;
+    readonly adopt?: TaskWorkflowDeveloperMutationMethods;
+    readonly createPeriodicNote?: TaskWorkflowDeveloperMutationMethods;
+    readonly updatePeriodicNote?: TaskWorkflowDeveloperMutationMethods;
   };
+}
+
+interface TaskWorkflowDeveloperApiAccessResult {
+  readonly contractVersion?: number;
+  readonly kind?: string;
+  readonly ok: boolean;
+  readonly api?: TaskWorkflowDeveloperApiV1;
+  readonly error?: DeveloperApiError;
 }
 
 interface TaskWorkflowDeveloperApiAccessor {
@@ -353,13 +532,9 @@ interface TaskWorkflowDeveloperApiAccessor {
     request: {
       readonly contractVersion: 1;
       readonly runtimeApi: { readonly min: 1; readonly max: 1 };
-      readonly requestedCapabilities: readonly ["tasks.filter-query"];
+      readonly requestedCapabilities: readonly string[];
     },
-  ) => {
-    readonly ok: boolean;
-    readonly api?: TaskWorkflowDeveloperApiV1;
-    readonly error?: DeveloperApiError;
-  };
+  ) => TaskWorkflowDeveloperApiAccessResult;
 }
 
 interface DeveloperApiAccessResult {
@@ -442,11 +617,14 @@ export interface DeveloperApiMutationResult {
   readonly recoveryRef?: string;
   readonly retryable: boolean;
   readonly mutationMayHaveApplied?: boolean;
+  readonly nativeProof?: DeveloperApiTaskWorkflowNativeProof;
 }
 
 export interface DeveloperApiPendingRecoveryResult {
   readonly ok: boolean;
-  readonly recoveries: readonly DeveloperApiPendingRecovery[];
+  readonly recoveries: readonly (DeveloperApiPendingRecovery & {
+    readonly workflowKind?: DeveloperApiTaskWorkflowKind;
+  })[];
   readonly message?: string;
 }
 
@@ -508,6 +686,9 @@ const MUTATION_CAPABILITIES: Record<
 const GENERAL_FIELD_TYPES: Record<string, string> = {
   description: "text",
   priority: "text",
+  taskType: "text",
+  taskImage: "text",
+  taskGallery: "list",
   dateDue: "date",
   dateScheduled: "date",
   dateStarted: "date",
@@ -525,6 +706,9 @@ const GENERAL_FIELD_TYPES: Record<string, string> = {
 };
 
 const CREATE_FIELD_TYPES: Record<string, string> = {
+  taskType: "text",
+  taskImage: "text",
+  taskGallery: "list",
   taskIcon: "text",
   taskColor: "text",
   note: "text",
@@ -540,11 +724,28 @@ const CREATE_FIELD_TYPES: Record<string, string> = {
   links: "list",
 };
 
+const TASK_WORKFLOW_CAPABILITIES: Record<
+  DeveloperApiTaskWorkflowKind,
+  readonly [string, string]
+> = {
+  adopt: ["tasks.adopt.preview", "tasks.adopt.apply"],
+  "periodic-create": [
+    "tasks.create.periodic-note.preview",
+    "tasks.create.periodic-note.apply",
+  ],
+  "periodic-update": [
+    "tasks.update.periodic-note.preview",
+    "tasks.update.periodic-note.apply",
+  ],
+};
+
 // The official runtime may settle a graph/project-serial mutation after the
 // default local REST/MCP request budget. Returning an uncertain outcome with
 // the durable recovery reference is safer than holding the HTTP request open
 // until the caller times out and then guessing whether to retry.
 const DEVELOPER_API_APPLY_TIMEOUT_MS = 120_000;
+const SHA256_HEX = /^[0-9a-f]{64}$/u;
+const DEVELOPER_RECOVERY_REF = /^dvr1_[0-9a-f]{48}$/u;
 
 function requestId(): string {
   return (
@@ -582,9 +783,9 @@ function stringValue(value: unknown): string | undefined {
   return undefined;
 }
 
-function fieldValue(value: unknown): string | undefined {
+function fieldValue(value: unknown): OperonFieldValue | undefined {
   if (Array.isArray(value)) {
-    return value.map((item) => String(item)).join("; ");
+    return value.map((item) => String(item));
   }
   const scalar = stringValue(value);
   if (scalar !== undefined) return scalar;
@@ -653,10 +854,14 @@ function emptyConfiguration(): OperonSemanticConfiguration {
 }
 
 function toRuntimeTask(task: DeveloperApiTask): RuntimeIndexedTask {
-  const fieldValues: Record<string, string> = {};
+  const fieldValues: Record<string, OperonFieldValue> = {};
   const writeField = (key: string, value: unknown): void => {
     const normalized = fieldValue(value);
-    if (normalized !== undefined && normalized !== "")
+    if (
+      normalized !== undefined &&
+      normalized !== "" &&
+      (!Array.isArray(normalized) || normalized.length > 0)
+    )
       fieldValues[key] = normalized;
   };
 
@@ -869,10 +1074,7 @@ function catalogConfiguration(catalog: DeveloperApiCatalog): {
       id: filter.id,
       name: filter.name,
       icon: filter.icon ?? null,
-      definition: JSON.parse(JSON.stringify(filter)) as Record<
-        string,
-        unknown
-      >,
+      definition: JSON.parse(JSON.stringify(filter)) as Record<string, unknown>,
     })),
   };
   return { pipelines, keyMappings, priorities, configuration };
@@ -972,6 +1174,11 @@ export class OperonDeveloperApiRuntimeAdapter {
   >();
   private recoveryApi: DeveloperApiV1 | null = null;
   private filterQueryApi: TaskWorkflowDeveloperApiV1 | null = null;
+  private readonly taskWorkflowApis = new Map<
+    DeveloperApiTaskWorkflowKind,
+    TaskWorkflowDeveloperApiV1
+  >();
+  private readonly taskWorkflowRecoveryDigests = new Map<string, string>();
   private grantedCapabilities: ReadonlySet<string> | null = null;
   private refreshInFlight: Promise<boolean> | null = null;
   private contractState: "unverified" | "valid" | "invalid" = "unverified";
@@ -1011,7 +1218,11 @@ export class OperonDeveloperApiRuntimeAdapter {
   private async refreshWithStartupRetry(
     includeMutationCapabilities: boolean,
   ): Promise<boolean> {
-    for (let attempt = 0; attempt <= STARTUP_REFRESH_RETRY_LIMIT; attempt += 1) {
+    for (
+      let attempt = 0;
+      attempt <= STARTUP_REFRESH_RETRY_LIMIT;
+      attempt += 1
+    ) {
       if (await this.refreshInternal(includeMutationCapabilities)) return true;
       const retryAfterMs = this.startupRetryDelayMs();
       if (retryAfterMs === null || attempt === STARTUP_REFRESH_RETRY_LIMIT)
@@ -1047,6 +1258,7 @@ export class OperonDeveloperApiRuntimeAdapter {
     this.mutationApis.clear();
     this.recoveryApi = null;
     this.filterQueryApi = null;
+    this.taskWorkflowApis.clear();
     this.grantedCapabilities = null;
 
     // Establish a baseline session first. Operon evaluates a requested set as
@@ -1160,6 +1372,21 @@ export class OperonDeveloperApiRuntimeAdapter {
         // down the already-verified core Developer API session.
         this.filterQueryApi = null;
       }
+      if (includeMutationCapabilities) {
+        for (const workflowKind of Object.keys(
+          TASK_WORKFLOW_CAPABILITIES,
+        ) as DeveloperApiTaskWorkflowKind[]) {
+          try {
+            const workflowApi = this.connectTaskWorkflow(workflowKind);
+            if (workflowApi)
+              this.taskWorkflowApis.set(workflowKind, workflowApi);
+          } catch {
+            // Task-workflow grants are additive and exact. A pending or broken
+            // optional workflow must never invalidate established core reads,
+            // filter execution, or already-approved mutation sessions.
+          }
+        }
+      }
       return true;
     } catch (error) {
       this.readApi = null;
@@ -1198,6 +1425,20 @@ export class OperonDeveloperApiRuntimeAdapter {
     return Boolean(this.filterQueryApi?.tasks.filterQuery);
   }
 
+  hasTaskWorkflowCapability(kind: DeveloperApiTaskWorkflowKind): boolean {
+    const api = this.taskWorkflowApis.get(kind);
+    const methods = this.taskWorkflowMethods(api, kind);
+    return Boolean(methods?.preview && methods.apply);
+  }
+
+  hasTaskWorkflowRecoverySupport(kind: DeveloperApiTaskWorkflowKind): boolean {
+    const methods = this.taskWorkflowMethods(
+      this.taskWorkflowApis.get(kind),
+      kind,
+    );
+    return Boolean(methods?.recover && methods.pendingRecoveries);
+  }
+
   async querySavedFilter(
     request: Record<string, unknown>,
   ): Promise<TaskWorkflowFilterResult> {
@@ -1227,9 +1468,10 @@ export class OperonDeveloperApiRuntimeAdapter {
         Number.isFinite(requestedLimit) ? Math.trunc(requestedLimit) : 100,
       ),
     );
-    return api.tasks.filterQuery({
+    const filterRequestId = requestId();
+    const result = await api.tasks.filterQuery({
       contractVersion: 1,
-      requestId: requestId(),
+      requestId: filterRequestId,
       kind: "task-filter-query",
       consistency: "live-verified",
       filterSetId,
@@ -1251,6 +1493,16 @@ export class OperonDeveloperApiRuntimeAdapter {
         ? { cursor: request.cursor }
         : {}),
     });
+    if (
+      result.contractVersion !== 1 ||
+      result.kind !== "task-filter-query-result" ||
+      result.requestId !== filterRequestId
+    ) {
+      throw new Error(
+        "Operon returned an invalid task-workflow filter-query discriminator.",
+      );
+    }
+    return result;
   }
 
   private requireReadApi(
@@ -1403,11 +1655,53 @@ export class OperonDeveloperApiRuntimeAdapter {
     const access = this.taskWorkflowAccessor.getTaskWorkflowDeveloperApiV1(
       this.consumerPlugin,
       {
-		...OPERON_BRIDGE_DEVELOPER_API_CONTRACT,
+        ...OPERON_BRIDGE_DEVELOPER_API_CONTRACT,
         requestedCapabilities: ["tasks.filter-query"],
       },
     );
-    return access.ok && access.api?.tasks.filterQuery ? access.api : null;
+    const api = this.taskWorkflowAccessApi(access);
+    return api?.tasks.filterQuery ? api : null;
+  }
+
+  private connectTaskWorkflow(
+    kind: DeveloperApiTaskWorkflowKind,
+  ): TaskWorkflowDeveloperApiV1 | null {
+    if (!this.taskWorkflowAccessor) return null;
+    const access = this.taskWorkflowAccessor.getTaskWorkflowDeveloperApiV1(
+      this.consumerPlugin,
+      {
+        ...OPERON_BRIDGE_DEVELOPER_API_CONTRACT,
+        requestedCapabilities: TASK_WORKFLOW_CAPABILITIES[kind],
+      },
+    );
+    const api = this.taskWorkflowAccessApi(access);
+    if (!api) return null;
+    const methods = this.taskWorkflowMethods(api, kind);
+    return methods?.preview && methods.apply ? api : null;
+  }
+
+  private taskWorkflowAccessApi(
+    access: TaskWorkflowDeveloperApiAccessResult,
+  ): TaskWorkflowDeveloperApiV1 | null {
+    if (
+      access.contractVersion !== 1 ||
+      access.kind !== "task-workflow-developer-api-access-result" ||
+      !access.ok ||
+      !access.api ||
+      access.error !== undefined ||
+      access.api.contractVersion !== 1 ||
+      access.api.runtimeApi !== 1
+    ) return null;
+    return access.api;
+  }
+
+  private taskWorkflowMethods(
+    api: TaskWorkflowDeveloperApiV1 | undefined,
+    kind: DeveloperApiTaskWorkflowKind,
+  ): TaskWorkflowDeveloperMutationMethods | undefined {
+    if (kind === "adopt") return api?.tasks.adopt;
+    if (kind === "periodic-create") return api?.tasks.createPeriodicNote;
+    return api?.tasks.updatePeriodicNote;
   }
 
   private requestMissingCapabilities(includeMutations: boolean): void {
@@ -1454,7 +1748,8 @@ export class OperonDeveloperApiRuntimeAdapter {
       this.contractState = "invalid";
       this.channelStatus = {
         error: {
-          reason: "Operon Developer API V1 negotiation returned an invalid result.",
+          reason:
+            "Operon Developer API V1 negotiation returned an invalid result.",
         },
       };
       return null;
@@ -1686,6 +1981,27 @@ export class OperonDeveloperApiRuntimeAdapter {
       );
     }
 
+    const invalidExecution = this.baseMutationResultViolation(
+      execution,
+      preview.plan,
+    );
+    if (invalidExecution) {
+      return this.mutationFailure(
+        "outcome-unknown",
+        `Operon returned an invalid Developer API mutation result after dispatch: ${invalidExecution}`,
+        operonId,
+        false,
+        {
+          nativeStatus: execution.status ?? "invalid-result",
+          recoveryRef:
+            execution.recovery?.recoveryRef ?? preview.plan.recoveryRef,
+          planDigest: preview.plan.planDigest,
+          mutationMayHaveApplied: true,
+        },
+      );
+    }
+    const proof = this.baseMutationProof(execution);
+
     const status = execution.status ?? "failed";
     if (status === "partial" || status === "outcome-unknown") {
       return this.mutationFailure(
@@ -1700,6 +2016,7 @@ export class OperonDeveloperApiRuntimeAdapter {
             execution.recovery?.recoveryRef ?? preview.plan.recoveryRef,
           planDigest: execution.recovery?.planDigest ?? preview.plan.planDigest,
           mutationMayHaveApplied: true,
+          nativeProof: proof,
         },
       );
     }
@@ -1710,7 +2027,7 @@ export class OperonDeveloperApiRuntimeAdapter {
           "Operon rejected the mutation.",
         operonId,
         false,
-        { nativeStatus: status },
+        { nativeStatus: status, nativeProof: proof },
       );
     }
 
@@ -1729,7 +2046,11 @@ export class OperonDeveloperApiRuntimeAdapter {
           `Operon applied the create plan, but the created task could not be identified safely: ${error instanceof Error ? error.message : String(error)}`,
           null,
           false,
-          { nativeStatus: status, mutationMayHaveApplied: true },
+          {
+            nativeStatus: status,
+            mutationMayHaveApplied: true,
+            nativeProof: proof,
+          },
         );
       }
       if (!appliedOperonId) {
@@ -1738,7 +2059,11 @@ export class OperonDeveloperApiRuntimeAdapter {
           "Operon applied the create plan, but no unique created task was observable.",
           null,
           false,
-          { nativeStatus: status, mutationMayHaveApplied: true },
+          {
+            nativeStatus: status,
+            mutationMayHaveApplied: true,
+            nativeProof: proof,
+          },
         );
       }
     }
@@ -1751,7 +2076,1232 @@ export class OperonDeveloperApiRuntimeAdapter {
       recoveryRef: preview.plan.recoveryRef,
       retryable: false,
       mutationMayHaveApplied: execution.mutationMayHaveApplied ?? true,
+      nativeProof: proof,
     };
+  }
+
+  async executeTaskWorkflow(
+    kind: DeveloperApiTaskWorkflowKind,
+    requested: Record<string, unknown>,
+    dryRun: boolean,
+    beforeApply?: () => Promise<TaskWorkflowBeforeApplyGateResult>,
+  ): Promise<DeveloperApiMutationResult> {
+    const api = this.taskWorkflowApis.get(kind);
+    const methods = this.taskWorkflowMethods(api, kind);
+    if (!methods?.preview || !methods.apply) {
+      return this.mutationFailure(
+        "not-ready",
+        `Operon task-workflow Developer API grant is unavailable: ${kind}.`,
+        null,
+        true,
+      );
+    }
+
+    let previewInput: Record<string, unknown>;
+    let existingOperonId: string | null = null;
+    let beforeIds = new Set(
+      this.rawTasks.map((task) => task.identity.operonId),
+    );
+    try {
+      if (kind === "adopt") {
+        const targetPath = requested.targetPath;
+        const line = Number(requested.line);
+        const expectedLine = requested.expectedLine;
+        if (
+          !isCanonicalVaultRelativePath(targetPath) ||
+          !targetPath.endsWith(".md")
+        ) {
+          throw new Error(
+            "targetPath must be one canonical vault-relative Markdown path.",
+          );
+        }
+        if (!Number.isInteger(line) || line < 1) {
+          throw new Error("line must be a positive one-based line number.");
+        }
+        if (
+          typeof expectedLine !== "string" ||
+          expectedLine.length > 65_536 ||
+          /[\r\n]/u.test(expectedLine)
+        ) {
+          throw new Error(
+            "expectedLine must be one exact bounded source line.",
+          );
+        }
+        const statusId = String(requested.statusId ?? "").trim();
+        const terminalSourcePolicy = requested.terminalSourcePolicy;
+        if (
+          terminalSourcePolicy !== undefined &&
+          terminalSourcePolicy !== "reopen"
+        ) {
+          throw new Error(
+            "terminalSourcePolicy must be 'reopen' when supplied.",
+          );
+        }
+        previewInput = {
+          operation: "adopt-inline",
+          source: {
+            filePath: targetPath,
+            lineNumber: line - 1,
+            expectedLine,
+          },
+          ...(statusId ? { statusId } : {}),
+          ...(terminalSourcePolicy ? { terminalSourcePolicy } : {}),
+        };
+      } else if (kind === "periodic-create") {
+        if (
+          requested.periodicKind !== "daily" &&
+          requested.periodicKind !== "weekly"
+        ) {
+          throw new Error("periodicKind must be daily or weekly.");
+        }
+        if (
+          requested.routeDate !== undefined &&
+          !/^\d{4}-\d{2}-\d{2}$/u.test(String(requested.routeDate))
+        ) {
+          throw new Error("routeDate must be an ISO date key (YYYY-MM-DD).");
+        }
+        if (
+          requested.targetPath !== undefined ||
+          requested.parentTask !== undefined
+        ) {
+          throw new Error(
+            "Periodic-note creation owns routing and parentage; targetPath and parentTask are not accepted.",
+          );
+        }
+        const mapped = this.mapCreateInput({ ...requested, source: "inline" });
+        const item = (mapped.spec.items as Record<string, unknown>[])[0];
+        previewInput = {
+          operation: "create",
+          items: [
+            {
+              ...item,
+              target: {
+                representation: "inline",
+                mode: "periodic-note",
+                periodicKind: requested.periodicKind,
+                ...(requested.routeDate
+                  ? { routeDate: String(requested.routeDate) }
+                  : {}),
+              },
+            },
+          ],
+        };
+      } else {
+        existingOperonId = String(requested.operonId ?? "").trim();
+        if (!existingOperonId) throw new Error("operonId is required.");
+        const requestKeys = Object.keys(requested);
+        if (requestKeys.some((key) => key !== "operonId" && key !== "fields")) {
+          throw new Error(
+            "Periodic-note update accepts only operonId and fields.dateScheduled.",
+          );
+        }
+        const fields = requested.fields;
+        if (!fields || typeof fields !== "object" || Array.isArray(fields)) {
+          throw new Error(
+            "Periodic-note update requires fields.dateScheduled.",
+          );
+        }
+        const fieldEntries = Object.entries(fields as Record<string, unknown>);
+        if (
+          fieldEntries.length !== 1 ||
+          fieldEntries[0]?.[0] !== "dateScheduled"
+        ) {
+          throw new Error(
+            "Periodic-note update accepts exactly fields.dateScheduled.",
+          );
+        }
+        const dateScheduled = fieldEntries[0][1];
+        if (
+          dateScheduled !== null &&
+          (typeof dateScheduled !== "string" || !dateScheduled.trim())
+        ) {
+          throw new Error(
+            "fields.dateScheduled must be a non-empty date string or null.",
+          );
+        }
+        const readApi = this.readApi;
+        if (!readApi)
+          throw new Error("Operon live read session is unavailable.");
+        const task = await this.getExactTask(readApi, existingOperonId);
+        if (!task)
+          throw new Error(`Operon task not found: ${existingOperonId}.`);
+        const mapped = await this.mapMutationInput(
+          readApi,
+          "update",
+          task,
+          requested,
+        );
+        previewInput = {
+          operation: "update-periodic-note",
+          target: mapped.target,
+          changes: mapped.spec.changes,
+        };
+      }
+    } catch (error) {
+      return this.mutationFailure(
+        "invalid-input",
+        error instanceof Error ? error.message : String(error),
+        existingOperonId,
+        false,
+      );
+    }
+
+    let preview: TaskWorkflowDeveloperMutationPreviewResult;
+    try {
+      preview = await methods.preview(previewInput);
+    } catch (error) {
+      return this.mutationFailure(
+        "failed",
+        error instanceof Error ? error.message : String(error),
+        existingOperonId,
+        false,
+      );
+    }
+    const previewViolation = this.taskWorkflowPreviewViolation(preview);
+    if (previewViolation) {
+      return this.mutationFailure(
+        "failed",
+        `Operon returned an invalid task-workflow preview result; apply was not dispatched: ${previewViolation}`,
+        existingOperonId,
+        false,
+        { mutationMayHaveApplied: false },
+      );
+    }
+    if (!preview.ok || !preview.plan) {
+      return this.mutationFailure(
+        this.mapNativeErrorCode(preview.error),
+        developerErrorMessage(preview.error),
+        existingOperonId,
+        false,
+      );
+    }
+    const planViolation = this.taskWorkflowPlanViolation(preview.plan);
+    if (planViolation) {
+      return this.mutationFailure(
+        "failed",
+        `Operon returned an invalid task-workflow plan; apply was not dispatched: ${planViolation}`,
+        existingOperonId,
+        false,
+        { mutationMayHaveApplied: false },
+      );
+    }
+    const plan = this.taskWorkflowPlanMetadata(preview.plan, kind);
+    if (dryRun) {
+      return {
+        ok: true,
+        operonId: existingOperonId,
+        code: "planned",
+        nativeStatus: "planned",
+        plan,
+        planDigest: preview.plan.planDigest,
+        recoveryRef: preview.plan.recoveryRef,
+        retryable: false,
+      };
+    }
+
+    if (beforeApply) {
+      let gate: TaskWorkflowBeforeApplyGateResult;
+      try {
+        gate = await beforeApply();
+      } catch (error) {
+        return this.mutationFailure(
+          "failed",
+          `The pre-apply revision gate could not be verified: ${error instanceof Error ? error.message : String(error)}`,
+          existingOperonId,
+          true,
+          {
+            nativeStatus: "planned-not-applied",
+            planDigest: preview.plan.planDigest,
+            recoveryRef: preview.plan.recoveryRef,
+            mutationMayHaveApplied: false,
+          },
+        );
+      }
+      if (!gate.ok) {
+        return this.mutationFailure(
+          "conflict",
+          gate.message ??
+            "The task revision changed after preview; the sealed plan was not applied.",
+          existingOperonId,
+          true,
+          {
+            nativeStatus: "planned-not-applied",
+            planDigest: preview.plan.planDigest,
+            recoveryRef: preview.plan.recoveryRef,
+            mutationMayHaveApplied: false,
+          },
+        );
+      }
+    }
+
+    let execution: TaskWorkflowDeveloperMutationExecutionResult;
+    try {
+      execution = await withTimeout(
+        methods.apply({ plan: preview.plan }),
+        DEVELOPER_API_APPLY_TIMEOUT_MS,
+      );
+    } catch (error) {
+      return this.mutationFailure(
+        "outcome-unknown",
+        `Operon task-workflow apply did not return a terminal result: ${error instanceof Error ? error.message : String(error)}`,
+        existingOperonId,
+        false,
+        {
+          nativeStatus: "timeout-or-transport-error",
+          recoveryRef: preview.plan.recoveryRef,
+          planDigest: preview.plan.planDigest,
+          mutationMayHaveApplied: true,
+        },
+      );
+    }
+    const terminal = this.projectTaskWorkflowExecution(
+      execution,
+      plan,
+      existingOperonId,
+    );
+    if (!terminal.ok) return terminal;
+
+    if (kind === "adopt") {
+      const targetPath = String(requested.targetPath);
+      const lineNumber = Number(requested.line) - 1;
+      try {
+        const live = await this.reloadLiveTasks();
+        const adopted = live.rawTasks.filter(
+          (task) =>
+            !beforeIds.has(task.identity.operonId) &&
+            task.representation === "inline" &&
+            task.locator.representation === "inline" &&
+            task.locator.filePath === targetPath &&
+            task.locator.lineNumber === lineNumber,
+        );
+        if (adopted.length !== 1) {
+          throw new Error(
+            "no unique adopted task is visible at the sealed source line",
+          );
+        }
+        return { ...terminal, operonId: adopted[0]!.identity.operonId };
+      } catch (error) {
+        return this.mutationFailure(
+          "failed",
+          `Operon applied adoption, but the adopted identity could not be proven: ${error instanceof Error ? error.message : String(error)}`,
+          null,
+          false,
+          {
+            nativeStatus: execution.status,
+            planDigest: preview.plan.planDigest,
+            recoveryRef: preview.plan.recoveryRef,
+            mutationMayHaveApplied: true,
+          },
+        );
+      }
+    }
+    if (kind === "periodic-create") {
+      try {
+        const live = await this.reloadLiveTasks();
+        const description = String(requested.description ?? "").trim();
+        const provenResourceKeys = this.taskWorkflowResourceKeys(execution);
+        const created = live.rawTasks.filter(
+          (task) =>
+            !beforeIds.has(task.identity.operonId) &&
+            task.representation === "inline" &&
+            task.description === description &&
+            provenResourceKeys.has(task.locator.filePath),
+        );
+        if (created.length !== 1) {
+          throw new Error(
+            "no unique periodic task is linked to the committed native resource evidence",
+          );
+        }
+        return { ...terminal, operonId: created[0]!.identity.operonId };
+      } catch (error) {
+        return this.mutationFailure(
+          "outcome-unknown",
+          `Operon applied periodic-note creation, but the created identity could not be proven uniquely: ${error instanceof Error ? error.message : String(error)}`,
+          null,
+          false,
+          {
+            nativeStatus: execution.status,
+            planDigest: preview.plan.planDigest,
+            recoveryRef: preview.plan.recoveryRef,
+            mutationMayHaveApplied: true,
+          },
+        );
+      }
+    }
+    return terminal;
+  }
+
+  async pendingTaskWorkflowRecoveries(
+    kind?: DeveloperApiTaskWorkflowKind,
+  ): Promise<DeveloperApiPendingRecoveryResult> {
+    const kinds = kind
+      ? [kind]
+      : (
+          Object.keys(
+            TASK_WORKFLOW_CAPABILITIES,
+          ) as DeveloperApiTaskWorkflowKind[]
+        ).filter((candidate) => this.hasTaskWorkflowRecoverySupport(candidate));
+    if (kinds.length === 0) {
+      return {
+        ok: false,
+        recoveries: [],
+        message: "No Operon task-workflow recovery grant is available.",
+      };
+    }
+    const recoveries: (DeveloperApiPendingRecovery & {
+      workflowKind: DeveloperApiTaskWorkflowKind;
+    })[] = [];
+    for (const workflowKind of kinds) {
+      const methods = this.taskWorkflowMethods(
+        this.taskWorkflowApis.get(workflowKind),
+        workflowKind,
+      );
+      if (!methods?.pendingRecoveries) {
+        return {
+          ok: false,
+          recoveries: [],
+          message: `Operon task-workflow recovery grant is unavailable: ${workflowKind}.`,
+        };
+      }
+      try {
+        const result = await methods.pendingRecoveries();
+        const pendingViolation = this.taskWorkflowPendingViolation(result);
+        if (pendingViolation) {
+          return {
+            ok: false,
+            recoveries: [],
+            message: `Operon returned invalid task-workflow pending recovery state: ${pendingViolation}`,
+          };
+        }
+        if (!result.ok) {
+          return {
+            ok: false,
+            recoveries: [],
+            message: developerErrorMessage(result.error),
+          };
+        }
+        for (const recovery of result.recoveries ?? []) {
+          if (recovery.recoveryRef && recovery.planDigest) {
+            this.taskWorkflowRecoveryDigests.set(
+              `${workflowKind}:${recovery.recoveryRef}`,
+              recovery.planDigest,
+            );
+          }
+          recoveries.push({ ...recovery, workflowKind });
+        }
+      } catch (error) {
+        return {
+          ok: false,
+          recoveries: [],
+          message: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }
+    return { ok: true, recoveries };
+  }
+
+  async recoverTaskWorkflow(
+    kind: DeveloperApiTaskWorkflowKind,
+    recoveryRef: string,
+    expectedPlanDigest?: string,
+  ): Promise<DeveloperApiMutationResult> {
+    const methods = this.taskWorkflowMethods(
+      this.taskWorkflowApis.get(kind),
+      kind,
+    );
+    if (!methods?.recover) {
+      return this.mutationFailure(
+        "not-ready",
+        `Operon task-workflow recovery grant is unavailable: ${kind}.`,
+        null,
+        true,
+        { recoveryRef, mutationMayHaveApplied: true },
+      );
+    }
+    const normalizedRecoveryRef = recoveryRef.trim();
+    if (!normalizedRecoveryRef) {
+      return this.mutationFailure(
+        "invalid-input",
+        "recoveryRef is required.",
+        null,
+        false,
+      );
+    }
+    const suppliedPlanDigest = String(expectedPlanDigest ?? "").trim();
+    if (suppliedPlanDigest && !SHA256_HEX.test(suppliedPlanDigest)) {
+      return this.mutationFailure(
+        "invalid-input",
+        "planDigest must be exactly 64 lowercase SHA-256 hexadecimal characters; native recovery was not dispatched.",
+        null,
+        false,
+        {
+          recoveryRef: normalizedRecoveryRef,
+          mutationMayHaveApplied: true,
+        },
+      );
+    }
+    let planDigest =
+      suppliedPlanDigest ||
+      this.taskWorkflowRecoveryDigests.get(`${kind}:${normalizedRecoveryRef}`) ||
+      "";
+    if (planDigest && !SHA256_HEX.test(planDigest)) {
+      return this.mutationFailure(
+        "invalid-input",
+        "The stored task-workflow planDigest is not valid lowercase SHA-256; native recovery was not dispatched.",
+        null,
+        false,
+        {
+          recoveryRef: normalizedRecoveryRef,
+          mutationMayHaveApplied: true,
+        },
+      );
+    }
+    if (!planDigest && methods.pendingRecoveries) {
+      try {
+        const pending = await methods.pendingRecoveries();
+        if (this.taskWorkflowPendingViolation(pending)) {
+          throw new Error("invalid task-workflow pending recovery result");
+        }
+        const match = (pending.recoveries ?? []).find(
+          (candidate) => candidate.recoveryRef === normalizedRecoveryRef,
+        );
+        planDigest = String(match?.planDigest ?? "").trim();
+      } catch {
+        // Recovery stays fail-closed when the sealed digest cannot be proven.
+      }
+    }
+    if (planDigest && !SHA256_HEX.test(planDigest)) {
+      return this.mutationFailure(
+        "invalid-input",
+        "Operon pending recovery state returned an invalid planDigest; native recovery was not dispatched.",
+        null,
+        false,
+        {
+          recoveryRef: normalizedRecoveryRef,
+          mutationMayHaveApplied: true,
+        },
+      );
+    }
+    if (!planDigest) {
+      return this.mutationFailure(
+        "not-ready",
+        "The recovery plan digest could not be proven from pending recovery state; the native recovery was not dispatched.",
+        null,
+        true,
+        { recoveryRef: normalizedRecoveryRef, mutationMayHaveApplied: true },
+      );
+    }
+    let execution: TaskWorkflowDeveloperMutationExecutionResult;
+    try {
+      execution = await methods.recover({ recoveryRef: normalizedRecoveryRef });
+    } catch (error) {
+      return this.mutationFailure(
+        "outcome-unknown",
+        `Operon task-workflow recovery did not return a terminal result: ${error instanceof Error ? error.message : String(error)}`,
+        null,
+        false,
+        { recoveryRef: normalizedRecoveryRef, mutationMayHaveApplied: true },
+      );
+    }
+    return this.projectTaskWorkflowExecution(
+      execution,
+      {
+        recoveryRef: normalizedRecoveryRef,
+        planDigest,
+        mutationKind:
+          kind === "adopt"
+            ? "task.adopt"
+            : kind === "periodic-create"
+              ? "task.create"
+              : "task.update",
+      },
+      null,
+    );
+  }
+
+  private projectTaskWorkflowExecution(
+    execution: TaskWorkflowDeveloperMutationExecutionResult,
+    plan: Pick<
+      DeveloperApiMutationPlan,
+      "recoveryRef" | "planDigest" | "mutationKind"
+    >,
+    operonId: string | null,
+  ): DeveloperApiMutationResult {
+    const status = execution.status ?? "failed";
+    const proof = this.taskWorkflowProof(execution);
+    const invalid = this.taskWorkflowResultViolation(execution, plan);
+    if (invalid) {
+      return this.mutationFailure(
+        "outcome-unknown",
+        `Operon returned an invalid task-workflow result after dispatch: ${invalid}`,
+        operonId,
+        false,
+        {
+          nativeStatus: status,
+          recoveryRef: execution.recovery?.recoveryRef ?? plan.recoveryRef,
+          planDigest: plan.planDigest,
+          mutationMayHaveApplied: true,
+          nativeProof: proof,
+        },
+      );
+    }
+    if (status === "applied" || status === "already-applied") {
+      return {
+        ok: true,
+        operonId,
+        code: status,
+        nativeStatus: status,
+        planDigest: execution.receipt?.planDigest ?? plan.planDigest,
+        recoveryRef: plan.recoveryRef,
+        retryable: false,
+        mutationMayHaveApplied: true,
+        nativeProof: proof,
+      };
+    }
+    if (status === "partial" || status === "outcome-unknown") {
+      return this.mutationFailure(
+        "outcome-unknown",
+        developerErrorMessage(execution.error) ||
+          "Operon requires recovery of the same task-workflow plan.",
+        operonId,
+        false,
+        {
+          nativeStatus: status,
+          recoveryRef: execution.recovery?.recoveryRef ?? plan.recoveryRef,
+          planDigest: execution.recovery?.planDigest ?? plan.planDigest,
+          mutationMayHaveApplied: true,
+          nativeProof: proof,
+        },
+      );
+    }
+    return this.mutationFailure(
+      this.mapNativeErrorCode(execution.error),
+      developerErrorMessage(execution.error),
+      operonId,
+      false,
+      { nativeStatus: status, recoveryRef: plan.recoveryRef, nativeProof: proof },
+    );
+  }
+
+  private taskWorkflowPlanViolation(
+    plan: TaskWorkflowDeveloperMutationPlan,
+  ): string | null {
+    const allowedKeys = new Set([
+      "contractVersion",
+      "kind",
+      "recoveryRef",
+      "planDigest",
+      "createdAt",
+      "expiresAt",
+      "riskLevel",
+      "requiresConsent",
+    ]);
+    if (
+      Object.keys(plan).length !== allowedKeys.size ||
+      Object.keys(plan).some((key) => !allowedKeys.has(key)) ||
+      [...allowedKeys].some(
+        (key) => !Object.prototype.hasOwnProperty.call(plan, key),
+      )
+    )
+      return "plan contains a non-public field";
+    if (
+      plan.contractVersion !== 1 ||
+      plan.kind !== "task-workflow-developer-mutation-plan"
+    )
+      return "plan discriminator is invalid";
+    if (!DEVELOPER_RECOVERY_REF.test(plan.recoveryRef))
+      return "recoveryRef is invalid";
+    if (!SHA256_HEX.test(plan.planDigest))
+      return "planDigest must be lowercase SHA-256 hex";
+    const createdAt = Date.parse(plan.createdAt);
+    const expiresAt = Date.parse(plan.expiresAt);
+    if (
+      !Number.isFinite(createdAt) ||
+      !Number.isFinite(expiresAt) ||
+      expiresAt <= createdAt
+    ) return "plan timestamps are invalid";
+    if (!["none", "routine", "elevated", "destructive"].includes(plan.riskLevel))
+      return "riskLevel is invalid";
+    if (typeof plan.requiresConsent !== "boolean")
+      return "requiresConsent must be boolean";
+    return null;
+  }
+
+  private taskWorkflowPreviewViolation(
+    preview: TaskWorkflowDeveloperMutationPreviewResult,
+  ): string | null {
+    if (preview.contractVersion !== 1)
+      return "contractVersion must equal 1";
+    if (preview.kind !== "task-workflow-developer-mutation-preview-result")
+      return "kind must be task-workflow-developer-mutation-preview-result";
+    if (
+      typeof preview.requestId !== "string" ||
+      !preview.requestId ||
+      preview.requestId.length > 128
+    ) return "requestId is invalid";
+    if (!Array.isArray(preview.warnings)) return "warnings must be an array";
+    if (preview.ok) {
+      if (!preview.plan || preview.error !== undefined)
+        return "successful preview union is inconsistent";
+      return null;
+    }
+    if (preview.plan !== undefined || !isRecord(preview.error))
+      return "failed preview union is inconsistent";
+    return null;
+  }
+
+  private taskWorkflowPendingViolation(
+    pending: DeveloperApiPendingRecoveriesResult,
+  ): string | null {
+    if (pending.contractVersion !== 1)
+      return "contractVersion must equal 1";
+    if (
+      pending.kind !==
+      "task-workflow-developer-pending-recoveries-result"
+    )
+      return "kind must be task-workflow-developer-pending-recoveries-result";
+    if (pending.ok) {
+      if (!Array.isArray(pending.recoveries) || pending.error !== undefined)
+        return "successful pending recovery union is inconsistent";
+      if (
+        pending.recoveries.length > 512 ||
+        pending.recoveries.some((recovery) => {
+          const createdAt = Date.parse(String(recovery.createdAt ?? ""));
+          const expiresAt = Date.parse(String(recovery.expiresAt ?? ""));
+          return (
+            !DEVELOPER_RECOVERY_REF.test(String(recovery.recoveryRef ?? "")) ||
+            !SHA256_HEX.test(String(recovery.planDigest ?? "")) ||
+            !Number.isFinite(createdAt) ||
+            !Number.isFinite(expiresAt) ||
+            expiresAt <= createdAt
+          );
+        })
+      ) return "pending recovery entries are invalid or unbounded";
+      return null;
+    }
+    if (pending.recoveries !== undefined || !isRecord(pending.error))
+      return "failed pending recovery union is inconsistent";
+    return null;
+  }
+
+  private baseMutationResultViolation(
+    execution: DeveloperApiMutationExecutionResult,
+    plan: DeveloperApiMutationPlan,
+  ): string | null {
+    if (execution.contractVersion !== 1) return "contractVersion must equal 1";
+    if (execution.kind !== "developer-mutation-execution-result")
+      return "kind must be developer-mutation-execution-result";
+    if (
+      typeof execution.requestId !== "string" ||
+      !execution.requestId ||
+      execution.requestId.length > 128
+    ) return "requestId is invalid";
+    if (
+      typeof plan.planDigest !== "string" ||
+      !SHA256_HEX.test(plan.planDigest) ||
+      typeof plan.mutationKind !== "string" ||
+      !plan.mutationKind ||
+      plan.mutationKind.length > 128
+    ) return "sealed preview plan identity is invalid";
+    if (
+      !Array.isArray(execution.groupResults) ||
+      execution.groupResults.length > 32
+    ) return "groupResults must be a bounded array";
+    const resourceKinds = new Set([
+      "timer",
+      "repeat-series",
+      "active-tracker",
+      "pinned",
+      "project-serial",
+      "task-source",
+    ]);
+    for (const group of execution.groupResults) {
+      if (
+        typeof group.groupId !== "string" ||
+        !group.groupId ||
+        group.groupId.length > 256 ||
+        !["committed", "failed", "outcome-unknown"].includes(
+          String(group.status),
+        ) ||
+        (group.resourceRevisions !== undefined &&
+          (!Array.isArray(group.resourceRevisions) ||
+            group.resourceRevisions.length > 64))
+      ) return "groupResults contain an invalid group";
+      for (const revision of group.resourceRevisions ?? []) {
+        if (
+          !resourceKinds.has(String(revision.resourceKind)) ||
+          typeof revision.resourceKey !== "string" ||
+          !revision.resourceKey ||
+          revision.resourceKey.length > 1024 ||
+          typeof revision.revision !== "string" ||
+          !revision.revision ||
+          revision.revision.length > 256
+        ) return "groupResults contain an invalid resource revision";
+      }
+    }
+    const receipt = execution.receipt;
+    const receiptMatches =
+      receipt?.contractVersion === 1 &&
+      receipt.planDigest === plan.planDigest &&
+      receipt.mutationKind === plan.mutationKind &&
+      typeof receipt.targetDigest === "string" &&
+      SHA256_HEX.test(receipt.targetDigest) &&
+      typeof receipt.effectiveAt === "string" &&
+      Number.isFinite(Date.parse(receipt.effectiveAt)) &&
+      typeof receipt.completedAt === "string" &&
+      Number.isFinite(Date.parse(receipt.completedAt)) &&
+      typeof receipt.expiresAt === "string" &&
+      Number.isFinite(Date.parse(receipt.expiresAt));
+    if (execution.status === "applied") {
+      if (
+        execution.mutationMayHaveApplied !== true ||
+        execution.retryAllowed !== false ||
+        execution.error !== undefined ||
+        execution.recovery !== undefined ||
+        execution.groupResults.length === 0 ||
+        execution.groupResults.some((group) => group.status !== "committed") ||
+        !receiptMatches ||
+        receipt?.terminalOutcome !== "applied" ||
+        execution.postflight?.status !== "verified" ||
+        typeof execution.postflight.observedAt !== "string" ||
+        !Number.isFinite(Date.parse(execution.postflight.observedAt))
+      ) return "applied union is inconsistent with the sealed plan";
+      return null;
+    }
+    if (execution.status === "already-applied") {
+      if (
+        execution.mutationMayHaveApplied !== true ||
+        execution.retryAllowed !== false ||
+        execution.error !== undefined ||
+        execution.recovery !== undefined ||
+        execution.groupResults.length !== 0 ||
+        !receiptMatches ||
+        receipt?.terminalOutcome !== "already-applied" ||
+        execution.postflight?.status !== "receipt-replay"
+      ) return "already-applied union is inconsistent with the sealed plan";
+      return null;
+    }
+    if (execution.status === "failed") {
+      if (
+        execution.mutationMayHaveApplied !== false ||
+        execution.retryAllowed !== false ||
+        !isRecord(execution.error) ||
+        execution.receipt !== undefined ||
+        execution.postflight !== undefined ||
+        execution.recovery !== undefined ||
+        execution.groupResults.some(
+          (group) =>
+            group.status === "committed" || group.status === "outcome-unknown",
+        )
+      ) return "failed union contains side-effect evidence";
+      return null;
+    }
+    if (
+      execution.status === "partial" ||
+      execution.status === "outcome-unknown"
+    ) {
+      const recovery = execution.recovery;
+      if (
+        execution.mutationMayHaveApplied !== true ||
+        execution.retryAllowed !== false ||
+        !isRecord(execution.error) ||
+        execution.receipt !== undefined ||
+        execution.postflight !== undefined ||
+        recovery?.required !== true ||
+        recovery.action !== "recover-same-plan" ||
+        recovery.mutationMayHaveApplied !== true ||
+        recovery.recoveryRef !== plan.recoveryRef ||
+        recovery.planDigest !== plan.planDigest ||
+        !recovery.plan ||
+        recovery.plan.recoveryRef !== plan.recoveryRef ||
+        recovery.plan.planDigest !== plan.planDigest ||
+        recovery.plan.mutationKind !== plan.mutationKind
+      ) return "uncertain union does not preserve the same sealed plan";
+      return null;
+    }
+    return "status is not part of the Developer API mutation result union";
+  }
+
+  private baseMutationProof(
+    execution: DeveloperApiMutationExecutionResult,
+  ): DeveloperApiTaskWorkflowNativeProof {
+    type ProofGroup = DeveloperApiTaskWorkflowNativeProof["groupResults"][number];
+    type ProofRevision = NonNullable<ProofGroup["resourceRevisions"]>[number];
+    const groupResults: ProofGroup[] = (execution.groupResults ?? []).map(
+      (group) => {
+        const resourceRevisions: ProofRevision[] = (
+          group.resourceRevisions ?? []
+        ).map((revision) => ({
+          resourceKind: revision.resourceKind as ProofRevision["resourceKind"],
+          resourceKey: revision.resourceKey as string,
+          revision: revision.revision as string,
+        }));
+        return {
+          groupId: group.groupId as string,
+          status: group.status as ProofGroup["status"],
+          ...(group.resourceRevisions ? { resourceRevisions } : {}),
+        };
+      },
+    );
+    const receipt = execution.receipt;
+    const postflight = execution.postflight;
+    return {
+      contractVersion: 1,
+      kind: "mutation-result",
+      status: execution.status as DeveloperApiTaskWorkflowNativeProof["status"],
+      mutationMayHaveApplied: execution.mutationMayHaveApplied as boolean,
+      retryAllowed: execution.retryAllowed as boolean,
+      groupResults,
+      ...(receipt
+        ? {
+            receipt: {
+              contractVersion: 1,
+              planDigest: receipt.planDigest as string,
+              mutationKind: receipt.mutationKind as string,
+              targetDigest: receipt.targetDigest as string,
+              terminalOutcome: receipt.terminalOutcome as
+                | "applied"
+                | "already-applied",
+              effectiveAt: receipt.effectiveAt as string,
+              completedAt: receipt.completedAt as string,
+              expiresAt: receipt.expiresAt as string,
+            },
+          }
+        : {}),
+      ...(postflight?.status === "verified" ||
+      postflight?.status === "receipt-replay"
+        ? {
+            postflight: {
+              status: postflight.status,
+              ...(typeof postflight.observedAt === "string"
+                ? { observedAt: postflight.observedAt }
+                : {}),
+            },
+          }
+        : {}),
+    };
+  }
+
+  private taskWorkflowProof(
+    execution: TaskWorkflowDeveloperMutationExecutionResult,
+  ): DeveloperApiTaskWorkflowNativeProof | undefined {
+    const statuses = new Set([
+      "applied",
+      "already-applied",
+      "partial",
+      "failed",
+      "outcome-unknown",
+    ] as const);
+    const groupStatuses = new Set([
+      "committed",
+      "failed",
+      "outcome-unknown",
+    ] as const);
+    const resourceKinds = new Set([
+      "timer",
+      "repeat-series",
+      "active-tracker",
+      "pinned",
+      "project-serial",
+      "task-source",
+    ] as const);
+    const mutationKinds = new Set([
+      "task.adopt",
+      "task.create",
+      "task.update",
+    ] as const);
+    if (
+      execution.contractVersion !== 1 ||
+      execution.kind !==
+        "task-workflow-developer-mutation-execution-result" ||
+      !statuses.has(execution.status as never) ||
+      typeof execution.mutationMayHaveApplied !== "boolean" ||
+      typeof execution.retryAllowed !== "boolean" ||
+      !Array.isArray(execution.groupResults) ||
+      execution.groupResults.length > 32
+    ) return undefined;
+    type ProofGroup = DeveloperApiTaskWorkflowNativeProof["groupResults"][number];
+    type ProofRevision = NonNullable<ProofGroup["resourceRevisions"]>[number];
+    const groupResults: ProofGroup[] = [];
+    for (const group of execution.groupResults) {
+      if (
+        typeof group.groupId !== "string" ||
+        !group.groupId ||
+        group.groupId.length > 256 ||
+        !groupStatuses.has(group.status as never) ||
+        (group.resourceRevisions !== undefined &&
+          (!Array.isArray(group.resourceRevisions) ||
+            group.resourceRevisions.length > 64))
+      ) return undefined;
+      const resourceRevisions: ProofRevision[] = [];
+      for (const revision of group.resourceRevisions ?? []) {
+        if (
+          !resourceKinds.has(revision.resourceKind as never) ||
+          typeof revision.resourceKey !== "string" ||
+          !revision.resourceKey ||
+          revision.resourceKey.length > 1024 ||
+          typeof revision.revision !== "string" ||
+          !revision.revision ||
+          revision.revision.length > 256
+        ) return undefined;
+        resourceRevisions.push({
+          resourceKind: revision.resourceKind as ProofRevision["resourceKind"],
+          resourceKey: revision.resourceKey,
+          revision: revision.revision,
+        });
+      }
+      groupResults.push({
+        groupId: group.groupId,
+        status: group.status as ProofGroup["status"],
+        ...(group.resourceRevisions ? { resourceRevisions } : {}),
+      });
+    }
+    const receipt = execution.receipt;
+    const projectedReceipt: DeveloperApiTaskWorkflowNativeProof["receipt"] =
+      receipt?.contractVersion === 1 &&
+      typeof receipt.planDigest === "string" &&
+      SHA256_HEX.test(receipt.planDigest) &&
+      mutationKinds.has(receipt.mutationKind as never) &&
+      typeof receipt.targetDigest === "string" &&
+      SHA256_HEX.test(receipt.targetDigest) &&
+      (receipt.terminalOutcome === "applied" ||
+        receipt.terminalOutcome === "already-applied") &&
+      typeof receipt.effectiveAt === "string" &&
+      Number.isFinite(Date.parse(receipt.effectiveAt)) &&
+      typeof receipt.completedAt === "string" &&
+      Number.isFinite(Date.parse(receipt.completedAt)) &&
+      typeof receipt.expiresAt === "string"
+      && Number.isFinite(Date.parse(receipt.expiresAt))
+        ? {
+            contractVersion: 1 as const,
+            planDigest: receipt.planDigest,
+            mutationKind: receipt.mutationKind as NonNullable<
+              DeveloperApiTaskWorkflowNativeProof["receipt"]
+            >["mutationKind"],
+            targetDigest: receipt.targetDigest,
+            terminalOutcome: receipt.terminalOutcome as NonNullable<
+              DeveloperApiTaskWorkflowNativeProof["receipt"]
+            >["terminalOutcome"],
+            effectiveAt: receipt.effectiveAt.slice(0, 64),
+            completedAt: receipt.completedAt.slice(0, 64),
+            expiresAt: receipt.expiresAt.slice(0, 64),
+          }
+        : undefined;
+    const postflight = execution.postflight;
+    const projectedPostflight:
+      | DeveloperApiTaskWorkflowNativeProof["postflight"]
+      | undefined =
+      postflight?.status === "verified" ||
+      postflight?.status === "receipt-replay"
+        ? {
+            status: postflight.status,
+            ...(typeof postflight.observedAt === "string"
+              ? {
+                  observedAt: Number.isFinite(Date.parse(postflight.observedAt))
+                    ? postflight.observedAt.slice(0, 64)
+                    : undefined,
+                }
+              : {}),
+          }
+        : undefined;
+    return {
+      contractVersion: 1,
+      kind: "mutation-result",
+      status: execution.status as DeveloperApiTaskWorkflowNativeProof["status"],
+      mutationMayHaveApplied: execution.mutationMayHaveApplied,
+      retryAllowed: execution.retryAllowed,
+      groupResults,
+      ...(projectedReceipt ? { receipt: projectedReceipt } : {}),
+      ...(projectedPostflight ? { postflight: projectedPostflight } : {}),
+    };
+  }
+
+  private taskWorkflowResourceKeys(
+    execution: TaskWorkflowDeveloperMutationExecutionResult,
+  ): Set<string> {
+    const keys = new Set<string>();
+    for (const group of execution.groupResults ?? []) {
+      for (const revision of group.resourceRevisions ?? []) {
+        if (!isRecord(revision)) continue;
+        if (
+          revision.resourceKind === "task-source" &&
+          typeof revision.resourceKey === "string" &&
+          revision.resourceKey
+        ) keys.add(revision.resourceKey);
+      }
+    }
+    return keys;
+  }
+
+  private taskWorkflowResultViolation(
+    execution: TaskWorkflowDeveloperMutationExecutionResult,
+    plan: Pick<
+      DeveloperApiMutationPlan,
+      "recoveryRef" | "planDigest" | "mutationKind"
+    >,
+  ): string | null {
+    if (execution.contractVersion !== 1) return "contractVersion must equal 1";
+    if (
+      execution.kind !==
+      "task-workflow-developer-mutation-execution-result"
+    )
+      return "kind must be task-workflow-developer-mutation-execution-result";
+    if (
+      typeof execution.requestId !== "string" ||
+      !execution.requestId ||
+      execution.requestId.length > 128
+    ) return "requestId is invalid";
+    if (!Array.isArray(execution.groupResults)) return "groupResults must be an array";
+    const status = execution.status;
+    const groups = execution.groupResults;
+    const receipt = execution.receipt;
+    const digestMatches =
+      receipt?.contractVersion === 1 &&
+      typeof receipt.planDigest === "string" &&
+      SHA256_HEX.test(receipt.planDigest) &&
+      receipt.planDigest === plan.planDigest;
+    const receiptStructureMatches =
+      digestMatches &&
+      receipt?.mutationKind === plan.mutationKind &&
+      typeof receipt.targetDigest === "string" &&
+      SHA256_HEX.test(receipt.targetDigest) &&
+      typeof receipt.effectiveAt === "string" &&
+      Number.isFinite(Date.parse(receipt.effectiveAt)) &&
+      typeof receipt.completedAt === "string" &&
+      Number.isFinite(Date.parse(receipt.completedAt)) &&
+      typeof receipt.expiresAt === "string" &&
+      Number.isFinite(Date.parse(receipt.expiresAt));
+    if (status === "applied") {
+      if (
+        execution.mutationMayHaveApplied !== true ||
+        execution.retryAllowed !== false ||
+        execution.error !== undefined ||
+        execution.recovery !== undefined
+      ) return "applied must be terminal and non-retryable";
+      if (
+        groups.length === 0 ||
+        groups.some(
+          (group) =>
+            !group ||
+            typeof group.groupId !== "string" ||
+            !group.groupId ||
+            group.status !== "committed" ||
+            (group.resourceRevisions !== undefined &&
+              (!Array.isArray(group.resourceRevisions) ||
+                group.resourceRevisions.length > 64 ||
+                group.resourceRevisions.some(
+                  (revision: {
+                    resourceKind?: string;
+                    resourceKey?: string;
+                    revision?: string;
+                  }) =>
+                    typeof revision.resourceKind !== "string" ||
+                    !revision.resourceKind ||
+                    typeof revision.resourceKey !== "string" ||
+                    !revision.resourceKey ||
+                    typeof revision.revision !== "string" ||
+                    !revision.revision,
+                ))),
+        )
+      ) return "applied requires non-empty committed groupResults";
+      if (new Set(groups.map((group) => group.groupId)).size !== groups.length)
+        return "groupResults contain duplicate group ids";
+      if (!receiptStructureMatches || receipt?.terminalOutcome !== "applied")
+        return "applied receipt does not match the sealed plan";
+      if (
+        execution.postflight?.status !== "verified" ||
+        typeof execution.postflight.observedAt !== "string" ||
+        !Number.isFinite(Date.parse(execution.postflight.observedAt))
+      )
+        return "applied requires verified postflight";
+      return null;
+    }
+    if (status === "already-applied") {
+      if (
+        execution.mutationMayHaveApplied !== true ||
+        execution.retryAllowed !== false ||
+        groups.length !== 0 ||
+        execution.error !== undefined ||
+        execution.recovery !== undefined
+      ) return "already-applied requires no new groups and no retry";
+      if (!receiptStructureMatches || receipt?.terminalOutcome !== "already-applied")
+        return "already-applied receipt does not match the sealed plan";
+      if (execution.postflight?.status !== "receipt-replay")
+        return "already-applied requires receipt-replay postflight";
+      return null;
+    }
+    if (status === "failed") {
+      if (
+        execution.mutationMayHaveApplied !== false ||
+        execution.retryAllowed !== false ||
+        !execution.error ||
+        receipt ||
+        execution.postflight ||
+        execution.recovery ||
+        groups.some((group) => group.status === "committed" || group.status === "outcome-unknown")
+      ) return "failed result has inconsistent side-effect evidence";
+      return null;
+    }
+    if (status === "partial" || status === "outcome-unknown") {
+      const recovery = execution.recovery;
+      if (
+        execution.mutationMayHaveApplied !== true ||
+        execution.retryAllowed !== false ||
+        !execution.error ||
+        execution.receipt !== undefined ||
+        execution.postflight !== undefined ||
+        recovery?.required !== true ||
+        recovery.action !== "recover-same-plan" ||
+        recovery.mutationMayHaveApplied !== true ||
+        recovery.recoveryRef !== plan.recoveryRef ||
+        recovery.planDigest !== plan.planDigest ||
+        !recovery.plan ||
+        this.taskWorkflowPlanViolation(recovery.plan) !== null ||
+        recovery.plan.recoveryRef !== recovery.recoveryRef ||
+        recovery.plan.planDigest !== recovery.planDigest
+      ) return "uncertain result must be non-retryable and may have applied";
+      return null;
+    }
+    return "status is not part of the task-workflow result union";
+  }
+
+  private taskWorkflowPlanMetadata(
+    plan: TaskWorkflowDeveloperMutationPlan,
+    kind: DeveloperApiTaskWorkflowKind,
+  ): DeveloperApiMutationPlan {
+    return {
+      planDigest: plan.planDigest,
+      recoveryRef: plan.recoveryRef,
+      capability: TASK_WORKFLOW_CAPABILITIES[kind][0],
+      mutationKind:
+        kind === "adopt"
+          ? "task.adopt"
+          : kind === "periodic-create"
+            ? "task.create"
+            : "task.update",
+      createdAt: plan.createdAt,
+      expiresAt: plan.expiresAt,
+      riskLevel: plan.riskLevel,
+      requiresConsent: plan.requiresConsent,
+    };
+  }
+
+  private async reloadLiveTasks(): Promise<{
+    tasks: RuntimeIndexedTask[];
+    rawTasks: DeveloperApiTask[];
+  }> {
+    if (!this.readApi)
+      throw new Error("Operon live read session is unavailable.");
+    const live = await this.readAllTasks(this.readApi);
+    this.tasks = live.tasks;
+    this.rawTasks = live.rawTasks;
+    this.indexer.taskCount = live.tasks.length;
+    if (live.generation !== null) this.generation = live.generation;
+    return live;
+  }
+
+  async refreshLiveTaskSnapshot(): Promise<void> {
+    await this.reloadLiveTasks();
   }
 
   async pendingRecoveries(): Promise<DeveloperApiPendingRecoveryResult> {
@@ -1875,7 +3425,11 @@ export class OperonDeveloperApiRuntimeAdapter {
     error: DeveloperApiError | undefined,
   ): DeveloperApiMutationResult["code"] {
     const code = String(error?.code ?? "").toLocaleLowerCase();
-    if (code.includes("conflict") || code.includes("revision"))
+    if (
+      code === "stale-source" ||
+      code.includes("conflict") ||
+      code.includes("revision")
+    )
       return "conflict";
     if (code.includes("not-found") || code.includes("missing"))
       return "not-found";
@@ -2001,6 +3555,11 @@ export class OperonDeveloperApiRuntimeAdapter {
       return { field: canonical, valueType, value: parsed };
     }
     if (valueType === "list") {
+      if (canonical === "taskGallery" && !Array.isArray(value)) {
+        throw new Error(
+          "Field 'taskGallery' requires an ordered string array; the Bridge never splits media references heuristically.",
+        );
+      }
       const values = Array.isArray(value)
         ? value
             .map(String)
@@ -2411,7 +3970,7 @@ export class OperonDeveloperApiRuntimeAdapter {
     const fields: Record<string, unknown>[] = [];
     const rawFields = requested.fields;
     let statusId = String(requested.statusId ?? "").trim() || null;
-    let priorityId: string | null = null;
+    let priorityId = String(requested.priorityId ?? "").trim() || null;
     let parent: Record<string, unknown> | undefined;
     const related: Record<string, unknown>[] = [];
     const dependencies: Record<string, unknown>[] = [];
@@ -2561,6 +4120,11 @@ export class OperonDeveloperApiRuntimeAdapter {
         : { kind: "number", field, value: parsed };
     }
     if (valueType === "list") {
+      if (field === "taskGallery" && !Array.isArray(value)) {
+        throw new Error(
+          "Create field 'taskGallery' requires an ordered string array; the Bridge never splits media references heuristically.",
+        );
+      }
       const list = this.listInput(value);
       return custom
         ? { kind: "custom", field, valueType, value: list }

--- a/plugins/obsidian-operon-bridge/src/main.ts
+++ b/plugins/obsidian-operon-bridge/src/main.ts
@@ -1386,8 +1386,9 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
     idempotencyKey: string,
     signature: string,
     payload: Record<string, unknown>,
+    httpStatusOverride?: number,
   ): void {
-    const httpStatus = this.mutationHttpStatus(payload);
+    const httpStatus = httpStatusOverride ?? this.mutationHttpStatus(payload);
     this.mutationResults.set(idempotencyKey, { signature, payload, httpStatus });
     this.mutationResultTimes.set(idempotencyKey, new Date().toISOString());
     this.mutationReservations.complete(idempotencyKey, signature, payload);
@@ -2694,23 +2695,49 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
     const runtime = this.requireMutationRuntime(capability);
     const beforeRead = await this.oneTask(operonId, true);
     if (!beforeRead.task) {
-      return {
-        httpStatus: 404,
-        payload: errorPayload(
+      const payload = {
+        ...errorPayload(
           new Error(`Operon task not found: ${operonId}`),
           "not_found",
         ),
+        operationId:
+          this.mutationReservations.get(idempotencyKey)?.operationId ??
+          this.mutationOperationId(),
+        idempotencyKey,
+        status: "rejected",
+        before: null,
+        requested,
+        after: null,
+        retryable: false,
+        mutationMayHaveApplied: false,
+        source: "operon-live",
+        stale: false,
       };
+      this.cacheMutation(idempotencyKey, signature, payload, 404);
+      return { httpStatus: 404, payload };
     }
     const expectedRevision = String(body.expectedRevision ?? "").trim();
     if (!expectedRevision) {
-      return {
-        httpStatus: 400,
-        payload: errorPayload(
+      const payload = {
+        ...errorPayload(
           new Error("expectedRevision is required."),
           "validation_error",
         ),
+        operationId:
+          this.mutationReservations.get(idempotencyKey)?.operationId ??
+          this.mutationOperationId(),
+        idempotencyKey,
+        status: "rejected",
+        before: beforeRead.task,
+        requested,
+        after: beforeRead.task,
+        retryable: false,
+        mutationMayHaveApplied: false,
+        source: "operon-live",
+        stale: false,
       };
+      this.cacheMutation(idempotencyKey, signature, payload, 400);
+      return { httpStatus: 400, payload };
     }
     const operationId = this.mutationOperationId();
     if (expectedRevision !== beforeRead.task.revision) {

--- a/plugins/obsidian-operon-bridge/src/main.ts
+++ b/plugins/obsidian-operon-bridge/src/main.ts
@@ -1386,9 +1386,8 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
     idempotencyKey: string,
     signature: string,
     payload: Record<string, unknown>,
-    httpStatusOverride?: number,
   ): void {
-    const httpStatus = httpStatusOverride ?? this.mutationHttpStatus(payload);
+    const httpStatus = this.mutationHttpStatus(payload);
     this.mutationResults.set(idempotencyKey, { signature, payload, httpStatus });
     this.mutationResultTimes.set(idempotencyKey, new Date().toISOString());
     this.mutationReservations.complete(idempotencyKey, signature, payload);
@@ -1533,8 +1532,8 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       );
     }
     const runtime = this.requireRuntime();
-    this.assertMutationRuntimeAdmitted(runtime);
     if (runtime.developerApi) {
+      this.assertMutationRuntimeAdmitted(runtime);
       if (
         capability === "adopt" &&
         !runtime.developerApi.hasTaskWorkflowCapability("adopt")
@@ -2678,11 +2677,41 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       dryRun: body.dryRun !== false,
       requested,
     });
+    const expectedRevision = String(body.expectedRevision ?? "").trim();
+    const validation = resolveMutationPreflight({
+      cached: this.mutationResults.get(idempotencyKey),
+      idempotencyKey,
+      signature,
+      requested,
+      validate: () =>
+        mutationPathValidationError(capability, requested) ??
+        (expectedRevision ? null : "expectedRevision is required."),
+      operationId: () => this.mutationOperationId(),
+    });
+    if (validation.kind === "response") return validation.response;
+    if (validation.kind === "validation-error") {
+      return {
+        httpStatus: 400,
+        payload: errorPayload(new Error(validation.message), "validation_error"),
+      };
+    }
+
+    const runtime = this.requireMutationRuntime(capability);
+    const beforeRead = await this.oneTask(operonId, true);
+    if (!beforeRead.task) {
+      return {
+        httpStatus: 404,
+        payload: errorPayload(
+          new Error(`Operon task not found: ${operonId}`),
+          "not_found",
+        ),
+      };
+    }
     const preflight = await this.mutationPreflight(
       idempotencyKey,
       signature,
       requested,
-      () => mutationPathValidationError(capability, requested),
+      () => null,
     );
     if (preflight.kind === "response") return preflight.response;
     if (preflight.kind === "validation-error") {
@@ -2690,54 +2719,6 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
         httpStatus: 400,
         payload: errorPayload(new Error(preflight.message), "validation_error"),
       };
-    }
-
-    const runtime = this.requireMutationRuntime(capability);
-    const beforeRead = await this.oneTask(operonId, true);
-    if (!beforeRead.task) {
-      const payload = {
-        ...errorPayload(
-          new Error(`Operon task not found: ${operonId}`),
-          "not_found",
-        ),
-        operationId:
-          this.mutationReservations.get(idempotencyKey)?.operationId ??
-          this.mutationOperationId(),
-        idempotencyKey,
-        status: "rejected",
-        before: null,
-        requested,
-        after: null,
-        retryable: false,
-        mutationMayHaveApplied: false,
-        source: "operon-live",
-        stale: false,
-      };
-      this.cacheMutation(idempotencyKey, signature, payload, 404);
-      return { httpStatus: 404, payload };
-    }
-    const expectedRevision = String(body.expectedRevision ?? "").trim();
-    if (!expectedRevision) {
-      const payload = {
-        ...errorPayload(
-          new Error("expectedRevision is required."),
-          "validation_error",
-        ),
-        operationId:
-          this.mutationReservations.get(idempotencyKey)?.operationId ??
-          this.mutationOperationId(),
-        idempotencyKey,
-        status: "rejected",
-        before: beforeRead.task,
-        requested,
-        after: beforeRead.task,
-        retryable: false,
-        mutationMayHaveApplied: false,
-        source: "operon-live",
-        stale: false,
-      };
-      this.cacheMutation(idempotencyKey, signature, payload, 400);
-      return { httpStatus: 400, payload };
     }
     const operationId = this.mutationOperationId();
     if (expectedRevision !== beforeRead.task.revision) {

--- a/plugins/obsidian-operon-bridge/src/main.ts
+++ b/plugins/obsidian-operon-bridge/src/main.ts
@@ -3,10 +3,14 @@ import {
   OPERON_BRIDGE_CONTRACT_VERSION,
   OPERON_BRIDGE_LEGACY_VERSIONS,
   OPERON_BRIDGE_BLOCKED_MUTATIONS,
+  isMutationAdmittedDeveloperApiVersion,
   OPERON_BRIDGE_TESTED_VERSION,
   isIndexReady,
   isCanonicalVaultRelativePath,
   isCanonicalVaultMarkdownPath,
+  interruptedMutationPayload,
+  managedFieldOutcomeMatches,
+  MutationReservationRegistry,
   mutationPathValidationError,
   resolveOperonCompatibility,
   resolveMutationPreflight,
@@ -15,6 +19,7 @@ import {
   normalizeTask,
   queryTasks,
   settingsSignature,
+  stablePriorityOutcomeMatches,
   shouldAttemptIndexValidation,
   type OperonBridgeTask,
   type OperonTaskQuery,
@@ -37,6 +42,7 @@ import {
   type DeveloperApiReadCapability,
   type DeveloperApiMutationCapability,
   type DeveloperApiMutationResult,
+  type DeveloperApiTaskWorkflowKind,
 } from "./developer-api-adapter";
 
 const EXTENSION_ID = "optimike-operon-bridge";
@@ -44,9 +50,23 @@ const REST_PREFIX = `/extensions/${EXTENSION_ID}/v1`;
 const LOCAL_REST_PLUGIN_ID = "obsidian-local-rest-api";
 const MAX_MOUNT_WAIT_MS = 30_000;
 const MOUNT_RETRY_MS = 500;
+const MUTATION_JOURNAL_VERSION = 1;
+const MUTATION_JOURNAL_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
+const MUTATION_JOURNAL_LIMIT = 500;
 
 interface OptimikeOperonBridgeSettings {
   mutationsEnabled: boolean;
+}
+
+interface PersistedMutationJournalEntry {
+  idempotencyKey: string;
+  signature: string;
+  state: "in-progress" | "terminal";
+  updatedAt: string;
+  operationId: string;
+  requested?: Record<string, unknown>;
+  payload?: Record<string, unknown>;
+  httpStatus?: number;
 }
 
 const DEFAULT_BRIDGE_SETTINGS: OptimikeOperonBridgeSettings = {
@@ -121,6 +141,8 @@ interface BridgeCapabilities {
   context: boolean;
   timers: boolean;
   adopt: boolean;
+  periodicCreate: boolean;
+  periodicUpdate: boolean;
   create: boolean;
   update: boolean;
   transition: boolean;
@@ -130,6 +152,7 @@ interface BridgeCapabilities {
   filterQuery: boolean;
   relocate: boolean;
   recovery: boolean;
+  taskWorkflowRecovery: boolean;
 }
 
 interface OperonPublicMutationResult {
@@ -193,6 +216,8 @@ interface StableTaskRead {
   generation: number;
   settingsSignature: string;
 }
+
+const STABLE_READ_MAX_ATTEMPTS = 2;
 
 const BASE_LIMITATIONS = [
   "Exact Operon semantics require Obsidian Desktop with Operon loaded; headless clients must treat persisted MCP snapshots as stale fallbacks.",
@@ -310,7 +335,10 @@ function sanitizeQuery(input: unknown): OperonTaskQuery {
   ) {
     query.fieldEquals = Object.fromEntries(
       Object.entries(source.fieldEquals as Record<string, unknown>).map(
-        ([key, value]) => [key, String(value)],
+        ([key, value]) => [
+          key,
+          Array.isArray(value) ? value.map(String) : String(value),
+        ],
       ),
     );
   }
@@ -349,13 +377,21 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
   private mountTimeout: number | null = null;
   private indexValidationInFlight: Promise<void> | null = null;
   private mutationResults = new Map<string, CachedMutation>();
+  private mutationResultTimes = new Map<string, string>();
+  private mutationReservations = new MutationReservationRegistry();
+  private dataWriteChain: Promise<void> = Promise.resolve();
+  private dataWriteFailed = false;
   private developerApiAdapter: OperonDeveloperApiRuntimeAdapter | null = null;
   private developerApiPlugin: object | null = null;
 
   async onload(): Promise<void> {
-    const stored =
-      (await this.loadData()) as Partial<OptimikeOperonBridgeSettings> | null;
-    this.settings = { ...DEFAULT_BRIDGE_SETTINGS, ...(stored ?? {}) };
+    const stored = (await this.loadData()) as Record<string, unknown> | null;
+    const storedSettings =
+      stored?.settings && typeof stored.settings === "object"
+        ? (stored.settings as Partial<OptimikeOperonBridgeSettings>)
+        : (stored as Partial<OptimikeOperonBridgeSettings> | null);
+    this.settings = { ...DEFAULT_BRIDGE_SETTINGS, ...(storedSettings ?? {}) };
+    this.restoreMutationJournal(stored?.mutationJournal);
     this.addSettingTab(new OptimikeOperonBridgeSettingTab(this.app, this));
     this.app.workspace.onLayoutReady(() => {
       this.tryMountRestExtension();
@@ -383,8 +419,8 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
 
   async setMutationsEnabled(value: boolean): Promise<void> {
     this.settings.mutationsEnabled = value;
-    this.mutationResults.clear();
-    await this.saveData(this.settings);
+    this.queuePersistPluginData();
+    await this.dataWriteChain;
   }
   private clearMountTimers(): void {
     if (this.mountInterval !== null) window.clearInterval(this.mountInterval);
@@ -692,7 +728,10 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
     if (runtime?.developerApi) {
       const readable = Boolean(runtime.compatible && ready);
       const mutationEnabled = Boolean(
-        runtime.compatible && ready && this.settings.mutationsEnabled,
+        runtime.compatible &&
+          ready &&
+          this.settings.mutationsEnabled &&
+          isMutationAdmittedDeveloperApiVersion(runtime.version),
       );
       const supports = (capability: DeveloperApiMutationCapability): boolean =>
         mutationEnabled &&
@@ -724,7 +763,15 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
           readable && runtime.developerApi!.hasReadCapability("context.build"),
         timers:
           readable && runtime.developerApi!.hasReadCapability("timers.read"),
-        adopt: false,
+        adopt:
+          mutationEnabled &&
+          runtime.developerApi!.hasTaskWorkflowCapability("adopt"),
+        periodicCreate:
+          mutationEnabled &&
+          runtime.developerApi!.hasTaskWorkflowCapability("periodic-create"),
+        periodicUpdate:
+          mutationEnabled &&
+          runtime.developerApi!.hasTaskWorkflowCapability("periodic-update"),
         create: supports("create"),
         update: supports("update"),
         transition: supports("transition"),
@@ -735,6 +782,12 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
         relocate: supports("relocate"),
         convert: supports("convert"),
         recovery: mutationEnabled && runtime.developerApi!.hasRecoverySupport(),
+        taskWorkflowRecovery:
+          mutationEnabled &&
+          (["adopt", "periodic-create", "periodic-update"] as const).some(
+            (kind) =>
+              runtime.developerApi!.hasTaskWorkflowRecoverySupport(kind),
+          ),
       };
     }
     const readable = Boolean(runtime?.compatible && ready);
@@ -755,6 +808,8 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       context: false,
       timers: false,
       adopt: Boolean(mutation?.ready && mutation.adopt),
+      periodicCreate: false,
+      periodicUpdate: false,
       create: Boolean(mutation?.ready && mutation.create),
       update: Boolean(mutation?.ready && mutation.update),
       transition: Boolean(mutation?.ready && mutation.transition),
@@ -766,6 +821,7 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       relocate: Boolean(mutation?.ready && mutation.relocate),
       convert: Boolean(mutation?.ready && mutation.convert),
       recovery: false,
+      taskWorkflowRecovery: false,
     };
   }
 
@@ -776,6 +832,9 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       capabilities.transition ||
       capabilities.relationshipMutation ||
       capabilities.recurrenceMutation ||
+      capabilities.adopt ||
+      capabilities.periodicCreate ||
+      capabilities.periodicUpdate ||
       capabilities.convert ||
       capabilities.relocate
       ? BASE_LIMITATIONS
@@ -929,6 +988,9 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
           capabilities.transition ||
           capabilities.relationshipMutation ||
           capabilities.recurrenceMutation ||
+          capabilities.adopt ||
+          capabilities.periodicCreate ||
+          capabilities.periodicUpdate ||
           capabilities.create ||
           capabilities.convert ||
           capabilities.relocate
@@ -1012,36 +1074,40 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
     includeProperties: boolean,
   ): Promise<StableTaskRead> {
     const runtime = this.requireRuntime();
-    const before = await this.indexState(runtime);
-    if (!before.ready || before.generation === null) {
-      throw new Error(
-        "Operon index is still initializing or is not in a verified idle state.",
-      );
+    for (let attempt = 0; attempt < STABLE_READ_MAX_ATTEMPTS; attempt += 1) {
+      const before = await this.indexState(runtime);
+      if (!before.ready || before.generation === null) {
+        throw new Error(
+          "Operon index is still initializing or is not in a verified idle state.",
+        );
+      }
+      const beforeSettings = this.currentSettingsSignature(runtime);
+      const tasks = runtime.indexer
+        .getAllTasks()
+        .map((task) =>
+          this.normalizeRuntimeTask(runtime, task, includeProperties),
+        );
+      const after = await this.indexState(runtime);
+      const afterSettings = this.currentSettingsSignature(runtime);
+      if (
+        !after.ready ||
+        after.generation !== before.generation ||
+        afterSettings !== beforeSettings ||
+        before.diagnostics?.taskCount !== tasks.length ||
+        after.diagnostics?.taskCount !== tasks.length
+      ) {
+        if (attempt + 1 < STABLE_READ_MAX_ATTEMPTS) continue;
+        throw new Error(
+          "Operon generation or settings changed during the read; retry after the index settles.",
+        );
+      }
+      return {
+        tasks,
+        generation: before.generation,
+        settingsSignature: beforeSettings,
+      };
     }
-    const beforeSettings = this.currentSettingsSignature(runtime);
-    const tasks = runtime.indexer
-      .getAllTasks()
-      .map((task) =>
-        this.normalizeRuntimeTask(runtime, task, includeProperties),
-      );
-    const after = await this.indexState(runtime);
-    const afterSettings = this.currentSettingsSignature(runtime);
-    if (
-      !after.ready ||
-      after.generation !== before.generation ||
-      afterSettings !== beforeSettings ||
-      before.diagnostics?.taskCount !== tasks.length ||
-      after.diagnostics?.taskCount !== tasks.length
-    ) {
-      throw new Error(
-        "Operon generation or settings changed during the read; retry after the index settles.",
-      );
-    }
-    return {
-      tasks,
-      generation: before.generation,
-      settingsSignature: beforeSettings,
-    };
+    throw new Error("Operon did not produce a stable task snapshot.");
   }
 
   private async oneTask(
@@ -1053,32 +1119,36 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
     settingsSignature: string;
   }> {
     const runtime = this.requireRuntime();
-    const state = await this.indexState(runtime);
-    if (!state.ready || state.generation === null) {
-      throw new Error(
-        "Operon index is still initializing or is not in a verified idle state.",
-      );
+    for (let attempt = 0; attempt < STABLE_READ_MAX_ATTEMPTS; attempt += 1) {
+      const state = await this.indexState(runtime);
+      if (!state.ready || state.generation === null) {
+        throw new Error(
+          "Operon index is still initializing or is not in a verified idle state.",
+        );
+      }
+      const signature = this.currentSettingsSignature(runtime);
+      const task = runtime.indexer.getTask(operonId);
+      const normalized = task
+        ? this.normalizeRuntimeTask(runtime, task, includeProperties)
+        : null;
+      const after = await this.indexState(runtime);
+      if (
+        !after.ready ||
+        after.generation !== state.generation ||
+        this.currentSettingsSignature(runtime) !== signature
+      ) {
+        if (attempt + 1 < STABLE_READ_MAX_ATTEMPTS) continue;
+        throw new Error(
+          "Operon generation or settings changed during the read; retry after the index settles.",
+        );
+      }
+      return {
+        task: normalized,
+        generation: state.generation,
+        settingsSignature: signature,
+      };
     }
-    const signature = this.currentSettingsSignature(runtime);
-    const task = runtime.indexer.getTask(operonId);
-    const normalized = task
-      ? this.normalizeRuntimeTask(runtime, task, includeProperties)
-      : null;
-    const after = await this.indexState(runtime);
-    if (
-      !after.ready ||
-      after.generation !== state.generation ||
-      this.currentSettingsSignature(runtime) !== signature
-    ) {
-      throw new Error(
-        "Operon generation or settings changed during the read; retry after the index settles.",
-      );
-    }
-    return {
-      task: normalized,
-      generation: state.generation,
-      settingsSignature: signature,
-    };
+    throw new Error("Operon did not produce a stable task read.");
   }
 
   private async oneTaskAfterMutation(
@@ -1193,24 +1263,151 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
     );
   }
 
+  private mutationHttpStatus(payload: Record<string, unknown>): number {
+    if (payload.ok === true) return 200;
+    switch (payload.status) {
+      case "conflict":
+        return 409;
+      case "not-ready":
+        return 503;
+      case "outcome-unknown":
+      case "failed":
+        return 500;
+      default:
+        return 422;
+    }
+  }
+
+  private restoreMutationJournal(value: unknown): void {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return;
+    const journal = value as Record<string, unknown>;
+    if (journal.version !== MUTATION_JOURNAL_VERSION || !Array.isArray(journal.entries))
+      return;
+    const cutoff = Date.now() - MUTATION_JOURNAL_RETENTION_MS;
+    const entries = journal.entries.slice(-MUTATION_JOURNAL_LIMIT);
+    let interrupted = false;
+    for (const candidate of entries) {
+      if (!candidate || typeof candidate !== "object" || Array.isArray(candidate))
+        continue;
+      const entry = candidate as unknown as PersistedMutationJournalEntry;
+      const updatedAtMs = Date.parse(String(entry.updatedAt ?? ""));
+      if (
+        typeof entry.idempotencyKey !== "string" ||
+        !entry.idempotencyKey ||
+        typeof entry.signature !== "string" ||
+        !entry.signature ||
+        !Number.isFinite(updatedAtMs) ||
+        updatedAtMs < cutoff
+      ) continue;
+      if (entry.state === "terminal" && entry.payload && typeof entry.payload === "object") {
+        this.mutationResults.set(entry.idempotencyKey, {
+          signature: entry.signature,
+          payload: entry.payload,
+          httpStatus: entry.httpStatus ?? this.mutationHttpStatus(entry.payload),
+        });
+        this.mutationResultTimes.set(entry.idempotencyKey, entry.updatedAt);
+        continue;
+      }
+      if (entry.state === "in-progress") {
+        const payload = interruptedMutationPayload({
+          idempotencyKey: entry.idempotencyKey,
+          operationId: entry.operationId,
+          requested: entry.requested ?? {},
+        });
+        this.mutationResults.set(entry.idempotencyKey, {
+          signature: entry.signature,
+          payload,
+          httpStatus: 500,
+        });
+        this.mutationResultTimes.set(entry.idempotencyKey, new Date().toISOString());
+        interrupted = true;
+      }
+    }
+    if (interrupted) this.queuePersistPluginData();
+  }
+
+  private mutationJournalEntries(): PersistedMutationJournalEntry[] {
+    const cutoff = Date.now() - MUTATION_JOURNAL_RETENTION_MS;
+    const terminal = [...this.mutationResults.entries()].flatMap(
+      ([idempotencyKey, cached]): PersistedMutationJournalEntry[] => {
+        const updatedAt = this.mutationResultTimes.get(idempotencyKey);
+        if (!updatedAt || Date.parse(updatedAt) < cutoff) return [];
+        return [{
+          idempotencyKey,
+          signature: cached.signature,
+          state: "terminal",
+          updatedAt,
+          operationId: String(cached.payload.operationId ?? "unknown"),
+          payload: cached.payload,
+          httpStatus: cached.httpStatus ?? this.mutationHttpStatus(cached.payload),
+        }];
+      },
+    );
+    const active = [...this.mutationReservations.entries()].map(
+      ([idempotencyKey, flight]): PersistedMutationJournalEntry => ({
+        idempotencyKey,
+        signature: flight.signature,
+        state: "in-progress",
+        updatedAt: flight.startedAt,
+        operationId: flight.operationId,
+        requested: flight.requested,
+      }),
+    );
+    return [...terminal, ...active]
+      .sort((left, right) => left.updatedAt.localeCompare(right.updatedAt))
+      .slice(-MUTATION_JOURNAL_LIMIT);
+  }
+
+  private async persistPluginData(): Promise<void> {
+    await this.saveData({
+      settings: this.settings,
+      mutationJournal: {
+        version: MUTATION_JOURNAL_VERSION,
+        retentionDays: 30,
+        entries: this.mutationJournalEntries(),
+      },
+    });
+  }
+
+  private queuePersistPluginData(): void {
+    this.dataWriteChain = this.dataWriteChain
+      .catch(() => undefined)
+      .then(() => this.persistPluginData())
+      .then(() => {
+        this.dataWriteFailed = false;
+      })
+      .catch(() => {
+        this.dataWriteFailed = true;
+        console.warn(`[${EXTENSION_ID}] Mutation journal persistence failed.`);
+      });
+  }
+
   private cacheMutation(
     idempotencyKey: string,
     signature: string,
     payload: Record<string, unknown>,
   ): void {
-    this.mutationResults.set(idempotencyKey, { signature, payload });
-    if (this.mutationResults.size <= 500) return;
-    const oldest = this.mutationResults.keys().next().value;
-    if (oldest) this.mutationResults.delete(oldest);
+    const httpStatus = this.mutationHttpStatus(payload);
+    this.mutationResults.set(idempotencyKey, { signature, payload, httpStatus });
+    this.mutationResultTimes.set(idempotencyKey, new Date().toISOString());
+    this.mutationReservations.complete(idempotencyKey, signature, payload);
+    if (this.mutationResults.size > MUTATION_JOURNAL_LIMIT) {
+      const oldest = this.mutationResults.keys().next().value;
+      if (oldest) {
+        this.mutationResults.delete(oldest);
+        this.mutationResultTimes.delete(oldest);
+      }
+    }
+    this.queuePersistPluginData();
   }
 
-  private mutationPreflight(
+  private async mutationPreflight(
     idempotencyKey: string,
     signature: string,
     requested: Record<string, unknown>,
     validate: () => string | null,
   ) {
-    return resolveMutationPreflight({
+    const terminal = resolveMutationPreflight({
       cached: this.mutationResults.get(idempotencyKey),
       idempotencyKey,
       signature,
@@ -1218,6 +1415,112 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       validate,
       operationId: () => this.mutationOperationId(),
     });
+    if (terminal.kind !== "continue") return terminal;
+    const reservation = this.mutationReservations.reserve({
+      idempotencyKey,
+      signature,
+      operationId: this.mutationOperationId(),
+      requested,
+      startedAt: new Date().toISOString(),
+    });
+    if (reservation.kind === "conflict") {
+        return resolveMutationPreflight({
+          cached: { signature: reservation.reservation.signature, payload: {} },
+          idempotencyKey,
+          signature,
+          requested,
+          validate: () => null,
+          operationId: () => this.mutationOperationId(),
+        });
+    }
+    if (reservation.kind === "join") {
+      return {
+        kind: "response" as const,
+        response: reservation.reservation.promise.then((payload) => ({
+          httpStatus: this.mutationHttpStatus(payload),
+          payload,
+        })),
+      };
+    }
+    this.queuePersistPluginData();
+    await this.dataWriteChain;
+    if (this.dataWriteFailed) {
+      throw new Error(
+        "The durable mutation reservation could not be persisted; no native mutation was dispatched.",
+      );
+    }
+    return terminal;
+  }
+
+  private failReservedMutation(
+    body: Record<string, unknown>,
+    error: unknown,
+  ): { httpStatus: number; payload: Record<string, unknown> } | null {
+    const idempotencyKey = String(body.idempotencyKey ?? "").trim();
+    const reservation = this.mutationReservations.get(idempotencyKey);
+    if (!idempotencyKey || !reservation) return null;
+    const payload: Record<string, unknown> = {
+      ok: false,
+      contractVersion: OPERON_BRIDGE_CONTRACT_VERSION,
+      operationId: reservation.operationId,
+      idempotencyKey,
+      status: "not-ready",
+      before: null,
+      requested: reservation.requested,
+      after: null,
+      error: {
+        code: "mutation_unavailable",
+        message: error instanceof Error ? error.message : String(error),
+      },
+      retryable: true,
+      mutationMayHaveApplied: false,
+      source: "operon-live",
+      stale: false,
+    };
+    this.cacheMutation(idempotencyKey, reservation.signature, payload);
+    return { httpStatus: 503, payload };
+  }
+
+  private async sendDurableMutationResponse(
+    res: any,
+    result: { httpStatus: number; payload: Record<string, unknown> },
+  ): Promise<void> {
+    await this.dataWriteChain;
+    if (!this.dataWriteFailed) {
+      sendJson(res, result.httpStatus, result.payload);
+      return;
+    }
+    const payload: Record<string, unknown> = {
+      ...result.payload,
+      ok: false,
+      status: "outcome-unknown",
+      error: {
+        code: "mutation_journal_persistence_failed",
+        message:
+          "The native operation returned, but its terminal Bridge receipt could not be persisted durably; inspect native recovery state before retrying.",
+      },
+      retryable: false,
+      mutationMayHaveApplied:
+        result.payload.mutationMayHaveApplied === true ||
+        result.payload.status === "applied" ||
+        result.payload.status === "already-applied",
+      recoveryRequired: true,
+    };
+    sendJson(res, 500, payload);
+  }
+
+  private async sendMutationFailure(
+    res: any,
+    body: Record<string, unknown>,
+    error: unknown,
+    fallbackCode: string,
+  ): Promise<void> {
+    const failed = this.failReservedMutation(body, error);
+    if (failed) {
+      await this.sendDurableMutationResponse(res, failed);
+      return;
+    }
+    sendJson(res, 503, errorPayload(error, fallbackCode));
   }
 
   private requireMutationRuntime(
@@ -1229,10 +1532,14 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       );
     }
     const runtime = this.requireRuntime();
+    this.assertMutationRuntimeAdmitted(runtime);
     if (runtime.developerApi) {
-      if (capability === "adopt") {
+      if (
+        capability === "adopt" &&
+        !runtime.developerApi.hasTaskWorkflowCapability("adopt")
+      ) {
         throw new Error(
-          "Operon Developer API V1 does not expose checkbox adoption; the Bridge will not use a Markdown or private-API fallback.",
+          "Operon task-workflow Developer API adoption grant is unavailable; the Bridge will not use a Markdown or private-API fallback.",
         );
       }
       return runtime;
@@ -1252,6 +1559,27 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
     return runtime;
   }
 
+  private requireTaskWorkflowRuntime(
+    kind: DeveloperApiTaskWorkflowKind,
+  ): OperonRuntime {
+    if (!this.settings.mutationsEnabled) {
+      throw new Error(
+        "Operon Bridge mutations are disabled in plugin settings.",
+      );
+    }
+    const runtime = this.requireRuntime();
+    this.assertMutationRuntimeAdmitted(runtime);
+    if (
+      !runtime.developerApi ||
+      !runtime.developerApi.hasTaskWorkflowCapability(kind)
+    ) {
+      throw new Error(
+        `Operon task-workflow Developer API capability is unavailable: ${kind}; no Markdown or private-API fallback is used.`,
+      );
+    }
+    return runtime;
+  }
+
   private requireDeveloperApiMutationRuntime(): OperonRuntime {
     if (!this.settings.mutationsEnabled) {
       throw new Error(
@@ -1259,12 +1587,21 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       );
     }
     const runtime = this.requireRuntime();
+    this.assertMutationRuntimeAdmitted(runtime);
     if (!runtime.developerApi) {
       throw new Error(
         "Operon Developer API V1 is unavailable; no Public API or Markdown fallback is used for recovery.",
       );
     }
     return runtime;
+  }
+
+  private assertMutationRuntimeAdmitted(runtime: OperonRuntime): void {
+    if (!isMutationAdmittedDeveloperApiVersion(runtime.version)) {
+      throw new Error(
+        `Operon ${runtime.version} is not admitted for Bridge mutations; reads remain available, but mutation routes fail closed until this exact build is certified or explicitly attested.`,
+      );
+    }
   }
 
   private async executeDeveloperRead(
@@ -1335,7 +1672,7 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
     }
     const requested = { recoveryRef };
     const signature = stableJson({ capability: "recovery", requested });
-    const preflight = this.mutationPreflight(
+    const preflight = await this.mutationPreflight(
       idempotencyKey,
       signature,
       requested,
@@ -1368,6 +1705,96 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       ...(native.mutationMayHaveApplied !== undefined
         ? { mutationMayHaveApplied: native.mutationMayHaveApplied }
         : {}),
+      ...(native.nativeProof ? { nativeProof: native.nativeProof } : {}),
+      source: "operon-live",
+      stale: false,
+    };
+    this.cacheMutation(idempotencyKey, signature, payload);
+    return {
+      httpStatus: native.ok
+        ? 200
+        : native.code === "not-ready"
+          ? 503
+          : native.code === "conflict"
+            ? 409
+            : native.code === "outcome-unknown"
+              ? 500
+              : 422,
+      payload,
+    };
+  }
+
+  private taskWorkflowKind(
+    value: unknown,
+  ): DeveloperApiTaskWorkflowKind | null {
+    return value === "adopt" ||
+      value === "periodic-create" ||
+      value === "periodic-update"
+      ? value
+      : null;
+  }
+
+  private async executeTaskWorkflowRecoveryMutation(
+    body: Record<string, unknown>,
+  ): Promise<{ httpStatus: number; payload: Record<string, unknown> }> {
+    const idempotencyKey = String(body.idempotencyKey ?? "").trim();
+    const recoveryRef = String(body.recoveryRef ?? "").trim();
+    const kind = this.taskWorkflowKind(body.kind);
+    if (!idempotencyKey || !recoveryRef || !kind) {
+      return {
+        httpStatus: 400,
+        payload: errorPayload(
+          new Error(
+            "idempotencyKey, recoveryRef, and kind (adopt, periodic-create, or periodic-update) are required.",
+          ),
+          "validation_error",
+        ),
+      };
+    }
+    const expectedPlanDigest = String(body.planDigest ?? "").trim() || undefined;
+    const requested = { kind, recoveryRef, ...(expectedPlanDigest ? { planDigest: expectedPlanDigest } : {}) };
+    const signature = stableJson({
+      capability: "task-workflow-recovery",
+      requested,
+    });
+    const preflight = await this.mutationPreflight(
+      idempotencyKey,
+      signature,
+      requested,
+      () => null,
+    );
+    if (preflight.kind === "response") return preflight.response;
+    const candidateRuntime = this.requireRuntime();
+    await this.indexState(candidateRuntime);
+    const runtime = this.requireTaskWorkflowRuntime(kind);
+    const native = await runtime.developerApi!.recoverTaskWorkflow(
+      kind,
+      recoveryRef,
+      expectedPlanDigest,
+    );
+    const payload: Record<string, unknown> = {
+      ok: native.ok,
+      contractVersion: OPERON_BRIDGE_CONTRACT_VERSION,
+      operationId: this.mutationOperationId(),
+      idempotencyKey,
+      status: native.ok
+        ? native.code === "already-applied"
+          ? "already-applied"
+          : "applied"
+        : native.code,
+      before: null,
+      requested,
+      after: null,
+      ...(native.planDigest ? { planDigest: native.planDigest } : {}),
+      ...(native.recoveryRef ? { recoveryRef: native.recoveryRef } : {}),
+      ...(native.message
+        ? { error: { code: native.code, message: native.message } }
+        : {}),
+      retryable: native.retryable,
+      ...(native.mutationMayHaveApplied !== undefined
+        ? { mutationMayHaveApplied: native.mutationMayHaveApplied }
+        : {}),
+      ...(native.nativeProof ? { nativeProof: native.nativeProof } : {}),
       source: "operon-live",
       stale: false,
     };
@@ -1413,7 +1840,7 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
     const targetPath = requested.targetPath;
     const line = Number(requested.line);
     const expectedLine = String(requested.expectedLine ?? "");
-    const preflight = this.mutationPreflight(
+    const preflight = await this.mutationPreflight(
       idempotencyKey,
       signature,
       requested,
@@ -1434,7 +1861,122 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       };
     }
     const canonicalTargetPath = targetPath as string;
+    const candidateRuntime = this.requireRuntime();
+    await this.indexState(candidateRuntime);
     const runtime = this.requireMutationRuntime("adopt");
+    if (runtime.developerApi) {
+      const operationId = this.mutationOperationId();
+      const native = await runtime.developerApi.executeTaskWorkflow(
+        "adopt",
+        requested,
+        body.dryRun !== false,
+      );
+      if (body.dryRun !== false || !native.ok || !native.operonId) {
+        const payload = {
+          ok: native.ok,
+          contractVersion: OPERON_BRIDGE_CONTRACT_VERSION,
+          operationId,
+          idempotencyKey,
+          status: native.ok ? "planned" : native.code,
+          before: null,
+          requested,
+          after: null,
+          ...(native.planDigest ? { planDigest: native.planDigest } : {}),
+          ...(native.recoveryRef ? { recoveryRef: native.recoveryRef } : {}),
+          ...(native.plan ? { plan: native.plan } : {}),
+          ...(native.nativeProof ? { nativeProof: native.nativeProof } : {}),
+          ...(!native.ok
+            ? {
+                error: {
+                  code: native.code,
+                  message: native.message ?? "Operon rejected task adoption.",
+                },
+                retryable: native.retryable,
+                ...(native.mutationMayHaveApplied !== undefined
+                  ? { mutationMayHaveApplied: native.mutationMayHaveApplied }
+                  : {}),
+              }
+            : {}),
+          source: "operon-live",
+          stale: false,
+        };
+        this.cacheMutation(idempotencyKey, signature, payload);
+        return {
+          httpStatus: native.ok
+            ? 200
+            : native.code === "not-ready"
+              ? 503
+              : native.code === "conflict"
+                ? 409
+                : native.code === "outcome-unknown"
+                  ? 500
+                  : 422,
+          payload,
+        };
+      }
+      let after: OperonBridgeTask | null = null;
+      try {
+        after = (await this.oneTaskAfterMutation(native.operonId, true)).task;
+      } catch (error) {
+        const payload = {
+          ok: false,
+          contractVersion: OPERON_BRIDGE_CONTRACT_VERSION,
+          operationId,
+          idempotencyKey,
+          status: "failed",
+          before: null,
+          requested,
+          after: null,
+          error: {
+            code: "outcome_unverified",
+            message: `Operon adopted ${native.operonId}, but the final indexed state could not be proven: ${error instanceof Error ? error.message : String(error)}`,
+          },
+          retryable: false,
+          mutationMayHaveApplied: true,
+          ...(native.planDigest ? { planDigest: native.planDigest } : {}),
+          ...(native.recoveryRef ? { recoveryRef: native.recoveryRef } : {}),
+          ...(native.nativeProof ? { nativeProof: native.nativeProof } : {}),
+          source: "operon-live",
+          stale: false,
+        };
+        this.cacheMutation(idempotencyKey, signature, payload);
+        return { httpStatus: 500, payload };
+      }
+      const locationMatches =
+        after?.path === canonicalTargetPath && after?.line === line;
+      const payload = {
+        ok: Boolean(after && locationMatches),
+        contractVersion: OPERON_BRIDGE_CONTRACT_VERSION,
+        operationId,
+        idempotencyKey,
+        status:
+          after && locationMatches
+            ? native.code === "already-applied"
+              ? "already-applied"
+              : "applied"
+            : "failed",
+        before: null,
+        requested,
+        after,
+        ...(native.planDigest ? { planDigest: native.planDigest } : {}),
+        ...(native.recoveryRef ? { recoveryRef: native.recoveryRef } : {}),
+        ...(native.nativeProof ? { nativeProof: native.nativeProof } : {}),
+        ...(!after || !locationMatches
+          ? {
+              error: {
+                code: "outcome_mismatch",
+                message:
+                  "The adopted task was not found at the requested source line.",
+              },
+              retryable: false,
+            }
+          : {}),
+        source: "operon-live",
+        stale: false,
+      };
+      this.cacheMutation(idempotencyKey, signature, payload);
+      return { httpStatus: after && locationMatches ? 200 : 500, payload };
+    }
     const file = this.app.vault.getAbstractFileByPath(canonicalTargetPath);
     if (!(file instanceof TFile)) {
       return {
@@ -1567,6 +2109,306 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
     return { httpStatus: after && locationMatches ? 200 : 500, payload };
   }
 
+  private async executePeriodicCreateMutation(
+    body: Record<string, unknown>,
+  ): Promise<{ httpStatus: number; payload: Record<string, unknown> }> {
+    const idempotencyKey = String(body.idempotencyKey ?? "").trim();
+    if (!idempotencyKey) {
+      return {
+        httpStatus: 400,
+        payload: errorPayload(
+          new Error("idempotencyKey is required."),
+          "validation_error",
+        ),
+      };
+    }
+    const requested =
+      body.periodic &&
+      typeof body.periodic === "object" &&
+      !Array.isArray(body.periodic)
+        ? (body.periodic as Record<string, unknown>)
+        : {};
+    const signature = stableJson({
+      capability: "periodic-create",
+      dryRun: body.dryRun !== false,
+      requested,
+    });
+    const preflight = await this.mutationPreflight(
+      idempotencyKey,
+      signature,
+      requested,
+      () =>
+        typeof requested.description !== "string" ||
+        !requested.description.trim() ||
+        (requested.periodicKind !== "daily" &&
+          requested.periodicKind !== "weekly")
+          ? "periodic creation requires description and periodicKind daily or weekly."
+          : null,
+    );
+    if (preflight.kind === "response") return preflight.response;
+    if (preflight.kind === "validation-error") {
+      return {
+        httpStatus: 400,
+        payload: errorPayload(new Error(preflight.message), "validation_error"),
+      };
+    }
+    const candidateRuntime = this.requireRuntime();
+    await this.indexState(candidateRuntime);
+    const runtime = this.requireTaskWorkflowRuntime("periodic-create");
+    const native = await runtime.developerApi!.executeTaskWorkflow(
+      "periodic-create",
+      requested,
+      body.dryRun !== false,
+    );
+    return this.taskWorkflowMutationPayload({
+      kind: "periodic-create",
+      body,
+      requested,
+      idempotencyKey,
+      signature,
+      native,
+      before: null,
+      runtime,
+    });
+  }
+
+  private async executePeriodicUpdateMutation(
+    operonId: string,
+    body: Record<string, unknown>,
+  ): Promise<{ httpStatus: number; payload: Record<string, unknown> }> {
+    const idempotencyKey = String(body.idempotencyKey ?? "").trim();
+    if (!idempotencyKey || !operonId) {
+      return {
+        httpStatus: 400,
+        payload: errorPayload(
+          new Error("operonId and idempotencyKey are required."),
+          "validation_error",
+        ),
+      };
+    }
+    const patch =
+      body.patch && typeof body.patch === "object" && !Array.isArray(body.patch)
+        ? (body.patch as Record<string, unknown>)
+        : {};
+    const requested = { ...patch, operonId };
+    const signature = stableJson({
+      capability: "periodic-update",
+      operonId,
+      expectedRevision: body.expectedRevision,
+      dryRun: body.dryRun !== false,
+      requested,
+    });
+    const preflight = await this.mutationPreflight(
+      idempotencyKey,
+      signature,
+      requested,
+      () => mutationPathValidationError("update", requested),
+    );
+    if (preflight.kind === "response") return preflight.response;
+    if (preflight.kind === "validation-error") {
+      return {
+        httpStatus: 400,
+        payload: errorPayload(new Error(preflight.message), "validation_error"),
+      };
+    }
+    const candidateRuntime = this.requireRuntime();
+    await this.indexState(candidateRuntime);
+    const runtime = this.requireTaskWorkflowRuntime("periodic-update");
+    const before = (await this.oneTask(operonId, true)).task;
+    if (!before) {
+      return {
+        httpStatus: 404,
+        payload: errorPayload(
+          new Error(`Operon task not found: ${operonId}`),
+          "not_found",
+        ),
+      };
+    }
+    const expectedRevision = String(body.expectedRevision ?? "").trim();
+    if (!expectedRevision) {
+      return {
+        httpStatus: 400,
+        payload: errorPayload(
+          new Error("expectedRevision is required."),
+          "validation_error",
+        ),
+      };
+    }
+    if (expectedRevision !== before.revision) {
+      const payload = {
+        ok: false,
+        contractVersion: OPERON_BRIDGE_CONTRACT_VERSION,
+        operationId: this.mutationOperationId(),
+        idempotencyKey,
+        status: "conflict",
+        before,
+        requested,
+        after: before,
+        error: {
+          code: "revision_conflict",
+          message: "expectedRevision does not match the live task revision.",
+        },
+        retryable: true,
+        source: "operon-live",
+        stale: false,
+      };
+      this.cacheMutation(idempotencyKey, signature, payload);
+      return { httpStatus: 409, payload };
+    }
+    const native = await runtime.developerApi!.executeTaskWorkflow(
+      "periodic-update",
+      requested,
+      body.dryRun !== false,
+      async () => {
+        await runtime.developerApi!.refreshLiveTaskSnapshot();
+        const current = (await this.oneTask(operonId, true)).task;
+        return current?.revision === expectedRevision
+          ? { ok: true }
+          : {
+              ok: false,
+              message:
+                "expectedRevision no longer matches after periodic-update preview; the sealed plan was not applied.",
+            };
+      },
+    );
+    return this.taskWorkflowMutationPayload({
+      kind: "periodic-update",
+      body,
+      requested,
+      idempotencyKey,
+      signature,
+      native,
+      before,
+      runtime,
+    });
+  }
+
+  private async taskWorkflowMutationPayload(options: {
+    kind: "periodic-create" | "periodic-update";
+    body: Record<string, unknown>;
+    requested: Record<string, unknown>;
+    idempotencyKey: string;
+    signature: string;
+    native: DeveloperApiMutationResult;
+    before: OperonBridgeTask | null;
+    runtime: OperonRuntime;
+  }): Promise<{ httpStatus: number; payload: Record<string, unknown> }> {
+    const {
+      kind,
+      body,
+      requested,
+      idempotencyKey,
+      signature,
+      native,
+      before,
+      runtime,
+    } = options;
+    const operationId = this.mutationOperationId();
+    if (body.dryRun !== false || !native.ok || !native.operonId) {
+      const payload = {
+        ok: native.ok,
+        contractVersion: OPERON_BRIDGE_CONTRACT_VERSION,
+        operationId,
+        idempotencyKey,
+        status: native.ok ? "planned" : native.code,
+        before,
+        requested,
+        after: null,
+        ...(native.planDigest ? { planDigest: native.planDigest } : {}),
+        ...(native.recoveryRef ? { recoveryRef: native.recoveryRef } : {}),
+        ...(native.plan ? { plan: native.plan } : {}),
+        ...(native.nativeProof ? { nativeProof: native.nativeProof } : {}),
+        ...(!native.ok
+          ? {
+              error: {
+                code: native.code,
+                message: native.message ?? `Operon rejected ${kind}.`,
+              },
+              retryable: native.retryable,
+              ...(native.mutationMayHaveApplied !== undefined
+                ? { mutationMayHaveApplied: native.mutationMayHaveApplied }
+                : {}),
+            }
+          : {}),
+        source: "operon-live",
+        stale: false,
+      };
+      this.cacheMutation(idempotencyKey, signature, payload);
+      return {
+        httpStatus: native.ok
+          ? 200
+          : native.code === "not-ready"
+            ? 503
+            : native.code === "conflict"
+              ? 409
+              : native.code === "outcome-unknown"
+                ? 500
+                : 422,
+        payload,
+      };
+    }
+    let after: OperonBridgeTask | null = null;
+    try {
+      after = (await this.oneTaskAfterMutation(native.operonId, true)).task;
+    } catch (error) {
+      const payload = {
+        ok: false,
+        contractVersion: OPERON_BRIDGE_CONTRACT_VERSION,
+        operationId,
+        idempotencyKey,
+        status: "failed",
+        before,
+        requested,
+        after: null,
+        error: {
+          code: "outcome_unverified",
+          message: `Operon returned ${native.nativeStatus ?? native.code}, but the final indexed state could not be proven: ${error instanceof Error ? error.message : String(error)}`,
+        },
+        retryable: false,
+        mutationMayHaveApplied: true,
+        source: "operon-live",
+        stale: false,
+      };
+      this.cacheMutation(idempotencyKey, signature, payload);
+      return { httpStatus: 500, payload };
+    }
+    const verificationRequest = { ...requested };
+    delete verificationRequest.operonId;
+    const mismatch = this.mutationOutcomeMismatch(
+      kind === "periodic-create" ? "create" : "update",
+      after,
+      verificationRequest,
+      runtime,
+    );
+    const payload = {
+      ok: !mismatch,
+      contractVersion: OPERON_BRIDGE_CONTRACT_VERSION,
+      operationId,
+      idempotencyKey,
+      status: mismatch
+        ? "failed"
+        : native.code === "already-applied"
+          ? "already-applied"
+          : "applied",
+      before,
+      requested,
+      after,
+      ...(native.planDigest ? { planDigest: native.planDigest } : {}),
+      ...(native.recoveryRef ? { recoveryRef: native.recoveryRef } : {}),
+      ...(native.nativeProof ? { nativeProof: native.nativeProof } : {}),
+      ...(mismatch
+        ? {
+            error: { code: "outcome_mismatch", message: mismatch },
+            retryable: false,
+          }
+        : {}),
+      source: "operon-live",
+      stale: false,
+    };
+    this.cacheMutation(idempotencyKey, signature, payload);
+    return { httpStatus: mismatch ? 500 : 200, payload };
+  }
+
   private mutationOutcomeMismatch(
     capability: DeveloperApiMutationCapability,
     after: OperonBridgeTask | null,
@@ -1605,6 +2447,9 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
         if (stableJson(actualTags) !== stableJson(expectedTags))
           return "Task tags do not match the request.";
       }
+      if (!stablePriorityOutcomeMatches(after.priority, requested.priorityId)) {
+        return "Task priority does not match the requested stable priority id.";
+      }
       const requestedFields =
         requested.fields &&
         typeof requested.fields === "object" &&
@@ -1617,8 +2462,8 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
           key === "priority"
             ? (resolvePriorityStableId(value, runtime.priorities) ??
               String(value).trim())
-            : String(value);
-        if (after.fields[key] !== expectedValue)
+            : value;
+        if (!managedFieldOutcomeMatches(after.fields[key], expectedValue))
           return `Managed field '${key}' does not match the request.`;
       }
       const requestedProperties =
@@ -1699,7 +2544,9 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
           if (after.fields[field] !== undefined && after.fields[field] !== "") {
             return `Recurrence field '${field}' was not cleared.`;
           }
-        } else if (after.fields[field] !== String(value)) {
+        } else if (
+          stableJson(after.fields[field] ?? null) !== stableJson(String(value))
+        ) {
           return `Recurrence field '${field}' does not match the request.`;
         }
       }
@@ -1830,7 +2677,7 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       dryRun: body.dryRun !== false,
       requested,
     });
-    const preflight = this.mutationPreflight(
+    const preflight = await this.mutationPreflight(
       idempotencyKey,
       signature,
       requested,
@@ -1943,6 +2790,7 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
           after: null,
           ...(native.recoveryRef ? { recoveryRef: native.recoveryRef } : {}),
           ...(native.planDigest ? { planDigest: native.planDigest } : {}),
+          ...(native.nativeProof ? { nativeProof: native.nativeProof } : {}),
           error: {
             code: native.code,
             message: native.message ?? "Operon rejected the mutation.",
@@ -1986,6 +2834,9 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
           },
           retryable: false,
           mutationMayHaveApplied: true,
+          ...(native.recoveryRef ? { recoveryRef: native.recoveryRef } : {}),
+          ...(native.planDigest ? { planDigest: native.planDigest } : {}),
+          ...(native.nativeProof ? { nativeProof: native.nativeProof } : {}),
           source: "operon-live",
           stale: false,
         };
@@ -2027,6 +2878,7 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
         after: afterRead.task,
         ...(native.planDigest ? { planDigest: native.planDigest } : {}),
         ...(native.recoveryRef ? { recoveryRef: native.recoveryRef } : {}),
+        ...(native.nativeProof ? { nativeProof: native.nativeProof } : {}),
         ...(outcomeMismatch
           ? {
               error: { code: "outcome_mismatch", message: outcomeMismatch },
@@ -2146,7 +2998,7 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       dryRun: body.dryRun !== false,
       requested,
     });
-    const preflight = this.mutationPreflight(
+    const preflight = await this.mutationPreflight(
       idempotencyKey,
       signature,
       requested,
@@ -2583,9 +3435,88 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
           const result = await this.executeRecoveryMutation(
             this.bodyRecord(req),
           );
-          sendJson(res, result.httpStatus, result.payload);
+          await this.sendDurableMutationResponse(res, result);
         } catch (error) {
-          sendJson(res, 503, errorPayload(error, "recovery_unavailable"));
+          await this.sendMutationFailure(
+            res,
+            this.bodyRecord(req),
+            error,
+            "recovery_unavailable",
+          );
+        }
+      });
+
+    api
+      .addRoute(`${REST_PREFIX}/task-workflows/pending-recoveries`)
+      .get(async (req: any, res: any) => {
+        try {
+          const rawKind = readQueryValue(req, "kind");
+          const decodedKind =
+            rawKind === undefined ? null : this.taskWorkflowKind(rawKind);
+          if (rawKind !== undefined && !decodedKind) {
+            sendJson(
+              res,
+              400,
+              errorPayload(
+                new Error(
+                  "kind must be adopt, periodic-create, or periodic-update.",
+                ),
+                "validation_error",
+              ),
+            );
+            return;
+          }
+          const runtime = this.requireDeveloperApiMutationRuntime();
+          await this.indexState(runtime);
+          const result =
+            await runtime.developerApi!.pendingTaskWorkflowRecoveries(
+              decodedKind ?? undefined,
+            );
+          if (!result.ok) {
+            sendJson(
+              res,
+              503,
+              errorPayload(
+                new Error(
+                  result.message ??
+                    "Operon task-workflow recovery state is unavailable.",
+                ),
+                "task_workflow_recovery_unavailable",
+              ),
+            );
+            return;
+          }
+          sendJson(res, 200, {
+            ok: true,
+            contractVersion: OPERON_BRIDGE_CONTRACT_VERSION,
+            source: "operon-live",
+            stale: false,
+            recoveries: result.recoveries,
+          });
+        } catch (error) {
+          sendJson(
+            res,
+            503,
+            errorPayload(error, "task_workflow_recovery_unavailable"),
+          );
+        }
+      });
+
+    api
+      .addRoute(`${REST_PREFIX}/task-workflows/recover`)
+      .post(async (req: any, res: any) => {
+        try {
+          const result = await this.executeTaskWorkflowRecoveryMutation(
+            this.bodyRecord(req),
+          );
+          await this.sendDurableMutationResponse(res, result);
+        } catch (error) {
+          await this.sendMutationFailure(
+            res,
+            this.bodyRecord(req),
+            error,
+            "task_workflow_recovery_unavailable",
+          );
         }
       });
 
@@ -2895,20 +3826,48 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
     api.addRoute(`${REST_PREFIX}/tasks`).post(async (req: any, res: any) => {
       try {
         const result = await this.executeCreateMutation(this.bodyRecord(req));
-        sendJson(res, result.httpStatus, result.payload);
+        await this.sendDurableMutationResponse(res, result);
       } catch (error) {
-        sendJson(res, 503, errorPayload(error, "mutation_unavailable"));
+        await this.sendMutationFailure(
+          res,
+          this.bodyRecord(req),
+          error,
+          "mutation_unavailable",
+        );
       }
     });
+
+    api
+      .addRoute(`${REST_PREFIX}/tasks/periodic`)
+      .post(async (req: any, res: any) => {
+        try {
+          const result = await this.executePeriodicCreateMutation(
+            this.bodyRecord(req),
+          );
+          await this.sendDurableMutationResponse(res, result);
+        } catch (error) {
+          await this.sendMutationFailure(
+            res,
+            this.bodyRecord(req),
+            error,
+            "mutation_unavailable",
+          );
+        }
+      });
 
     api
       .addRoute(`${REST_PREFIX}/tasks/adopt`)
       .post(async (req: any, res: any) => {
         try {
           const result = await this.executeAdoptMutation(this.bodyRecord(req));
-          sendJson(res, result.httpStatus, result.payload);
+          await this.sendDurableMutationResponse(res, result);
         } catch (error) {
-          sendJson(res, 503, errorPayload(error, "mutation_unavailable"));
+          await this.sendMutationFailure(
+            res,
+            this.bodyRecord(req),
+            error,
+            "mutation_unavailable",
+          );
         }
       });
 
@@ -2933,9 +3892,36 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
             requested,
             (operonApi) => operonApi.updateTask(operonId, requested),
           );
-          sendJson(res, result.httpStatus, result.payload);
+          await this.sendDurableMutationResponse(res, result);
         } catch (error) {
-          sendJson(res, 503, errorPayload(error, "mutation_unavailable"));
+          await this.sendMutationFailure(
+            res,
+            this.bodyRecord(req),
+            error,
+            "mutation_unavailable",
+          );
+        }
+      });
+
+    api
+      .addRoute(`${REST_PREFIX}/tasks/:operonId/periodic-update`)
+      .post(async (req: any, res: any) => {
+        try {
+          const operonId = decodeURIComponent(
+            String(req?.params?.operonId ?? ""),
+          ).trim();
+          const result = await this.executePeriodicUpdateMutation(
+            operonId,
+            this.bodyRecord(req),
+          );
+          await this.sendDurableMutationResponse(res, result);
+        } catch (error) {
+          await this.sendMutationFailure(
+            res,
+            this.bodyRecord(req),
+            error,
+            "mutation_unavailable",
+          );
         }
       });
 
@@ -2962,9 +3948,14 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
             requested,
             (operonApi) => operonApi.transitionTask(operonId, requested),
           );
-          sendJson(res, result.httpStatus, result.payload);
+          await this.sendDurableMutationResponse(res, result);
         } catch (error) {
-          sendJson(res, 503, errorPayload(error, "mutation_unavailable"));
+          await this.sendMutationFailure(
+            res,
+            this.bodyRecord(req),
+            error,
+            "mutation_unavailable",
+          );
         }
       });
 
@@ -2993,9 +3984,14 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
               );
             },
           );
-          sendJson(res, result.httpStatus, result.payload);
+          await this.sendDurableMutationResponse(res, result);
         } catch (error) {
-          sendJson(res, 503, errorPayload(error, "mutation_unavailable"));
+          await this.sendMutationFailure(
+            res,
+            this.bodyRecord(req),
+            error,
+            "mutation_unavailable",
+          );
         }
       });
 
@@ -3022,9 +4018,14 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
               );
             },
           );
-          sendJson(res, result.httpStatus, result.payload);
+          await this.sendDurableMutationResponse(res, result);
         } catch (error) {
-          sendJson(res, 503, errorPayload(error, "mutation_unavailable"));
+          await this.sendMutationFailure(
+            res,
+            this.bodyRecord(req),
+            error,
+            "mutation_unavailable",
+          );
         }
       });
 
@@ -3053,9 +4054,14 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
             requested,
             (operonApi) => operonApi.convertTask(operonId, requested),
           );
-          sendJson(res, result.httpStatus, result.payload);
+          await this.sendDurableMutationResponse(res, result);
         } catch (error) {
-          sendJson(res, 503, errorPayload(error, "mutation_unavailable"));
+          await this.sendMutationFailure(
+            res,
+            this.bodyRecord(req),
+            error,
+            "mutation_unavailable",
+          );
         }
       });
 
@@ -3077,9 +4083,14 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
             requested,
             (operonApi) => operonApi.relocateTask(operonId, requested),
           );
-          sendJson(res, result.httpStatus, result.payload);
+          await this.sendDurableMutationResponse(res, result);
         } catch (error) {
-          sendJson(res, 503, errorPayload(error, "mutation_unavailable"));
+          await this.sendMutationFailure(
+            res,
+            this.bodyRecord(req),
+            error,
+            "mutation_unavailable",
+          );
         }
       });
 

--- a/plugins/obsidian-operon-bridge/src/main.ts
+++ b/plugins/obsidian-operon-bridge/src/main.ts
@@ -43,6 +43,7 @@ import {
   type DeveloperApiMutationCapability,
   type DeveloperApiMutationResult,
   type DeveloperApiTaskWorkflowKind,
+  type TaskWorkflowIdentityStore,
 } from "./developer-api-adapter";
 
 const EXTENSION_ID = "optimike-operon-bridge";
@@ -53,6 +54,7 @@ const MOUNT_RETRY_MS = 500;
 const MUTATION_JOURNAL_VERSION = 1;
 const MUTATION_JOURNAL_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 const MUTATION_JOURNAL_LIMIT = 500;
+const TASK_WORKFLOW_IDENTITY_STORE_VERSION = 1;
 
 interface OptimikeOperonBridgeSettings {
   mutationsEnabled: boolean;
@@ -67,6 +69,12 @@ interface PersistedMutationJournalEntry {
   requested?: Record<string, unknown>;
   payload?: Record<string, unknown>;
   httpStatus?: number;
+}
+
+interface PersistedTaskWorkflowIdentity {
+  key: string;
+  operonId: string;
+  updatedAt: string;
 }
 
 const DEFAULT_BRIDGE_SETTINGS: OptimikeOperonBridgeSettings = {
@@ -379,6 +387,10 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
   private mutationResults = new Map<string, CachedMutation>();
   private mutationResultTimes = new Map<string, string>();
   private mutationReservations = new MutationReservationRegistry();
+  private taskWorkflowIdentities = new Map<
+    string,
+    { operonId: string; updatedAt: string }
+  >();
   private dataWriteChain: Promise<void> = Promise.resolve();
   private dataWriteFailed = false;
   private developerApiAdapter: OperonDeveloperApiRuntimeAdapter | null = null;
@@ -392,6 +404,7 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
         : (stored as Partial<OptimikeOperonBridgeSettings> | null);
     this.settings = { ...DEFAULT_BRIDGE_SETTINGS, ...(storedSettings ?? {}) };
     this.restoreMutationJournal(stored?.mutationJournal);
+    this.restoreTaskWorkflowIdentities(stored?.taskWorkflowIdentities);
     this.addSettingTab(new OptimikeOperonBridgeSettingTab(this.app, this));
     this.app.workspace.onLayoutReady(() => {
       this.tryMountRestExtension();
@@ -469,6 +482,7 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
     this.developerApiAdapter = new OperonDeveloperApiRuntimeAdapter(
       this,
       plugin,
+      this.taskWorkflowIdentityStore(),
     );
     return this.developerApiAdapter;
   }
@@ -1358,6 +1372,71 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       .slice(-MUTATION_JOURNAL_LIMIT);
   }
 
+  private restoreTaskWorkflowIdentities(value: unknown): void {
+    if (!value || typeof value !== "object" || Array.isArray(value)) return;
+    const stored = value as Record<string, unknown>;
+    if (
+      stored.version !== TASK_WORKFLOW_IDENTITY_STORE_VERSION ||
+      !Array.isArray(stored.entries)
+    ) return;
+    const cutoff = Date.now() - MUTATION_JOURNAL_RETENTION_MS;
+    for (const candidate of stored.entries.slice(-MUTATION_JOURNAL_LIMIT)) {
+      if (!candidate || typeof candidate !== "object" || Array.isArray(candidate))
+        continue;
+      const entry = candidate as unknown as PersistedTaskWorkflowIdentity;
+      const updatedAtMs = Date.parse(String(entry.updatedAt ?? ""));
+      if (
+        !/^(adopt|periodic-create|periodic-update):[0-9a-f]{64}$/u.test(
+          String(entry.key ?? ""),
+        ) ||
+        !/^[a-z0-9]{7}$/u.test(String(entry.operonId ?? "")) ||
+        !Number.isFinite(updatedAtMs) ||
+        updatedAtMs < cutoff
+      ) continue;
+      this.taskWorkflowIdentities.set(entry.key, {
+        operonId: entry.operonId,
+        updatedAt: entry.updatedAt,
+      });
+    }
+  }
+
+  private taskWorkflowIdentityEntries(): PersistedTaskWorkflowIdentity[] {
+    const cutoff = Date.now() - MUTATION_JOURNAL_RETENTION_MS;
+    return [...this.taskWorkflowIdentities.entries()]
+      .flatMap(([key, value]) =>
+        Date.parse(value.updatedAt) < cutoff
+          ? []
+          : [{ key, operonId: value.operonId, updatedAt: value.updatedAt }],
+      )
+      .sort((left, right) => left.updatedAt.localeCompare(right.updatedAt))
+      .slice(-MUTATION_JOURNAL_LIMIT);
+  }
+
+  private taskWorkflowIdentityStore(): TaskWorkflowIdentityStore {
+    return {
+      get: (key) => this.taskWorkflowIdentities.get(key)?.operonId,
+      set: async (key, operonId) => {
+        this.taskWorkflowIdentities.delete(key);
+        this.taskWorkflowIdentities.set(key, {
+          operonId,
+          updatedAt: new Date().toISOString(),
+        });
+        while (this.taskWorkflowIdentities.size > MUTATION_JOURNAL_LIMIT) {
+          const oldest = this.taskWorkflowIdentities.keys().next().value;
+          if (typeof oldest !== "string") break;
+          this.taskWorkflowIdentities.delete(oldest);
+        }
+        this.queuePersistPluginData();
+        await this.dataWriteChain;
+        if (this.dataWriteFailed) {
+          throw new Error(
+            "The task-workflow identity receipt could not be persisted durably.",
+          );
+        }
+      },
+    };
+  }
+
   private async persistPluginData(): Promise<void> {
     await this.saveData({
       settings: this.settings,
@@ -1365,6 +1444,11 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
         version: MUTATION_JOURNAL_VERSION,
         retentionDays: 30,
         entries: this.mutationJournalEntries(),
+      },
+      taskWorkflowIdentities: {
+        version: TASK_WORKFLOW_IDENTITY_STORE_VERSION,
+        retentionDays: 30,
+        entries: this.taskWorkflowIdentityEntries(),
       },
     });
   }
@@ -2198,17 +2282,25 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       dryRun: body.dryRun !== false,
       requested,
     });
-    const preflight = await this.mutationPreflight(
+    const expectedRevision = String(body.expectedRevision ?? "").trim();
+    const validation = resolveMutationPreflight({
+      cached: this.mutationResults.get(idempotencyKey),
       idempotencyKey,
       signature,
       requested,
-      () => mutationPathValidationError("update", requested),
-    );
-    if (preflight.kind === "response") return preflight.response;
-    if (preflight.kind === "validation-error") {
+      validate: () =>
+        mutationPathValidationError("update", requested) ??
+        (expectedRevision ? null : "expectedRevision is required."),
+      operationId: () => this.mutationOperationId(),
+    });
+    if (validation.kind === "response") return validation.response;
+    if (validation.kind === "validation-error") {
       return {
         httpStatus: 400,
-        payload: errorPayload(new Error(preflight.message), "validation_error"),
+        payload: errorPayload(
+          new Error(validation.message),
+          "validation_error",
+        ),
       };
     }
     const candidateRuntime = this.requireRuntime();
@@ -2224,12 +2316,18 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
         ),
       };
     }
-    const expectedRevision = String(body.expectedRevision ?? "").trim();
-    if (!expectedRevision) {
+    const preflight = await this.mutationPreflight(
+      idempotencyKey,
+      signature,
+      requested,
+      () => null,
+    );
+    if (preflight.kind === "response") return preflight.response;
+    if (preflight.kind === "validation-error") {
       return {
         httpStatus: 400,
         payload: errorPayload(
-          new Error("expectedRevision is required."),
+          new Error(preflight.message),
           "validation_error",
         ),
       };

--- a/plugins/obsidian-operon-bridge/src/main.ts
+++ b/plugins/obsidian-operon-bridge/src/main.ts
@@ -1924,11 +1924,12 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
     const targetPath = requested.targetPath;
     const line = Number(requested.line);
     const expectedLine = String(requested.expectedLine ?? "");
-    const preflight = await this.mutationPreflight(
+    const validation = resolveMutationPreflight({
+      cached: this.mutationResults.get(idempotencyKey),
       idempotencyKey,
       signature,
       requested,
-      () =>
+      validate: () =>
         !isCanonicalVaultMarkdownPath(targetPath) ||
         !Number.isInteger(line) ||
         line < 1 ||
@@ -1936,6 +1937,39 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
         /[\r\n]/u.test(expectedLine)
           ? "adoption requires targetPath, a positive one-based line, and one exact expectedLine."
           : null,
+      operationId: () => this.mutationOperationId(),
+    });
+    if (validation.kind === "response") return validation.response;
+    if (validation.kind === "validation-error") {
+      return {
+        httpStatus: 400,
+        payload: errorPayload(
+          new Error(validation.message),
+          "validation_error",
+        ),
+      };
+    }
+    const canonicalTargetPath = targetPath as string;
+    const candidateRuntime = this.requireRuntime();
+    await this.indexState(candidateRuntime);
+    const runtime = this.requireMutationRuntime("adopt");
+    const legacyFile = runtime.developerApi
+      ? null
+      : this.app.vault.getAbstractFileByPath(canonicalTargetPath);
+    if (!runtime.developerApi && !(legacyFile instanceof TFile)) {
+      return {
+        httpStatus: 404,
+        payload: errorPayload(
+          new Error(`Markdown source file not found: ${canonicalTargetPath}`),
+          "not_found",
+        ),
+      };
+    }
+    const preflight = await this.mutationPreflight(
+      idempotencyKey,
+      signature,
+      requested,
+      () => null,
     );
     if (preflight.kind === "response") return preflight.response;
     if (preflight.kind === "validation-error") {
@@ -1944,10 +1978,6 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
         payload: errorPayload(new Error(preflight.message), "validation_error"),
       };
     }
-    const canonicalTargetPath = targetPath as string;
-    const candidateRuntime = this.requireRuntime();
-    await this.indexState(candidateRuntime);
-    const runtime = this.requireMutationRuntime("adopt");
     if (runtime.developerApi) {
       const operationId = this.mutationOperationId();
       const native = await runtime.developerApi.executeTaskWorkflow(
@@ -2061,17 +2091,7 @@ export default class OptimikeOperonBridgePlugin extends Plugin {
       this.cacheMutation(idempotencyKey, signature, payload);
       return { httpStatus: after && locationMatches ? 200 : 500, payload };
     }
-    const file = this.app.vault.getAbstractFileByPath(canonicalTargetPath);
-    if (!(file instanceof TFile)) {
-      return {
-        httpStatus: 404,
-        payload: errorPayload(
-          new Error(`Markdown source file not found: ${canonicalTargetPath}`),
-          "not_found",
-        ),
-      };
-    }
-    const content = await this.app.vault.cachedRead(file);
+    const content = await this.app.vault.cachedRead(legacyFile as TFile);
     const currentLine = content.split("\n")[line - 1];
     const normalizedCurrentLine = currentLine?.endsWith("\r")
       ? currentLine.slice(0, -1)

--- a/profiles/elysia-tasks/README.fr.md
+++ b/profiles/elysia-tasks/README.fr.md
@@ -29,7 +29,9 @@ plutôt que figer un seul identifiant de plugin :
 const plugins = app.plugins?.plugins;
 const loadedTaskEngines = [plugins?.kairelys, plugins?.operon].filter(Boolean);
 if (loadedTaskEngines.length !== 1) {
-  throw new Error(`Un seul moteur de tâches doit être chargé, trouvé : ${loadedTaskEngines.length}.`);
+  throw new Error(
+    `Un seul moteur de tâches doit être chargé, trouvé : ${loadedTaskEngines.length}.`,
+  );
 }
 const [taskEngine] = loadedTaskEngines;
 if (taskEngine.api?.version !== "1") {
@@ -76,7 +78,7 @@ Le fichier de référence est [`v1/profile.json`](v1/profile.json).
 
 ## Skill agentique publique
 
-La skill portable [`elysia-task-gouverneur`](skills/elysia-task-gouverneur/SKILL.md) permet à un agent de piloter ce profil via les 23 outils `operon_*` gouvernés du MCP Optimike.
+La skill portable [`elysia-task-gouverneur`](skills/elysia-task-gouverneur/SKILL.md) permet à un agent de piloter ce profil via les 25 outils `operon_*` gouvernés du MCP Optimike. Les opérations Daily/Weekly et l’adoption officielle restent conditionnées aux grants live exacts ; leur présence dans le profil ne les autorise pas.
 
 Elle couvre :
 

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/SKILL.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: elysia-task-gouverneur
-description: 'Orchestre les tâches d’un coffre compatible avec le profil public ÉLYSIA Tasks via les 23 outils operon_* gouvernés : opérations ponctuelles, relations, récurrence, récupération, audits, triage, cycle de vie et santé du runtime, avec capacités live, IDs stables, dry-run et validation humaine.'
+description: "Orchestre les tâches d’un coffre compatible avec le profil public ÉLYSIA Tasks via les 25 outils operon_* gouvernés : opérations ponctuelles, Daily/Weekly, relations, récurrence, récupération, audits, triage, cycle de vie et santé du runtime, avec capacités live, IDs stables, dry-run et validation humaine."
 metadata:
   version: 1.3.0
   skill_structure: graph
@@ -38,14 +38,14 @@ Utilise le profil public `elysia.tasks` et la configuration live du moteur pour 
 
 ## Reference Gate Map
 
-| Intention | `module_route` | Modules obligatoires |
-|---|---|---|
-| Créer ou adopter | `operation-ponctuelle` | [admission-p90-j.md](references/admission-p90-j.md) + [operations-ponctuelles.md](references/operations-ponctuelles.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
-| Modifier, terminer, lier, gérer une récurrence, convertir ou déplacer | `operation-ponctuelle` | [operations-ponctuelles.md](references/operations-ponctuelles.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
-| Résultat incertain ou récupération | `sante-performance` | [sante-et-performance.md](references/sante-et-performance.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
-| Audit, triage, conformité ou saved filters | `audit-triage` | [audits-et-triage.md](references/audits-et-triage.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
-| Changement de phase d’un projet ou nettoyage de backlog | `cycle-vie-projet` | [cycle-de-vie-projet.md](references/cycle-de-vie-projet.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
-| Cache stale, incident, incompatibilité ou lenteur | `sante-performance` | [sante-et-performance.md](references/sante-et-performance.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
+| Intention                                                             | `module_route`         | Modules obligatoires                                                                                                                                                                    |
+| --------------------------------------------------------------------- | ---------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Créer ou adopter                                                      | `operation-ponctuelle` | [admission-p90-j.md](references/admission-p90-j.md) + [operations-ponctuelles.md](references/operations-ponctuelles.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md) |
+| Modifier, terminer, lier, gérer une récurrence, convertir ou déplacer | `operation-ponctuelle` | [operations-ponctuelles.md](references/operations-ponctuelles.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md)                                                       |
+| Résultat incertain ou récupération                                    | `sante-performance`    | [sante-et-performance.md](references/sante-et-performance.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md)                                                           |
+| Audit, triage, conformité ou saved filters                            | `audit-triage`         | [audits-et-triage.md](references/audits-et-triage.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md)                                                                   |
+| Changement de phase d’un projet ou nettoyage de backlog               | `cycle-vie-projet`     | [cycle-de-vie-projet.md](references/cycle-de-vie-projet.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md)                                                             |
+| Cache stale, incident, incompatibilité ou lenteur                     | `sante-performance`    | [sante-et-performance.md](references/sante-et-performance.md) + [runtime-et-mutations.md](references/runtime-et-mutations.md)                                                           |
 
 ## Routage rapide
 

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/operations-ponctuelles.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/operations-ponctuelles.md
@@ -14,11 +14,19 @@ Utiliser `operon_create_task` pour une action qui n’existe pas encore. Résoud
 
 ### Adopter
 
-Le verdict `ADOPT` ne garantit pas l’apply. Utiliser `operon_adopt_task` seulement si le runtime annonce `adopt: true`, puis verrouiller le chemin, le numéro de ligne et le contenu attendu. Sinon retourner une indisponibilité structurée sans modifier le Markdown.
+Le verdict `ADOPT` ne garantit pas l’apply. Utiliser `operon_adopt_task` seulement si le runtime annonce `adopt: true`, puis verrouiller le chemin, le numéro de ligne et le contenu attendu. Operon doit produire et appliquer son plan opaque scellé ; sinon retourner une indisponibilité structurée sans modifier le Markdown.
+
+### Créer dans une Daily ou Weekly Note
+
+Utiliser `operon_create_periodic_task` seulement si `periodicCreate: true`. Fournir le kind Daily/Weekly et, au besoin, une date de routage ; ne jamais imposer `targetPath` ou `parentTask`. Relire la tâche créée et sa note périodique après apply.
+
+### Réaligner le scheduling périodique
+
+Utiliser `operon_update_periodic_scheduling` seulement si `periodicUpdate: true`, avec `expectedRevision`. Operon décide retain, detach ou realign sans déplacement du Markdown source. Un changement de note exige une autre opération explicite.
 
 ### Modifier
 
-Utiliser `operon_update_task` et envoyer seulement les champs intentionnellement modifiés. Préserver les propriétés inconnues.
+Utiliser `operon_update_task` et envoyer seulement les champs intentionnellement modifiés. Préserver les propriétés inconnues. Envoyer `taskGallery` comme tableau ordonné, jamais comme chaîne ; ne jamais écrire `__taskDataType`.
 
 ### Changer d’état
 

--- a/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/runtime-et-mutations.md
+++ b/profiles/elysia-tasks/skills/elysia-task-gouverneur/references/runtime-et-mutations.md
@@ -43,6 +43,8 @@ Mutation :
 
 - `operon_adopt_task`
 - `operon_create_task`
+- `operon_create_periodic_task`
+- `operon_update_periodic_scheduling`
 - `operon_update_task`
 - `operon_transition_task`
 - `operon_set_relationships`
@@ -55,7 +57,9 @@ Récupération :
 - `operon_list_pending_recoveries`
 - `operon_recover_mutation`
 
-Le serveur enregistre vingt-trois outils. Leur présence ne remplace jamais le contrôle de capacité live. Operon officiel `3.2.0` exécute les filtres sauvegardés après un grant exact `tasks.filter-query` et avec un `filterSetId` exact, mais ne publie pas le catalogue de ces IDs. `adopt` reste indisponible et doit échouer de façon structurée. `operon_query_tasks` est la requête structurée Operon ; l’ancien outil non préfixé `query_tasks` relève du legacy Markdown.
+Le serveur enregistre vingt-cinq outils. Leur présence ne remplace jamais le contrôle de capacité live. Operon officiel `3.5.2` exécute les filtres sauvegardés après leur grant exact, mais reste en lecture seule à la frontière du Bridge même si les grants adoption ou Daily/Weekly existent. Seul le build local attesté `3.5.240438` exerce ces workflows de mutation. Operon ne publie toujours pas le catalogue des IDs de filtres. Un grant absent renvoie une indisponibilité structurée sans fallback Markdown. `operon_query_tasks` est la requête structurée Operon ; l’ancien outil non préfixé `query_tasks` relève du legacy Markdown.
+
+`taskType` et `taskImage` sont des valeurs scalaires. `taskGallery` est un tableau ordonné : ne jamais le convertir en chaîne à séparateurs. `__taskDataType` est dérivé et read-only. Les plans task-workflow sont opaques ; après `outcome-unknown`, récupérer uniquement le même `recoveryRef` avec le kind annoncé.
 
 Les relations sont admises en mode `guarded`. La récurrence et la récupération exigent le mode `full`. La CLI reste la surface opérateur/admin et n’est pas relayée génériquement par le MCP.
 
@@ -76,7 +80,7 @@ Pour une tâche existante :
 
 Ne jamais réutiliser la clé du dry-run pour l’apply : `dryRun` fait partie de la requête canonique.
 
-Pour une création, aucune révision antérieure n’existe : destination, pipeline, statut initial et clé d’idempotence doivent être explicites. Pour une adoption, exiger d’abord `adopt: true`, puis verrouiller le chemin, la ligne et le contenu attendu. Après une mutation de relations, relire la source et les relations inverses. Après une mutation de récurrence, vérifier règle et portée. Après `outcome-unknown`, récupérer uniquement le même `recoveryRef` ; ne jamais rejouer la mutation initiale.
+Pour une création, aucune révision antérieure n’existe : destination, pipeline, statut initial et clé d’idempotence doivent être explicites. Pour une création Daily/Weekly, laisser Operon résoudre la note, le template et le conteneur ; ne fournir ni chemin arbitraire ni parent. Pour une adoption, exiger d’abord `adopt: true`, puis verrouiller le chemin, la ligne et le contenu attendu. Après une mutation de relations, relire la source et les relations inverses. Après une mutation de récurrence, vérifier règle et portée. Après `outcome-unknown`, récupérer uniquement le même `recoveryRef` ; ne jamais rejouer la mutation initiale.
 
 ## Interdits
 

--- a/scripts/smoke-operon-35-live.mjs
+++ b/scripts/smoke-operon-35-live.mjs
@@ -1,0 +1,2387 @@
+#!/usr/bin/env node
+
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+import { createHash, randomUUID } from "node:crypto";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  rmdir,
+  writeFile,
+} from "node:fs/promises";
+import { createServer as createHttpServer } from "node:http";
+import { createServer as createNetServer } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { parse as parseYaml } from "yaml";
+
+const EXPECTED_VAULT = path.resolve(
+  "C:\\Users\\micka\\.codex\\visualizations\\2026\\07\\20\\019f801c-bc43-72f0-bf34-31552d406cbc\\operon-bridge-pilot-vault-2.5.0",
+);
+const EXPECTED_VAULT_NAME = "operon-bridge-pilot-vault-2.5.0";
+const EXPECTED_OPERON_VERSION = "3.5.240438";
+const EXPECTED_BASE_URL = "http://127.0.0.1:27233";
+const FIXTURE_PATH = "Canary/Operon-3.5.2-Live-Canary.md";
+const PERIODIC_REGISTRY_PATH = path.join(
+  EXPECTED_VAULT,
+  ".obsidian",
+  "plugins",
+  "operon",
+  "state",
+  "periodic-note-containers.json",
+);
+const ORIGINAL_MODIFICATION = "2000-01-01T00:00:00";
+const PROJECT_ROOT = path.dirname(
+  fileURLToPath(new URL("../package.json", import.meta.url)),
+);
+const BACKEND_ENTRY = path.join(PROJECT_ROOT, "dist", "index.js");
+const PROJECT_LOGS_PATH = path.join(PROJECT_ROOT, "logs");
+const BRIDGE_PREFIX = "/extensions/optimike-operon-bridge/v1";
+const RUN_CONFIRMATION = "I_CONFIRM_PILOT_2_DISPOSABLE_LIVE_MUTATIONS";
+const OPEN_CONFIRMATION = "I_CONFIRM_OPENING_ONLY_OPERON_PILOT_2";
+const MUTATION_TIMEOUT_MS = boundedInteger(
+  process.env.OPERON_35_CANARY_MUTATION_TIMEOUT_MS,
+  150_000,
+  125_000,
+  300_000,
+);
+const READ_TIMEOUT_MS = boundedInteger(
+  process.env.OPERON_35_CANARY_READ_TIMEOUT_MS,
+  30_000,
+  5_000,
+  120_000,
+);
+const STARTUP_TIMEOUT_MS = boundedInteger(
+  process.env.OPERON_35_CANARY_STARTUP_TIMEOUT_MS,
+  180_000,
+  15_000,
+  600_000,
+);
+const CLI_TIMEOUT_MS = boundedInteger(
+  process.env.OPERON_35_CANARY_CLI_TIMEOUT_MS,
+  30_000,
+  5_000,
+  120_000,
+);
+
+function boundedInteger(raw, fallback, minimum, maximum) {
+  const value = raw === undefined ? fallback : Number(raw);
+  if (!Number.isInteger(value) || value < minimum || value > maximum) {
+    throw new Error(
+      `Timeout must be an integer between ${minimum} and ${maximum} ms.`,
+    );
+  }
+  return value;
+}
+
+function envTrue(name) {
+  return (process.env[name] ?? "").trim().toLowerCase() === "true";
+}
+
+function sha256(value) {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function shortHash(value) {
+  return sha256(String(value)).slice(0, 16);
+}
+
+function boundedDiagnosticToken(value) {
+  if (typeof value !== "string" || !value) return null;
+  return value.length <= 128 && /^[a-z0-9_.:-]+$/iu.test(value)
+    ? value
+    : `hashed-${shortHash(value)}`;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function canonicalRelativeMarkdownPath(value) {
+  if (
+    typeof value !== "string" ||
+    !value.endsWith(".md") ||
+    value.includes("\\") ||
+    value.startsWith("/") ||
+    /^[a-z]:/iu.test(value)
+  ) {
+    return false;
+  }
+  return value
+    .split("/")
+    .every(
+      (segment) =>
+        segment.length > 0 &&
+        segment === segment.trim() &&
+        segment !== "." &&
+        segment !== "..",
+    );
+}
+
+function absoluteVaultPath(relativePath) {
+  assert.equal(
+    canonicalRelativeMarkdownPath(relativePath),
+    true,
+    `Unsafe vault-relative Markdown path: ${relativePath}`,
+  );
+  const absolute = path.resolve(EXPECTED_VAULT, ...relativePath.split("/"));
+  const vaultPrefix = `${EXPECTED_VAULT}${path.sep}`.toLowerCase();
+  assert.equal(
+    absolute.toLowerCase().startsWith(vaultPrefix),
+    true,
+    "Resolved path escaped the Pilot 2 vault.",
+  );
+  return absolute;
+}
+
+async function exists(target) {
+  try {
+    await access(target);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function withTimeout(promise, label, timeoutMs) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`${label} timed out after ${timeoutMs}ms.`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function redactText(value, apiKey) {
+  let text = String(value ?? "");
+  if (apiKey) text = text.split(apiKey).join("[REDACTED_API_KEY]");
+  text = text
+    .split(EXPECTED_VAULT)
+    .join(`[REDACTED_VAULT]${path.sep}`)
+    .replace(/Bearer\s+[^\s"']+/giu, "Bearer [REDACTED]");
+  return text.slice(0, 2_000);
+}
+
+function parseMcpPayload(result, label) {
+  const text = (result.content ?? [])
+    .filter((block) => block.type === "text")
+    .map((block) => block.text)
+    .join("\n");
+  try {
+    return text ? JSON.parse(text) : null;
+  } catch {
+    throw new Error(`${label} returned a non-JSON MCP payload.`);
+  }
+}
+
+function markdownFrontmatter(content, label) {
+  const match = /^---\r?\n([\s\S]*?)\r?\n---(?:\r?\n|$)/u.exec(content);
+  assert.ok(match, `${label} has no YAML frontmatter.`);
+  const parsed = parseYaml(match[1]);
+  assert.equal(
+    parsed !== null && typeof parsed === "object" && !Array.isArray(parsed),
+    true,
+    `${label} frontmatter is not a YAML mapping.`,
+  );
+  return parsed;
+}
+
+function frontmatterScalarWhenValid(content, key) {
+  try {
+    const value = markdownFrontmatter(content, "canary fixture")[key];
+    return typeof value === "string" || typeof value === "number"
+      ? String(value)
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+function mutationStatus(result, label, expected) {
+  const status = result?.status;
+  if (status === "outcome-unknown") {
+    const recovery = result.recoveryRef
+      ? ` recoveryRefHash=${shortHash(result.recoveryRef)}`
+      : "";
+    throw new Error(`${label} returned outcome-unknown.${recovery}`);
+  }
+  assert.equal(status, expected, `${label} returned status ${String(status)}.`);
+  return result;
+}
+
+function assertNativeMutationProof(result, label) {
+  assert.match(
+    result?.planDigest ?? "",
+    /^[a-f0-9]{64}$/u,
+    `${label} did not return an exact sealed planDigest.`,
+  );
+  const proof = result?.nativeProof;
+  assert.equal(proof?.contractVersion, 1, `${label} native proof is missing.`);
+  assert.equal(proof?.kind, "mutation-result");
+  assert.equal(proof?.mutationMayHaveApplied, true);
+  assert.equal(proof?.retryAllowed, false);
+  assert.equal(proof?.receipt?.planDigest, result.planDigest);
+  assert.equal(
+    ["verified", "receipt-replay"].includes(proof?.postflight?.status),
+    true,
+    `${label} native postflight is not verified.`,
+  );
+  assert.equal(Array.isArray(proof?.groupResults), true);
+  assert.ok(proof.groupResults.length > 0, `${label} has no atomic groups.`);
+  const revisions = proof.groupResults.flatMap((group) => {
+    assert.equal(
+      group.status,
+      "committed",
+      `${label} has an uncommitted group.`,
+    );
+    assert.equal(Array.isArray(group.resourceRevisions), true);
+    return group.resourceRevisions;
+  });
+  assert.ok(revisions.length > 0, `${label} has no resource revisions.`);
+  for (const revision of revisions) {
+    assert.equal(typeof revision.resourceKind, "string");
+    assert.ok(revision.resourceKey);
+    assert.ok(revision.revision);
+  }
+  return {
+    label,
+    status: proof.status,
+    planDigestHash: shortHash(result.planDigest),
+    postflight: proof.postflight.status,
+    atomicGroupCount: proof.groupResults.length,
+    resourceRevisionCount: revisions.length,
+    resourceRevisionHashes: revisions.map((revision) =>
+      shortHash(
+        `${revision.resourceKind}\0${revision.resourceKey}\0${revision.revision}`,
+      ),
+    ),
+  };
+}
+
+function strictDate(value) {
+  assert.match(value, /^\d{4}-\d{2}-\d{2}$/u);
+  return value;
+}
+
+function addUtcDays(date, days) {
+  const next = new Date(date.getTime());
+  next.setUTCDate(next.getUTCDate() + days);
+  return next;
+}
+
+function isoDate(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function isoWeekMarkers(value) {
+  const date = new Date(`${strictDate(value)}T00:00:00Z`);
+  const day = date.getUTCDay() || 7;
+  const monday = addUtcDays(date, 1 - day);
+  const thursday = addUtcDays(date, 4 - day);
+  const yearStart = new Date(Date.UTC(thursday.getUTCFullYear(), 0, 1));
+  const week = Math.ceil(
+    ((thursday.getTime() - yearStart.getTime()) / 86_400_000 + 1) / 7,
+  );
+  return [
+    isoDate(monday),
+    `${thursday.getUTCFullYear()}-W${String(week).padStart(2, "0")}`,
+  ];
+}
+
+function routeDates(runId) {
+  const digest = createHash("sha256").update(runId).digest();
+  const offset = digest.readUInt16BE(0) % 5_000;
+  const first = addUtcDays(new Date(Date.UTC(2080, 0, 1)), offset);
+  const daily = strictDate(isoDate(first));
+  return {
+    daily,
+    scheduled: strictDate(
+      isoDate(addUtcDays(new Date(`${daily}T00:00:00Z`), 7)),
+    ),
+    weekly: strictDate(isoDate(addUtcDays(first, 35))),
+    concurrent: strictDate(isoDate(addUtcDays(first, 77))),
+  };
+}
+
+function assertCollisionFree(snapshot, markers) {
+  const collisions = [];
+  for (const [relativePath, value] of snapshot) {
+    const content = value.content.toString("utf8");
+    const matched = markers.filter(
+      (marker) => content.includes(marker) || relativePath.includes(marker),
+    );
+    if (matched.length > 0) {
+      collisions.push({
+        pathHash: shortHash(relativePath),
+        markerHashes: matched.map(shortHash),
+      });
+    }
+  }
+  assert.deepEqual(
+    collisions,
+    [],
+    "Canary marker or route-date collision exists before mutation.",
+  );
+}
+
+async function captureMarkdownSnapshot(backupRoot) {
+  const inventory = new Map();
+  async function walk(absoluteFolder, relativeFolder) {
+    const entries = await readdir(absoluteFolder, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === ".obsidian") continue;
+      const absolute = path.join(absoluteFolder, entry.name);
+      const relative = relativeFolder
+        ? `${relativeFolder}/${entry.name}`
+        : entry.name;
+      if (entry.isDirectory()) {
+        await walk(absolute, relative);
+      } else if (entry.isFile() && entry.name.toLowerCase().endsWith(".md")) {
+        const content = await readFile(absolute);
+        inventory.set(relative, {
+          sha256: sha256(content),
+          size: content.length,
+          content,
+        });
+        if (backupRoot) {
+          const backupPath = path.join(backupRoot, ...relative.split("/"));
+          await mkdir(path.dirname(backupPath), { recursive: true });
+          await writeFile(backupPath, content, { mode: 0o600 });
+        }
+      }
+    }
+  }
+  await walk(EXPECTED_VAULT, "");
+  return inventory;
+}
+
+async function markdownInventory() {
+  return await captureMarkdownSnapshot();
+}
+
+function inventoryDigest(inventory) {
+  return sha256(
+    [...inventory.entries()]
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([relativePath, value]) =>
+        JSON.stringify([relativePath, value.sha256, value.size]),
+      )
+      .join("\n"),
+  );
+}
+
+function inventoryDiff(before, after) {
+  const paths = new Set([...before.keys(), ...after.keys()]);
+  return [...paths].sort().flatMap((relativePath) => {
+    const oldValue = before.get(relativePath);
+    const newValue = after.get(relativePath);
+    if (oldValue?.sha256 === newValue?.sha256) return [];
+    return [
+      {
+        path: relativePath,
+        change: !oldValue ? "created" : !newValue ? "removed" : "modified",
+        beforeSha256: oldValue?.sha256 ?? null,
+        afterSha256: newValue?.sha256 ?? null,
+      },
+    ];
+  });
+}
+
+function redactedInventoryChanges(changes) {
+  return changes.map((change) => ({
+    pathHash: shortHash(change.path),
+    change: change.change,
+    beforeSha256Hash: change.beforeSha256
+      ? shortHash(change.beforeSha256)
+      : null,
+    afterSha256Hash: change.afterSha256 ? shortHash(change.afterSha256) : null,
+  }));
+}
+
+async function unusedLoopbackUrl() {
+  const server = createNetServer();
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.equal(typeof address, "object");
+  assert.ok(address);
+  const port = address.port;
+  await new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+  return `http://127.0.0.1:${port}`;
+}
+
+async function fetchWithAbortTimeout(url, init, label, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } catch (error) {
+    if (controller.signal.aborted) {
+      const timeoutError = new Error(
+        `${label} timed out after ${timeoutMs}ms.`,
+      );
+      timeoutError.code = "FETCH_TIMEOUT";
+      throw timeoutError;
+    }
+    throw error;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function assertAbortableFetchContract() {
+  let observeAbort;
+  const abortedRequest = new Promise((resolve) => {
+    observeAbort = resolve;
+  });
+  const server = createHttpServer((request) => {
+    request.once("aborted", () => observeAbort(true));
+    request.once("close", () => {
+      if (request.aborted) observeAbort(true);
+    });
+    // Deliberately never respond: the client timeout must abort the request.
+  });
+  await new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address();
+  assert.equal(typeof address, "object");
+  assert.ok(address);
+  try {
+    await assert.rejects(
+      fetchWithAbortTimeout(
+        `http://127.0.0.1:${address.port}/blocked-mutation`,
+        { method: "POST", body: "bounded-offline-test" },
+        "offline abortable fetch",
+        250,
+      ),
+      (error) => error?.code === "FETCH_TIMEOUT",
+    );
+    assert.equal(
+      await withTimeout(
+        abortedRequest,
+        "offline server to observe fetch abort",
+        2_000,
+      ),
+      true,
+    );
+  } finally {
+    server.closeAllConnections?.();
+    await new Promise((resolve) => server.close(() => resolve()));
+  }
+}
+
+async function offlineStartupOrderContract() {
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "operon-startup-order-offline-"),
+  );
+  assert.equal(await exists(BACKEND_ENTRY), true, "Run npm run build first.");
+  const closedBaseUrl = await unusedLoopbackUrl();
+  const childEnv = { ...process.env };
+  delete childEnv.OBSIDIAN_STARTUP_BLOCKING;
+  delete childEnv.OBSIDIAN_STARTUP_MAX_RETRIES;
+  delete childEnv.OBSIDIAN_STARTUP_RETRY_DELAY_MS;
+  Object.assign(childEnv, {
+    NODE_ENV: "test",
+    MCP_TRANSPORT_TYPE: "stdio",
+    MCP_TOOL_PROFILE: "tasks",
+    MCP_WRITE_MODE: "readonly",
+    OPERON_MUTATIONS_ENABLED: "false",
+    OBSIDIAN_RUNTIME_MODE: "live",
+    OBSIDIAN_VAULT: tempRoot,
+    OBSIDIAN_BASE_URL: closedBaseUrl,
+    OBSIDIAN_API_KEY: "offline-contract-placeholder",
+    OBSIDIAN_ENABLE_CACHE: "false",
+    SEMANTIC_SEARCH_PREWARM: "false",
+    // LOGS_DIR is intentionally kept inside the project boundary required by
+    // config.ensureDirectory; an OS-temp LOGS_DIR makes the backend exit.
+    LOGS_DIR: PROJECT_LOGS_PATH,
+    MCP_LOG_LEVEL: "error",
+  });
+
+  let client;
+  let diagnostic = "";
+  try {
+    await assertAbortableFetchContract();
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [BACKEND_ENTRY],
+      cwd: tempRoot,
+      env: childEnv,
+      stderr: "pipe",
+    });
+    transport.stderr?.on("data", (chunk) => {
+      if (diagnostic.length < 16_384) diagnostic += chunk.toString("utf8");
+    });
+    client = new Client(
+      { name: "operon-startup-order-offline", version: "1.0.0" },
+      { capabilities: {} },
+    );
+    await withTimeout(client.connect(transport), "offline MCP connect", 30_000);
+    const before = await withTimeout(
+      client.listTools(),
+      "offline tools/list before status",
+      READ_TIMEOUT_MS,
+    );
+    const result = await withTimeout(
+      client.callTool({ name: "operon_status", arguments: {} }),
+      "offline operon_status",
+      READ_TIMEOUT_MS,
+    );
+    const payload = parseMcpPayload(result, "offline operon_status");
+    assert.equal(result.isError, false);
+    assert.equal(payload?.ok, false);
+    assert.equal(payload?.source, "unavailable");
+    assert.equal(payload?.error?.code, "live_bridge_unavailable");
+    const after = await withTimeout(
+      client.listTools(),
+      "offline tools/list after status",
+      READ_TIMEOUT_MS,
+    );
+    assert.equal(after.tools.length, before.tools.length);
+    assert.equal(
+      after.tools.some((tool) => tool.name === "operon_status"),
+      true,
+    );
+    console.log(
+      JSON.stringify(
+        {
+          ok: true,
+          runtimeMode: "live",
+          startupBlockingExplicit: false,
+          degradedStatusObserved: true,
+          sameClientAliveAfterStatus: true,
+          abortableFetchTimeoutVerified: true,
+          diagnosticHash: diagnostic ? shortHash(diagnostic) : null,
+        },
+        null,
+        2,
+      ),
+    );
+  } catch (error) {
+    const safeDiagnostic = redactText(
+      diagnostic.split(tempRoot).join("[OFFLINE_TEMP]"),
+      "offline-contract-placeholder",
+    );
+    throw new Error(
+      `${error instanceof Error ? error.message : String(error)}; backendDiagnostic=${safeDiagnostic || "[none]"}`,
+    );
+  } finally {
+    await client?.close().catch(() => undefined);
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+async function inspectPendingLive() {
+  const apiKey = (process.env.OBSIDIAN_API_KEY ?? "").trim();
+  const baseUrl = (process.env.OBSIDIAN_BASE_URL ?? "").replace(/\/$/u, "");
+  const requestedVault = path.resolve(process.env.OBSIDIAN_VAULT ?? "");
+  assert.equal(
+    requestedVault.toLowerCase(),
+    EXPECTED_VAULT.toLowerCase(),
+    "OBSIDIAN_VAULT must be the exact disposable Pilot 2 path.",
+  );
+  assert.equal(baseUrl, EXPECTED_BASE_URL);
+  assert.ok(apiKey, "OBSIDIAN_API_KEY is required and is never logged.");
+  assert.equal(
+    envTrue("OPERON_35_CANARY_CONFIRM_PILOT_ALREADY_OPEN"),
+    true,
+    "Confirm that Pilot 2 is already open.",
+  );
+  assert.equal(await exists(EXPECTED_VAULT), true, "Pilot 2 vault is missing.");
+
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "operon-pending-live-inspect-"),
+  );
+  const cachePath = path.join(tempRoot, "shared-cache.sqlite");
+  let client;
+  try {
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [BACKEND_ENTRY],
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        NODE_ENV: "production",
+        MCP_TRANSPORT_TYPE: "stdio",
+        MCP_TOOL_PROFILE: "tasks",
+        MCP_WRITE_MODE: "readonly",
+        OPERON_MUTATIONS_ENABLED: "false",
+        OPERON_MUTATION_ALLOWED_PATH_PREFIXES: "",
+        OBSIDIAN_RUNTIME_MODE: "live",
+        OBSIDIAN_STARTUP_BLOCKING: "false",
+        OBSIDIAN_VAULT: EXPECTED_VAULT,
+        OBSIDIAN_BASE_URL: baseUrl,
+        OBSIDIAN_API_KEY: apiKey,
+        OBSIDIAN_SHARED_CACHE_DB_PATH: cachePath,
+        OBSIDIAN_ENABLE_CACHE: "true",
+        SEMANTIC_SEARCH_PREWARM: "false",
+        LOGS_DIR: PROJECT_LOGS_PATH,
+        MCP_LOG_LEVEL: process.env.MCP_LOG_LEVEL ?? "error",
+      },
+      stderr: "pipe",
+    });
+    transport.stderr?.on("data", () => undefined);
+    client = new Client(
+      { name: "operon-pending-live-inspector", version: "1.0.0" },
+      { capabilities: {} },
+    );
+    await withTimeout(client.connect(transport), "MCP stdio connect", 30_000);
+
+    const statusResult = await withTimeout(
+      client.callTool({ name: "operon_status", arguments: {} }),
+      "operon_status",
+      READ_TIMEOUT_MS,
+    );
+    assert.equal(statusResult.isError, false, "operon_status failed.");
+    const status = parseMcpPayload(statusResult, "operon_status");
+    assertLiveStatus(status?.live);
+
+    const pendingResult = await withTimeout(
+      client.callTool({
+        name: "operon_list_pending_recoveries",
+        arguments: {},
+      }),
+      "operon_list_pending_recoveries",
+      READ_TIMEOUT_MS,
+    );
+    assert.equal(
+      pendingResult.isError,
+      false,
+      "operon_list_pending_recoveries failed.",
+    );
+    const pending = parseMcpPayload(
+      pendingResult,
+      "operon_list_pending_recoveries",
+    );
+    assert.equal(Array.isArray(pending?.recoveries), true);
+    const recoveries = pending.recoveries.map((recovery) => ({
+      kind: boundedDiagnosticToken(recovery?.kind) ?? "unknown",
+      recoveryRefHash:
+        typeof recovery?.recoveryRef === "string"
+          ? shortHash(recovery.recoveryRef)
+          : null,
+      planDigestHash:
+        typeof recovery?.planDigest === "string"
+          ? shortHash(recovery.planDigest)
+          : null,
+    }));
+    console.log(
+      JSON.stringify({ count: recoveries.length, recoveries }, null, 2),
+    );
+  } finally {
+    await client?.close().catch(() => undefined);
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+async function waitForFileStable(absolutePath, predicate, label) {
+  const deadline = Date.now() + 25_000;
+  let previous = null;
+  let stableCount = 0;
+  while (Date.now() < deadline) {
+    const current = await readFile(absolutePath, "utf8");
+    if (predicate(current)) {
+      stableCount = current === previous ? stableCount + 1 : 0;
+      if (stableCount >= 2) return current;
+    }
+    previous = current;
+    await sleep(500);
+  }
+  throw new Error(`Timed out waiting for ${label}.`);
+}
+
+async function runCli(command, args) {
+  const child = spawn(command, args, {
+    cwd: process.cwd(),
+    env: process.env,
+    shell: false,
+    windowsHide: true,
+    stdio: "ignore",
+  });
+  const exitCode = await withTimeout(
+    new Promise((resolve, reject) => {
+      child.once("error", reject);
+      child.once("exit", (code) => resolve(code));
+    }),
+    "Obsidian CLI vault open",
+    CLI_TIMEOUT_MS,
+  ).catch((error) => {
+    // Never terminate an Obsidian process as a timeout side effect. The CLI
+    // child is detached from this canary's event-loop ownership instead.
+    child.unref();
+    throw error;
+  });
+  if (exitCode !== 0) {
+    throw new Error(`Obsidian CLI exited ${String(exitCode)}.`);
+  }
+  return { exitCode };
+}
+
+async function waitForLocalRestClosed() {
+  const deadline = Date.now() + CLI_TIMEOUT_MS;
+  let consecutiveFailures = 0;
+  while (Date.now() < deadline) {
+    try {
+      await fetchWithAbortTimeout(
+        EXPECTED_BASE_URL,
+        {},
+        "Pilot 2 Local REST close probe",
+        1_000,
+      );
+      consecutiveFailures = 0;
+    } catch {
+      consecutiveFailures += 1;
+      if (consecutiveFailures >= 3) return;
+    }
+    await sleep(250);
+  }
+  throw new Error("Pilot 2 Local REST remained available after CLI close.");
+}
+
+async function optionalFileState(absolutePath) {
+  if (!(await exists(absolutePath))) return { exists: false, content: null };
+  return { exists: true, content: await readFile(absolutePath) };
+}
+
+function sameOptionalFileState(left, right) {
+  return (
+    left?.exists === right?.exists &&
+    (!left?.exists || left.content.equals(right.content))
+  );
+}
+
+function assertLiveStatus(status) {
+  assert.equal(status?.ok, true, "Operon status is not healthy.");
+  assert.equal(status?.source, "operon-runtime");
+  assert.equal(status?.stale, false);
+  assert.equal(status?.bridge?.version, "0.8.0");
+  assert.equal(status?.bridge?.mode, "read-write");
+  assert.equal(status?.operon?.present, true);
+  assert.equal(status?.operon?.version, EXPECTED_OPERON_VERSION);
+  assert.equal(status?.operon?.compatible, true);
+  assert.equal(status?.index?.ready, true);
+  assert.equal(Number.isInteger(status?.index?.generation), true);
+  assert.ok(status.index.generation > 0);
+  assert.equal(status?.index?.duplicateConflictCount, 0);
+  for (const capability of [
+    "status",
+    "configuration",
+    "list",
+    "get",
+    "query",
+    "validate",
+    "adopt",
+    "create",
+    "update",
+    "periodicCreate",
+    "periodicUpdate",
+    "taskWorkflowRecovery",
+  ]) {
+    assert.equal(
+      status?.capabilities?.[capability],
+      true,
+      `Required live capability is unavailable: ${capability}.`,
+    );
+  }
+}
+
+function assertRefreshedSnapshotStatus(status) {
+  assert.equal(status?.ok, true, "Forced Operon snapshot refresh failed.");
+  assert.equal(status?.source, "operon-live");
+  assert.equal(status?.stale, false);
+  assert.equal(status?.snapshot?.bridgeVersion, "0.8.0");
+  assert.equal(status?.snapshot?.operonVersion, EXPECTED_OPERON_VERSION);
+  assert.equal(Number.isInteger(status?.snapshot?.generation), true);
+  assert.ok(status.snapshot.generation > 0);
+}
+
+async function main() {
+  const apiKey = (process.env.OBSIDIAN_API_KEY ?? "").trim();
+  const baseUrl = (process.env.OBSIDIAN_BASE_URL ?? "").replace(/\/$/u, "");
+  const requestedVault = path.resolve(process.env.OBSIDIAN_VAULT ?? "");
+  const startupOrder = envTrue("OPERON_35_CANARY_OPEN_VAULT");
+
+  assert.equal(
+    process.env.OPERON_35_CANARY_CONFIRM,
+    RUN_CONFIRMATION,
+    `Refusing live mutations. Set OPERON_35_CANARY_CONFIRM=${RUN_CONFIRMATION}.`,
+  );
+  assert.equal(
+    requestedVault.toLowerCase(),
+    EXPECTED_VAULT.toLowerCase(),
+    "OBSIDIAN_VAULT must be the exact disposable Pilot 2 path.",
+  );
+  assert.equal(
+    baseUrl,
+    EXPECTED_BASE_URL,
+    `OBSIDIAN_BASE_URL must be exactly ${EXPECTED_BASE_URL}.`,
+  );
+  assert.ok(apiKey, "OBSIDIAN_API_KEY is required and is never logged.");
+  assert.equal(
+    envTrue("OPERON_MUTATIONS_ENABLED"),
+    true,
+    "OPERON_MUTATIONS_ENABLED=true is required.",
+  );
+  assert.equal(await exists(EXPECTED_VAULT), true, "Pilot 2 vault is missing.");
+  assert.equal(
+    path.basename(EXPECTED_VAULT),
+    EXPECTED_VAULT_NAME,
+    "Pilot 2 vault identity mismatch.",
+  );
+  if (startupOrder) {
+    assert.equal(
+      process.env.OPERON_35_CANARY_CONFIRM_OPEN_VAULT,
+      OPEN_CONFIRMATION,
+      `Refusing to open Obsidian. Set OPERON_35_CANARY_CONFIRM_OPEN_VAULT=${OPEN_CONFIRMATION}.`,
+    );
+  } else {
+    assert.equal(
+      envTrue("OPERON_35_CANARY_CONFIRM_PILOT_ALREADY_OPEN"),
+      true,
+      "Confirm the already-open Pilot 2 with OPERON_35_CANARY_CONFIRM_PILOT_ALREADY_OPEN=true, or use the guarded startup-order mode.",
+    );
+  }
+
+  const fixtureAbsolutePath = absoluteVaultPath(FIXTURE_PATH);
+  assert.equal(
+    await exists(fixtureAbsolutePath),
+    false,
+    `Dedicated fixture already exists: ${FIXTURE_PATH}. Recover or remove it before rerunning.`,
+  );
+
+  const runId = randomUUID();
+  const dates = routeDates(runId);
+  const tempRoot = await mkdtemp(
+    path.join(os.tmpdir(), "operon-35-live-backup-"),
+  );
+  const backupManifestPath = path.join(tempRoot, "fixture-state.json");
+  const evidenceFile = path.join(
+    os.tmpdir(),
+    `operon-35-live-evidence-${runId}.json`,
+  );
+  const cachePath = path.join(tempRoot, "shared-cache.sqlite");
+  const markdownBackupPath = path.join(tempRoot, "markdown-backup");
+  const periodicRegistryBackupPath = path.join(
+    tempRoot,
+    "periodic-note-containers-before.json",
+  );
+  await writeFile(
+    backupManifestPath,
+    `${JSON.stringify(
+      {
+        schemaVersion: 2,
+        vaultName: EXPECTED_VAULT_NAME,
+        fixturePath: FIXTURE_PATH,
+        existedBefore: false,
+        restoreContract: "all-canary-markdown-byte-exact",
+        runIdHash: shortHash(runId),
+      },
+      null,
+      2,
+    )}\n`,
+    { encoding: "utf8", mode: 0o600 },
+  );
+
+  const evidence = {
+    schemaVersion: 1,
+    redacted: true,
+    ok: false,
+    runId,
+    startedAt: new Date().toISOString(),
+    vaultName: EXPECTED_VAULT_NAME,
+    fixturePath: FIXTURE_PATH,
+    startupOrder: { enabled: startupOrder, degradedObserved: false },
+    routeDates: dates,
+    runtime: null,
+    validation: {},
+    frontmatterDateManager: {},
+    adoption: {},
+    media: {},
+    periodicScheduling: {},
+    periodicCreates: [],
+    bridgeConcurrency: {},
+    pendingRecoveries: {},
+    mutationStatuses: [],
+    nativeProofs: [],
+    preMutationInventory: null,
+    artifactRestoration: { restored: false },
+    periodicRegistryRestoration: { restored: false },
+    fixtureRestoration: { restored: false },
+    error: null,
+  };
+
+  let transport;
+  let client;
+  let backendStderr = "";
+  let fixtureCreated = false;
+  let fixtureRestored = false;
+  let baselineSnapshot = null;
+  let periodicRegistryBaseline = null;
+  let openedVaultCli = null;
+  let success = false;
+  let shutdownSignal = null;
+  const activeRequests = new Set();
+  const artifactPaths = new Set([FIXTURE_PATH]);
+
+  const onSignal = (signal) => {
+    shutdownSignal ??= signal;
+  };
+  const onSigint = () => onSignal("SIGINT");
+  const onSigterm = () => onSignal("SIGTERM");
+  process.on("SIGINT", onSigint);
+  process.on("SIGTERM", onSigterm);
+
+  function assertActive() {
+    if (shutdownSignal) throw new Error(`Interrupted by ${shutdownSignal}.`);
+  }
+
+  function track(promise) {
+    activeRequests.add(promise);
+    promise.then(
+      () => activeRequests.delete(promise),
+      () => activeRequests.delete(promise),
+    );
+    return promise;
+  }
+
+  async function callRaw(name, args, options = {}) {
+    assertActive();
+    const underlying = track(client.callTool({ name, arguments: args }));
+    const result = await withTimeout(
+      underlying,
+      name,
+      options.timeoutMs ?? READ_TIMEOUT_MS,
+    );
+    assertActive();
+    const payload = parseMcpPayload(result, name);
+    if (result.isError && !options.allowError) {
+      const code = payload?.error?.code ?? "MCP_TOOL_ERROR";
+      throw new Error(`${name} failed with ${String(code)}.`);
+    }
+    return { payload, isError: result.isError === true };
+  }
+
+  async function call(name, args, options = {}) {
+    return (await callRaw(name, args, options)).payload;
+  }
+
+  function mutationDiagnostic(result, label, options = {}) {
+    const error =
+      result?.error && typeof result.error === "object" ? result.error : {};
+    const details =
+      error?.details && typeof error.details === "object" ? error.details : {};
+    const message =
+      typeof error.message === "string"
+        ? error.message
+        : typeof options.thrownMessage === "string"
+          ? options.thrownMessage
+          : null;
+    const safeMessage = message
+      ? redactText(message, apiKey)
+          .split(runId)
+          .join("[REDACTED_RUN_ID]")
+          .split(FIXTURE_PATH)
+          .join("[REDACTED_FIXTURE]")
+      : null;
+    const recoveryRef = result?.recoveryRef ?? details?.recoveryRef;
+    const planDigest = result?.planDigest ?? details?.planDigest;
+    const nativeStatus = result?.nativeStatus ?? details?.nativeStatus;
+    const mutationMayHaveApplied =
+      result?.mutationMayHaveApplied ?? details?.mutationMayHaveApplied;
+    const nativeProof =
+      result?.nativeProof && typeof result.nativeProof === "object"
+        ? result.nativeProof
+        : null;
+    const nativeGroups = Array.isArray(nativeProof?.groupResults)
+      ? nativeProof.groupResults.slice(0, 32)
+      : [];
+    const diagnosticCode = boundedDiagnosticToken(
+      typeof error.code === "string"
+        ? error.code
+        : typeof options.thrownCode === "string"
+          ? options.thrownCode
+          : options.transportError
+            ? /timed out/iu.test(message ?? "")
+              ? "MCP_TIMEOUT"
+              : /connection closed/iu.test(message ?? "")
+                ? "MCP_CONNECTION_CLOSED"
+                : "MCP_TRANSPORT_ERROR"
+            : undefined,
+    );
+    return {
+      label,
+      status: boundedDiagnosticToken(
+        result?.status ??
+          (options.transportError
+            ? "transport-error"
+            : options.mcpToolError
+              ? "mcp-tool-error"
+              : null),
+      ),
+      ...(diagnosticCode ? { code: diagnosticCode } : {}),
+      ...(boundedDiagnosticToken(nativeStatus)
+        ? { nativeStatus: boundedDiagnosticToken(nativeStatus) }
+        : {}),
+      ...(typeof nativeProof?.status === "string"
+        ? { nativeProofStatus: boundedDiagnosticToken(nativeProof.status) }
+        : {}),
+      ...(nativeGroups.length > 0
+        ? {
+            nativeGroupStatuses: nativeGroups.map(
+              (group) => boundedDiagnosticToken(group?.status) ?? "unknown",
+            ),
+            nativeGroupErrorCodes: nativeGroups.flatMap((group) => {
+              const code = boundedDiagnosticToken(group?.error?.code);
+              return code ? [code] : [];
+            }),
+          }
+        : {}),
+      ...(typeof mutationMayHaveApplied === "boolean"
+        ? { mutationMayHaveApplied }
+        : {}),
+      ...(typeof result?.retryable === "boolean"
+        ? { retryable: result.retryable }
+        : {}),
+      ...(typeof result?.operationId === "string"
+        ? { operationIdHash: shortHash(result.operationId) }
+        : {}),
+      ...(typeof recoveryRef === "string" && recoveryRef
+        ? { recoveryRefHash: shortHash(recoveryRef) }
+        : {}),
+      ...(typeof planDigest === "string" && planDigest
+        ? { planDigestHash: shortHash(planDigest) }
+        : {}),
+      ...(safeMessage
+        ? {
+            messageHash: shortHash(safeMessage),
+            messageChars: safeMessage.length,
+            messageTruncated: message.length > 2_000,
+          }
+        : {}),
+      ...(options.mcpToolError ? { mcpToolError: true } : {}),
+      ...(options.transportError ? { transportError: true } : {}),
+    };
+  }
+
+  async function callMutation(name, args, label) {
+    let observed;
+    try {
+      observed = await callRaw(name, args, {
+        allowError: true,
+        timeoutMs: MUTATION_TIMEOUT_MS,
+      });
+    } catch (error) {
+      evidence.mutationStatuses.push(
+        mutationDiagnostic(null, label, {
+          transportError: true,
+          thrownMessage: error instanceof Error ? error.message : String(error),
+          thrownCode: typeof error?.code === "string" ? error.code : undefined,
+        }),
+      );
+      throw error;
+    }
+    const result = observed.payload;
+    evidence.mutationStatuses.push(
+      mutationDiagnostic(result, label, { mcpToolError: observed.isError }),
+    );
+    if (observed.isError) {
+      const code = result?.error?.code ?? "MCP_TOOL_ERROR";
+      throw new Error(`${label} failed with ${String(code)}.`);
+    }
+    if (result?.status === "outcome-unknown") {
+      throw new Error(
+        `${label} returned outcome-unknown; no recovery or blind retry was attempted.`,
+      );
+    }
+    return result;
+  }
+
+  async function waitForLiveStatus() {
+    const deadline = Date.now() + STARTUP_TIMEOUT_MS;
+    let attempts = 0;
+    while (Date.now() < deadline) {
+      attempts += 1;
+      const observed = await callRaw(
+        "operon_status",
+        {},
+        { allowError: true, timeoutMs: READ_TIMEOUT_MS },
+      );
+      if (!observed.isError) {
+        try {
+          const liveStatus = observed.payload?.live;
+          assertLiveStatus(liveStatus);
+          return { status: liveStatus, attempts };
+        } catch {
+          // The same stdio connection remains alive while the live runtime settles.
+        }
+      }
+      await sleep(1_000);
+    }
+    throw new Error(
+      `Pilot 2 did not become live on the same MCP client within ${STARTUP_TIMEOUT_MS}ms.`,
+    );
+  }
+
+  async function validateZero(label) {
+    const result = await call("operon_validate", { forceRefresh: true });
+    assert.deepEqual(
+      result?.summary,
+      { P0: 0, P1: 0, P2: 0 },
+      `${label} validation is not P0/P1/P2 = 0/0/0.`,
+    );
+    evidence.validation[label] = result.summary;
+    return result;
+  }
+
+  async function pendingRecoveriesZero(label) {
+    const result = await call("operon_list_pending_recoveries", {});
+    assert.equal(
+      Array.isArray(result?.recoveries),
+      true,
+      `${label} pending recovery response is malformed.`,
+    );
+    assert.equal(
+      result.recoveries.length,
+      0,
+      `${label} has pending Operon recoveries; the canary will not recover or retry them.`,
+    );
+    evidence.pendingRecoveries[label] = 0;
+  }
+
+  async function stableTask(operonId) {
+    const deadline = Date.now() + 30_000;
+    let previousRevision = null;
+    while (Date.now() < deadline) {
+      const result = await call("operon_get_task", {
+        operonId,
+        includeProperties: true,
+        forceRefresh: true,
+      });
+      const task = result?.task;
+      if (task?.revision && task.revision === previousRevision) return task;
+      previousRevision = task?.revision ?? null;
+      await sleep(750);
+    }
+    throw new Error(
+      `Operon task ${shortHash(operonId)} did not reach a stable revision.`,
+    );
+  }
+
+  async function periodicCreateViaMcp(kind, routeDate, label) {
+    const description = `Operon 3.5.2 ${kind} canary ${runId}`;
+    const before = await markdownInventory();
+    const periodic = {
+      description,
+      periodicKind: kind,
+      routeDate,
+      fields: { taskType: `canary-${kind}` },
+    };
+    const preview = mutationStatus(
+      await callMutation(
+        "operon_create_periodic_task",
+        {
+          idempotencyKey: `${runId}:${kind}:preview`,
+          dryRun: true,
+          periodic,
+        },
+        `${label} preview`,
+      ),
+      `${label} preview`,
+      "planned",
+    );
+    assert.equal(
+      preview.plan?.capability,
+      "tasks.create.periodic-note.preview",
+    );
+    assert.equal(preview.plan?.mutationKind, "task.create");
+    assert.equal(preview.plan?.planDigest, preview.planDigest);
+    trackPlannedTaskSourceArtifacts(preview.plan, `${label} preview`);
+    assert.deepEqual(
+      redactedInventoryChanges(
+        inventoryDiff(before, await markdownInventory()),
+      ),
+      [],
+      `${label} preview changed the vault inventory.`,
+    );
+    const result = mutationStatus(
+      await callMutation(
+        "operon_create_periodic_task",
+        {
+          idempotencyKey: `${runId}:${kind}:apply`,
+          dryRun: false,
+          periodic,
+        },
+        label,
+      ),
+      label,
+      "applied",
+    );
+    evidence.nativeProofs.push(assertNativeMutationProof(result, label));
+    assert.equal(result?.after?.source, "inline");
+    assert.equal(
+      canonicalRelativeMarkdownPath(result?.after?.path),
+      true,
+      `${label} returned an unsafe source path.`,
+    );
+    artifactPaths.add(result.after.path);
+    const after = await markdownInventory();
+    const changes = inventoryDiff(before, after);
+    const sourceBefore = before.get(result.after.path);
+    assert.equal(
+      sourceBefore,
+      undefined,
+      `${label} routed into a pre-existing Markdown note; refusing to treat it as a canary artifact.`,
+    );
+    assert.equal(
+      changes.some(
+        (change) =>
+          change.path === result.after.path && change.change === "created",
+      ),
+      true,
+      `${label} did not create a dedicated periodic note.`,
+    );
+    const sourceContent = await readFile(
+      absoluteVaultPath(result.after.path),
+      "utf8",
+    );
+    assert.equal(
+      sourceContent.includes(runId),
+      true,
+      `${label} source does not contain the run marker.`,
+    );
+    evidence.periodicCreates.push({
+      kind,
+      routeDate,
+      pathHash: shortHash(result.after.path),
+      operationIdHash: shortHash(result.operationId),
+      operonIdHash: shortHash(result.after.operonId),
+      previewPlanDigestHash: shortHash(preview.planDigest),
+      markdownChanges: redactedInventoryChanges(changes),
+      restoredOnPass: false,
+    });
+    return result.after;
+  }
+
+  function trackPlannedTaskSourceArtifacts(plan, label) {
+    const candidates = [
+      plan?.periodicRoute?.notePath,
+      plan?.periodicUpdate?.notePath,
+      ...(plan?.periodicUpdate?.sourceTransitions ?? []).map(
+        (transition) => transition?.filePath,
+      ),
+    ].filter((value) => typeof value === "string");
+    for (const relativePath of new Set(candidates)) {
+      assert.equal(
+        canonicalRelativeMarkdownPath(relativePath),
+        true,
+        `${label} returned an unsafe planned task-source path.`,
+      );
+      artifactPaths.add(relativePath);
+    }
+  }
+
+  function trackNativeTaskSourceArtifacts(result, label) {
+    for (const group of result?.nativeProof?.groupResults ?? []) {
+      for (const revision of group.resourceRevisions ?? []) {
+        if (revision.resourceKind !== "task-source") continue;
+        assert.equal(
+          canonicalRelativeMarkdownPath(revision.resourceKey),
+          true,
+          `${label} returned an unsafe task-source resource key.`,
+        );
+        artifactPaths.add(revision.resourceKey);
+      }
+    }
+  }
+
+  async function removeEmptyArtifactParents(relativePath) {
+    let current = path.dirname(absoluteVaultPath(relativePath));
+    const vaultRoot = EXPECTED_VAULT.toLowerCase();
+    while (current.toLowerCase() !== vaultRoot) {
+      try {
+        await rmdir(current);
+      } catch (error) {
+        if (error?.code === "ENOENT") return;
+        if (error?.code === "ENOTEMPTY" || error?.code === "EEXIST") return;
+        throw error;
+      }
+      current = path.dirname(current);
+    }
+  }
+
+  async function restoreAllCanaryArtifacts() {
+    if (!baselineSnapshot) {
+      fixtureRestored = !fixtureCreated;
+      evidence.fixtureRestoration = {
+        restored: fixtureRestored,
+        expectedState: "absent",
+      };
+      return;
+    }
+
+    const current = await captureMarkdownSnapshot();
+    const changes = inventoryDiff(baselineSnapshot, current);
+    const restorable = [];
+    const unexpected = [];
+    for (const change of changes) {
+      const currentContent = current.get(change.path)?.content;
+      const belongsToRun =
+        artifactPaths.has(change.path) ||
+        change.path === FIXTURE_PATH ||
+        currentContent?.includes(Buffer.from(runId, "utf8"));
+      (belongsToRun ? restorable : unexpected).push(change);
+    }
+
+    for (const change of restorable) {
+      const original = baselineSnapshot.get(change.path);
+      const absolute = absoluteVaultPath(change.path);
+      if (original) {
+        await mkdir(path.dirname(absolute), { recursive: true });
+        await writeFile(absolute, original.content, { mode: 0o600 });
+      } else {
+        await rm(absolute, { force: true });
+        await removeEmptyArtifactParents(change.path);
+      }
+    }
+
+    const after = await captureMarkdownSnapshot();
+    const remaining = inventoryDiff(baselineSnapshot, after);
+    const restored = remaining.length === 0 && unexpected.length === 0;
+    fixtureRestored = !(await exists(fixtureAbsolutePath));
+    evidence.fixtureRestoration = {
+      restored: fixtureRestored,
+      expectedState: "absent",
+    };
+    evidence.artifactRestoration = {
+      restored,
+      restoredChangeCount: restorable.length,
+      unexpectedChangeCount: unexpected.length,
+      remainingChangeCount: remaining.length,
+      restoredPathHashes: restorable.map((change) => shortHash(change.path)),
+      unexpectedPathHashes: unexpected.map((change) => shortHash(change.path)),
+      remainingPathHashes: remaining.map((change) => shortHash(change.path)),
+      finalInventoryDigestHash: shortHash(inventoryDigest(after)),
+    };
+    assert.equal(
+      unexpected.length,
+      0,
+      "Unexpected Markdown changes occurred during the canary; they were not overwritten.",
+    );
+    assert.deepEqual(
+      remaining,
+      [],
+      "Canary Markdown artifacts were not restored byte-for-byte.",
+    );
+  }
+
+  try {
+    transport = new StdioClientTransport({
+      command: process.execPath,
+      args: [BACKEND_ENTRY],
+      cwd: PROJECT_ROOT,
+      env: {
+        ...process.env,
+        NODE_ENV: "production",
+        MCP_TRANSPORT_TYPE: "stdio",
+        MCP_TOOL_PROFILE: "tasks",
+        MCP_WRITE_MODE: "full",
+        OPERON_MUTATIONS_ENABLED: "true",
+        OPERON_MUTATION_ALLOWED_PATH_PREFIXES: "",
+        OBSIDIAN_RUNTIME_MODE: "live",
+        // The startup-order contract is a live-runtime promise: the MCP must
+        // remain connected while Desktop/Local REST is temporarily absent.
+        OBSIDIAN_STARTUP_BLOCKING: "false",
+        OBSIDIAN_VAULT: EXPECTED_VAULT,
+        OBSIDIAN_BASE_URL: baseUrl,
+        OBSIDIAN_API_KEY: apiKey,
+        OBSIDIAN_SHARED_CACHE_DB_PATH: cachePath,
+        OBSIDIAN_ENABLE_CACHE: "true",
+        SEMANTIC_SEARCH_PREWARM: "false",
+        LOGS_DIR: PROJECT_LOGS_PATH,
+        MCP_LOG_LEVEL: process.env.MCP_LOG_LEVEL ?? "error",
+      },
+      stderr: "pipe",
+    });
+    transport.stderr?.on("data", (chunk) => {
+      if (backendStderr.length < 32_768) {
+        backendStderr += chunk.toString("utf8");
+      }
+    });
+    client = new Client(
+      { name: "operon-35-live-canary", version: "1.0.0" },
+      { capabilities: {} },
+    );
+    await withTimeout(client.connect(transport), "MCP stdio connect", 30_000);
+
+    const toolListBefore = await withTimeout(
+      client.listTools(),
+      "MCP tools/list",
+      READ_TIMEOUT_MS,
+    );
+    const toolNames = new Set(toolListBefore.tools.map((tool) => tool.name));
+    for (const required of [
+      "operon_status",
+      "operon_validate",
+      "operon_adopt_task",
+      "operon_create_periodic_task",
+      "operon_update_periodic_scheduling",
+      "operon_update_task",
+      "operon_get_task",
+      "operon_query_tasks",
+      "operon_list_pending_recoveries",
+      "operon_recover_mutation",
+    ]) {
+      assert.equal(
+        toolNames.has(required),
+        true,
+        `Missing MCP tool: ${required}.`,
+      );
+    }
+
+    if (startupOrder) {
+      const degraded = await callRaw("operon_status", {}, { allowError: true });
+      const degradedObserved =
+        degraded.isError ||
+        degraded.payload?.ok !== true ||
+        degraded.payload?.live?.index?.ready !== true;
+      assert.equal(
+        degradedObserved,
+        true,
+        "Startup-order mode requires Pilot 2 to be closed at the first status call.",
+      );
+      evidence.startupOrder.degradedObserved = true;
+      evidence.startupOrder.connectionAliveAfterDegraded =
+        (
+          await withTimeout(
+            client.listTools(),
+            "MCP tools/list after degraded status",
+            READ_TIMEOUT_MS,
+          )
+        ).tools.length === toolListBefore.tools.length;
+      assert.equal(
+        evidence.startupOrder.connectionAliveAfterDegraded,
+        true,
+        "MCP connection did not survive the degraded status call.",
+      );
+      const cliCommand =
+        (process.env.OPERON_35_CANARY_OBSIDIAN_CLI ?? "obsidian").trim() ||
+        "obsidian";
+      openedVaultCli = cliCommand;
+      const cli = await runCli(cliCommand, [
+        `vault=${EXPECTED_VAULT_NAME}`,
+        "version",
+      ]);
+      evidence.startupOrder.cliExitCode = cli.exitCode;
+    }
+
+    const live = await waitForLiveStatus();
+    evidence.startupOrder.liveAttempts = live.attempts;
+    evidence.startupOrder.sameClientBecameLive = true;
+    evidence.runtime = {
+      operonVersion: live.status.operon.version,
+      bridgeVersion: live.status.bridge.version,
+      bridgeMode: live.status.bridge.mode,
+      compatibilityState: live.status.operon.compatibilityState ?? null,
+      generation: live.status.index.generation,
+      taskCount: live.status.index.taskCount,
+      capabilities: Object.fromEntries(
+        [
+          "adopt",
+          "create",
+          "update",
+          "periodicCreate",
+          "periodicUpdate",
+          "taskWorkflowRecovery",
+        ].map((name) => [name, live.status.capabilities[name]]),
+      ),
+    };
+
+    await validateZero("before");
+    await pendingRecoveriesZero("before");
+
+    const collisionMarkers = [
+      ...new Set([
+        runId,
+        dates.daily,
+        dates.scheduled,
+        dates.weekly,
+        ...isoWeekMarkers(dates.weekly),
+        dates.concurrent,
+      ]),
+    ];
+    baselineSnapshot = await captureMarkdownSnapshot(markdownBackupPath);
+    periodicRegistryBaseline = await optionalFileState(PERIODIC_REGISTRY_PATH);
+    if (periodicRegistryBaseline.exists) {
+      await writeFile(
+        periodicRegistryBackupPath,
+        periodicRegistryBaseline.content,
+        { mode: 0o600 },
+      );
+    }
+    assertCollisionFree(baselineSnapshot, collisionMarkers);
+    await writeFile(
+      backupManifestPath,
+      `${JSON.stringify(
+        {
+          schemaVersion: 2,
+          vaultName: EXPECTED_VAULT_NAME,
+          fixturePath: FIXTURE_PATH,
+          existedBefore: false,
+          restoreContract: "all-canary-markdown-byte-exact",
+          runIdHash: shortHash(runId),
+          markdownCount: baselineSnapshot.size,
+          inventoryDigest: inventoryDigest(baselineSnapshot),
+          periodicRegistryExisted: periodicRegistryBaseline.exists,
+          periodicRegistryDigest: periodicRegistryBaseline.exists
+            ? sha256(periodicRegistryBaseline.content)
+            : null,
+        },
+        null,
+        2,
+      )}\n`,
+      { encoding: "utf8", mode: 0o600 },
+    );
+    const preflightQuery = await call("operon_query_tasks", {
+      search: runId,
+      forceRefresh: true,
+      limit: 100,
+    });
+    assert.equal(
+      (preflightQuery?.tasks ?? []).length,
+      0,
+      "The unique canary run marker already resolves to an Operon task.",
+    );
+    evidence.preMutationInventory = {
+      completed: true,
+      markdownCount: baselineSnapshot.size,
+      inventoryDigestHash: shortHash(inventoryDigest(baselineSnapshot)),
+      collisionMarkerHashes: collisionMarkers.map(shortHash),
+      operonCollisionCount: 0,
+      backupStoredInPrivateTemp: true,
+      periodicRegistryExisted: periodicRegistryBaseline.exists,
+      periodicRegistryDigestHash: periodicRegistryBaseline.exists
+        ? shortHash(sha256(periodicRegistryBaseline.content))
+        : null,
+    };
+
+    const communityPlugins = JSON.parse(
+      await readFile(
+        path.join(EXPECTED_VAULT, ".obsidian", "community-plugins.json"),
+        "utf8",
+      ),
+    );
+    const operonSettings = JSON.parse(
+      await readFile(
+        path.join(
+          EXPECTED_VAULT,
+          ".obsidian",
+          "plugins",
+          "operon",
+          "data.json",
+        ),
+        "utf8",
+      ),
+    );
+    const periodicProfile = operonSettings?.ui?.taskCreationProfile;
+    assert.equal(
+      periodicProfile?.manageDailyNotesWithOperon,
+      true,
+      "Pilot 2 must use Operon-managed Daily Notes before the canary mutates Markdown.",
+    );
+    assert.equal(
+      periodicProfile?.createDailyNotesAsOperonTask,
+      true,
+      "Pilot 2 must create Daily Notes as Operon tasks before the canary mutates Markdown.",
+    );
+    assert.equal(
+      periodicProfile?.manageWeeklyNotesWithOperon,
+      true,
+      "Pilot 2 must use Operon-managed Weekly Notes before the canary mutates Markdown.",
+    );
+    assert.equal(
+      periodicProfile?.createWeeklyNotesAsOperonTask,
+      true,
+      "Pilot 2 must create Weekly Notes as Operon tasks before the canary mutates Markdown.",
+    );
+    const dateManagerSettings = JSON.parse(
+      await readFile(
+        path.join(
+          EXPECTED_VAULT,
+          ".obsidian",
+          "plugins",
+          "frontmatter-date-manager",
+          "data.json",
+        ),
+        "utf8",
+      ),
+    );
+    const dateManagerManifest = JSON.parse(
+      await readFile(
+        path.join(
+          EXPECTED_VAULT,
+          ".obsidian",
+          "plugins",
+          "frontmatter-date-manager",
+          "manifest.json",
+        ),
+        "utf8",
+      ),
+    );
+    assert.equal(communityPlugins.includes("frontmatter-date-manager"), true);
+    assert.equal(dateManagerManifest.version, "1.2.1");
+    assert.equal(dateManagerSettings.enableAutoUpdate, true);
+    assert.equal(dateManagerSettings.enableModifiedTime, true);
+
+    await mkdir(path.dirname(fixtureAbsolutePath), { recursive: true });
+    const expectedLine = `- [ ] Operon adoption canary ${runId}`;
+    const initialFixture = [
+      "---",
+      "canary: operon-3.5.2-live",
+      `modification: ${ORIGINAL_MODIFICATION}`,
+      "---",
+      "",
+      `Dedicated Pilot 2 fixture ${runId}.`,
+      expectedLine,
+      "",
+    ].join("\n");
+    await writeFile(fixtureAbsolutePath, initialFixture, {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
+    fixtureCreated = true;
+    const fixtureBeforeAdoption = await waitForFileStable(
+      fixtureAbsolutePath,
+      (content) =>
+        content.includes(expectedLine) &&
+        frontmatterScalarWhenValid(content, "modification") ===
+          ORIGINAL_MODIFICATION,
+      "the external fixture to settle before governed adoption",
+    );
+    const fixtureLines = fixtureBeforeAdoption.split(/\r?\n/u);
+    const adoptionIndexes = fixtureLines
+      .map((line, index) => ({ line, index }))
+      .filter((entry) => entry.line === expectedLine);
+    assert.equal(adoptionIndexes.length, 1);
+    const adoptionLine = adoptionIndexes[0].index + 1;
+    const adoptionArgs = {
+      idempotencyKey: `${runId}:adopt:apply`,
+      dryRun: false,
+      adoption: {
+        targetPath: FIXTURE_PATH,
+        line: adoptionLine,
+        expectedLine,
+      },
+    };
+    const adopted = mutationStatus(
+      await callMutation("operon_adopt_task", adoptionArgs, "adoption apply"),
+      "adoption apply",
+      "applied",
+    );
+    evidence.nativeProofs.push(
+      assertNativeMutationProof(adopted, "adoption apply"),
+    );
+    assert.equal(adopted.after?.path, FIXTURE_PATH);
+    assert.equal(adopted.after?.line, adoptionLine);
+    const fixtureAfterGovernedAdoption = await waitForFileStable(
+      fixtureAbsolutePath,
+      (content) => {
+        const modification = frontmatterScalarWhenValid(
+          content,
+          "modification",
+        );
+        return (
+          content.includes(runId) &&
+          modification !== null &&
+          modification !== ORIGINAL_MODIFICATION
+        );
+      },
+      "Frontmatter Date Manager after governed Operon adoption",
+    );
+    const observedModification = markdownFrontmatter(
+      fixtureAfterGovernedAdoption,
+      "governed adoption fixture",
+    ).modification;
+    assert.ok(observedModification);
+    evidence.frontmatterDateManager = {
+      enabled: true,
+      version: dateManagerManifest.version,
+      autoUpdate: true,
+      modifiedTimeObserved: true,
+      trigger: "operon_adopt_task",
+      externalCreateWasNotTreatedAsTheTrigger: true,
+      beforeContentHash: shortHash(fixtureBeforeAdoption),
+      afterContentHash: shortHash(fixtureAfterGovernedAdoption),
+      observedModificationHash: shortHash(String(observedModification)),
+      pluginSettingsHash: shortHash(JSON.stringify(dateManagerSettings)),
+    };
+    const adoptedId = adopted.after.operonId;
+    const replay = await callMutation(
+      "operon_adopt_task",
+      adoptionArgs,
+      "adoption replay",
+    );
+    assert.equal(
+      replay.operationId,
+      adopted.operationId,
+      "Adoption replay returned a different operationId.",
+    );
+    assert.equal(replay.replayed, true);
+    evidence.nativeProofs.push(
+      assertNativeMutationProof(replay, "adoption replay"),
+    );
+    const staleLine = mutationStatus(
+      await callMutation(
+        "operon_adopt_task",
+        {
+          ...adoptionArgs,
+          idempotencyKey: `${runId}:adopt:stale-line`,
+        },
+        "adoption stale line",
+      ),
+      "adoption stale line",
+      "conflict",
+    );
+    evidence.adoption = {
+      applied: true,
+      replayed: replay.replayed,
+      staleLineConflict: staleLine.status,
+      operationIdHash: shortHash(adopted.operationId),
+      operonIdHash: shortHash(adoptedId),
+      exactLine: adoptionLine,
+    };
+
+    const beforeMedia = await stableTask(adoptedId);
+    const taskType = `canary-type-${runId.slice(0, 8)}`;
+    const taskImage = `Canary\\cover;${runId.slice(0, 8)}.png`;
+    const galleryInput = [
+      `Canary/gallery;${runId.slice(0, 8)}.png`,
+      `Canary\\gallery;${runId.slice(0, 8)}.png`,
+      `Canary/gallery;${runId.slice(0, 8)}.png`,
+    ];
+    const galleryExpected = galleryInput.slice(0, 2);
+    const mediaApplied = mutationStatus(
+      await callMutation(
+        "operon_update_task",
+        {
+          operonId: adoptedId,
+          expectedRevision: beforeMedia.revision,
+          idempotencyKey: `${runId}:media:apply`,
+          dryRun: false,
+          patch: {
+            fields: {
+              taskType,
+              taskImage,
+              taskGallery: galleryInput,
+            },
+          },
+        },
+        "typed media apply",
+      ),
+      "typed media apply",
+      "applied",
+    );
+    evidence.nativeProofs.push(
+      assertNativeMutationProof(mediaApplied, "typed media apply"),
+    );
+    assert.equal(typeof mediaApplied.after?.fields?.taskType, "string");
+    assert.equal(mediaApplied.after.fields.taskType, taskType);
+    assert.equal(typeof mediaApplied.after.fields.taskImage, "string");
+    assert.equal(mediaApplied.after.fields.taskImage, taskImage);
+    assert.equal(Array.isArray(mediaApplied.after.fields.taskGallery), true);
+    assert.deepEqual(mediaApplied.after.fields.taskGallery, galleryExpected);
+    // Isolate the stale-revision assertion from normal post-write index churn
+    // (including Frontmatter Date Manager's immediate timestamp update). The
+    // following mutation must fail because its revision is stale, not because
+    // the Operon snapshot was sampled while a live generation was settling.
+    await stableTask(adoptedId);
+    const staleRevision = mutationStatus(
+      await callMutation(
+        "operon_update_task",
+        {
+          operonId: adoptedId,
+          expectedRevision: beforeMedia.revision,
+          idempotencyKey: `${runId}:media:stale-revision`,
+          dryRun: false,
+          patch: { fields: { taskType: `${taskType}-stale` } },
+        },
+        "typed media stale revision",
+      ),
+      "typed media stale revision",
+      "conflict",
+    );
+    evidence.media = {
+      taskTypeScalar: true,
+      taskImageScalar: true,
+      galleryArray: true,
+      galleryOrderPreserved: true,
+      galleryFirstOccurrenceDeduplicated: true,
+      punctuationPreserved: true,
+      staleRevisionConflict: staleRevision.status,
+    };
+
+    const daily = await periodicCreateViaMcp(
+      "daily",
+      dates.daily,
+      "Daily periodic create",
+    );
+    const weekly = await periodicCreateViaMcp(
+      "weekly",
+      dates.weekly,
+      "Weekly periodic create",
+    );
+    assert.notEqual(daily.path, weekly.path);
+
+    const schedulingCapabilityStatus = await call("operon_status", {
+      forceRefresh: true,
+    });
+    assertRefreshedSnapshotStatus(schedulingCapabilityStatus);
+    assert.equal(
+      schedulingCapabilityStatus.snapshot.capabilities.periodicUpdate,
+      true,
+      "The created periodic fixture cannot be scheduled because the live projection does not explicitly expose periodicUpdate: true.",
+    );
+    const beforeSchedule = await stableTask(daily.operonId);
+    assert.deepEqual(
+      { path: beforeSchedule.path, line: beforeSchedule.line },
+      { path: daily.path, line: daily.line },
+      "The created Daily fixture locator changed before periodic scheduling.",
+    );
+    assert.equal(beforeSchedule.source, "inline");
+    assert.equal(
+      typeof beforeSchedule.parentTask === "string" &&
+        beforeSchedule.parentTask.length > 0,
+      true,
+      "The created Daily fixture has no projected periodic parent; refusing periodic scheduling.",
+    );
+    const sourceLocator = {
+      path: beforeSchedule.path,
+      line: beforeSchedule.line,
+    };
+    const schedulePreview = mutationStatus(
+      await callMutation(
+        "operon_update_periodic_scheduling",
+        {
+          operonId: daily.operonId,
+          expectedRevision: beforeSchedule.revision,
+          idempotencyKey: `${runId}:periodic-schedule:set-preview`,
+          dryRun: true,
+          patch: { fields: { dateScheduled: dates.scheduled } },
+        },
+        "periodic scheduling set preview",
+      ),
+      "periodic scheduling set preview",
+      "planned",
+    );
+    assert.equal(
+      schedulePreview.plan?.capability,
+      "tasks.update.periodic-note.preview",
+      "Operon did not project the additive periodic-update plan for the created Daily fixture.",
+    );
+    assert.equal(schedulePreview.plan?.mutationKind, "task.update");
+    assert.equal(schedulePreview.plan?.planDigest, schedulePreview.planDigest);
+    trackPlannedTaskSourceArtifacts(
+      schedulePreview.plan,
+      "Periodic scheduling set preview",
+    );
+    const beforeScheduleApply = await stableTask(daily.operonId);
+    assert.equal(
+      beforeScheduleApply.revision,
+      beforeSchedule.revision,
+      "The Daily fixture changed after periodic scheduling preview.",
+    );
+    const beforeSchedulingMutationInventory = await markdownInventory();
+    const scheduledResult = await callMutation(
+      "operon_update_periodic_scheduling",
+      {
+        operonId: daily.operonId,
+        expectedRevision: beforeScheduleApply.revision,
+        idempotencyKey: `${runId}:periodic-schedule:set`,
+        dryRun: false,
+        patch: { fields: { dateScheduled: dates.scheduled } },
+      },
+      "periodic scheduling set",
+    );
+    const schedulingMutationChanges = inventoryDiff(
+      beforeSchedulingMutationInventory,
+      await markdownInventory(),
+    );
+    for (const change of schedulingMutationChanges) {
+      if (
+        change.change === "created" &&
+        path.basename(change.path, ".md") === dates.scheduled
+      ) {
+        assert.equal(
+          canonicalRelativeMarkdownPath(change.path),
+          true,
+          "Periodic scheduling created an unsafe task-source path.",
+        );
+        artifactPaths.add(change.path);
+      }
+    }
+    trackNativeTaskSourceArtifacts(scheduledResult, "Periodic scheduling set");
+    const scheduled = mutationStatus(
+      scheduledResult,
+      "periodic scheduling set",
+      "applied",
+    );
+    evidence.nativeProofs.push(
+      assertNativeMutationProof(scheduled, "periodic scheduling set"),
+    );
+    assert.equal(scheduled.after.path, sourceLocator.path);
+    assert.equal(scheduled.after.operonId, daily.operonId);
+    assert.equal(Number.isInteger(scheduled.after.line), true);
+    assert.equal(scheduled.after.dates.scheduled, dates.scheduled);
+    assert.equal(
+      typeof scheduled.after.parentTask === "string" &&
+        scheduled.after.parentTask.length > 0,
+      true,
+      "Periodic scheduling set did not project a periodic parent.",
+    );
+    assert.notEqual(scheduled.after.parentTask, beforeSchedule.parentTask);
+    const beforeClear = await stableTask(daily.operonId);
+    assert.equal(beforeClear.parentTask === beforeSchedule.parentTask, false);
+    const clearPreview = mutationStatus(
+      await callMutation(
+        "operon_update_periodic_scheduling",
+        {
+          operonId: daily.operonId,
+          expectedRevision: beforeClear.revision,
+          idempotencyKey: `${runId}:periodic-schedule:clear-preview`,
+          dryRun: true,
+          patch: { fields: { dateScheduled: null } },
+        },
+        "periodic scheduling clear preview",
+      ),
+      "periodic scheduling clear preview",
+      "planned",
+    );
+    assert.equal(
+      clearPreview.plan?.capability,
+      "tasks.update.periodic-note.preview",
+      "Operon did not project the additive periodic-update clear plan for the created Daily fixture.",
+    );
+    assert.equal(clearPreview.plan?.mutationKind, "task.update");
+    assert.equal(clearPreview.plan?.planDigest, clearPreview.planDigest);
+    trackPlannedTaskSourceArtifacts(
+      clearPreview.plan,
+      "Periodic scheduling clear preview",
+    );
+    const beforeClearApply = await stableTask(daily.operonId);
+    assert.equal(
+      beforeClearApply.revision,
+      beforeClear.revision,
+      "The Daily fixture changed after periodic scheduling clear preview.",
+    );
+    const clearedResult = await callMutation(
+      "operon_update_periodic_scheduling",
+      {
+        operonId: daily.operonId,
+        expectedRevision: beforeClearApply.revision,
+        idempotencyKey: `${runId}:periodic-schedule:clear`,
+        dryRun: false,
+        patch: { fields: { dateScheduled: null } },
+      },
+      "periodic scheduling clear",
+    );
+    trackNativeTaskSourceArtifacts(clearedResult, "Periodic scheduling clear");
+    const cleared = mutationStatus(
+      clearedResult,
+      "periodic scheduling clear",
+      "applied",
+    );
+    evidence.nativeProofs.push(
+      assertNativeMutationProof(cleared, "periodic scheduling clear"),
+    );
+    assert.equal(cleared.after.path, sourceLocator.path);
+    assert.equal(cleared.after.operonId, daily.operonId);
+    assert.equal(Number.isInteger(cleared.after.line), true);
+    assert.equal(cleared.after.dates.scheduled, null);
+    assert.equal(cleared.after.parentTask, null);
+    evidence.periodicScheduling = {
+      fixtureKind: "daily",
+      fixtureOperonIdHash: shortHash(daily.operonId),
+      capabilityProjected: true,
+      periodicParentProjected: true,
+      initialParentTaskHash: shortHash(beforeSchedule.parentTask),
+      setPreviewPlanDigestHash: shortHash(schedulePreview.planDigest),
+      clearPreviewPlanDigestHash: shortHash(clearPreview.planDigest),
+      set: true,
+      clear: true,
+      sourcePathPreserved: true,
+      sourceIdentityPreserved: true,
+      sourceLineShiftObserved:
+        scheduled.after.line !== sourceLocator.line ||
+        cleared.after.line !== sourceLocator.line,
+      sourcePathHash: shortHash(sourceLocator.path),
+    };
+
+    const concurrentDescription = `Operon 3.5.2 concurrent periodic canary ${runId}`;
+    const concurrentBody = JSON.stringify({
+      idempotencyKey: `${runId}:bridge:periodic-concurrent`,
+      dryRun: false,
+      periodic: {
+        description: concurrentDescription,
+        periodicKind: "daily",
+        routeDate: dates.concurrent,
+        fields: { taskType: "canary-concurrent-periodic" },
+      },
+    });
+    const beforeConcurrent = await markdownInventory();
+    const bridgeUrl = `${baseUrl}${BRIDGE_PREFIX}/tasks/periodic`;
+    const bridgePost = async () => {
+      const response = await fetchWithAbortTimeout(
+        bridgeUrl,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: concurrentBody,
+        },
+        "concurrent Bridge periodic POST",
+        MUTATION_TIMEOUT_MS,
+      );
+      const payload = await response.json();
+      return { status: response.status, payload };
+    };
+    const bridgeSettled = await Promise.allSettled([
+      track(bridgePost()),
+      track(bridgePost()),
+    ]);
+    for (const [index, settled] of bridgeSettled.entries()) {
+      if (settled.status === "rejected") {
+        evidence.mutationStatuses.push(
+          mutationDiagnostic(
+            null,
+            `Bridge concurrency ${index === 0 ? "A" : "B"}`,
+            {
+              transportError: true,
+              thrownMessage:
+                settled.reason instanceof Error
+                  ? settled.reason.message
+                  : String(settled.reason),
+              thrownCode:
+                typeof settled.reason?.code === "string"
+                  ? settled.reason.code
+                  : undefined,
+            },
+          ),
+        );
+      }
+    }
+    const rejectedBridge = bridgeSettled.find(
+      (settled) => settled.status === "rejected",
+    );
+    if (rejectedBridge) throw rejectedBridge.reason;
+    const [bridgeA, bridgeB] = bridgeSettled.map((settled) => settled.value);
+    evidence.mutationStatuses.push(
+      {
+        ...mutationDiagnostic(bridgeA.payload, "Bridge concurrency A"),
+        httpStatus: bridgeA.status,
+      },
+      {
+        ...mutationDiagnostic(bridgeB.payload, "Bridge concurrency B"),
+        httpStatus: bridgeB.status,
+      },
+    );
+    assert.equal(bridgeA.status, 200);
+    assert.equal(bridgeB.status, 200);
+    mutationStatus(bridgeA.payload, "Bridge concurrency A", "applied");
+    evidence.nativeProofs.push(
+      assertNativeMutationProof(bridgeA.payload, "Bridge concurrency A"),
+    );
+    assert.equal(bridgeB.payload.status, bridgeA.payload.status);
+    assert.equal(
+      bridgeB.payload.operationId,
+      bridgeA.payload.operationId,
+      "Concurrent Bridge responses returned different operationIds.",
+    );
+    const bridgeResultHash = sha256(JSON.stringify(bridgeA.payload));
+    assert.equal(
+      sha256(JSON.stringify(bridgeB.payload)),
+      bridgeResultHash,
+      "Concurrent Bridge responses returned different result bodies.",
+    );
+    const concurrentTask = bridgeA.payload.after;
+    assert.equal(concurrentTask?.source, "inline");
+    assert.equal(canonicalRelativeMarkdownPath(concurrentTask?.path), true);
+    artifactPaths.add(concurrentTask.path);
+    const afterConcurrent = await markdownInventory();
+    const concurrentChanges = inventoryDiff(beforeConcurrent, afterConcurrent);
+    assert.equal(beforeConcurrent.has(concurrentTask.path), false);
+    assert.equal(
+      concurrentChanges.some(
+        (change) =>
+          change.path === concurrentTask.path && change.change === "created",
+      ),
+      true,
+    );
+    const concurrentQuery = await call("operon_query_tasks", {
+      search: concurrentDescription,
+      pathIncludes: [concurrentTask.path],
+      forceRefresh: true,
+      limit: 100,
+    });
+    const exactConcurrentTasks = (concurrentQuery?.tasks ?? []).filter(
+      (task) =>
+        task.description === concurrentDescription &&
+        task.path === concurrentTask.path,
+    );
+    assert.equal(
+      exactConcurrentTasks.length,
+      1,
+      "Concurrent Bridge requests created more than one periodic task.",
+    );
+    assert.equal(
+      exactConcurrentTasks[0].operonId,
+      concurrentTask.operonId,
+      "The single visible concurrent task does not match the Bridge result.",
+    );
+    evidence.bridgeConcurrency = {
+      route: `${BRIDGE_PREFIX}/tasks/periodic`,
+      httpStatuses: [bridgeA.status, bridgeB.status],
+      sameOperationId: true,
+      sameResult: true,
+      exactVisibleTaskCount: exactConcurrentTasks.length,
+      resultHash: bridgeResultHash,
+      operationIdHash: shortHash(bridgeA.payload.operationId),
+      operonIdHash: shortHash(concurrentTask.operonId),
+      pathHash: shortHash(concurrentTask.path),
+      markdownChanges: redactedInventoryChanges(concurrentChanges),
+      restoredOnPass: false,
+    };
+
+    await validateZero("afterMutations");
+    await pendingRecoveriesZero("afterMutations");
+
+    await restoreAllCanaryArtifacts();
+    assert.equal(fixtureRestored, true);
+    const cleanupDeadline = Date.now() + 45_000;
+    while (Date.now() < cleanupDeadline) {
+      const query = await call("operon_query_tasks", {
+        search: runId,
+        forceRefresh: true,
+        limit: 100,
+      });
+      if ((query?.tasks ?? []).length === 0) break;
+      await sleep(750);
+    }
+    const restoredQuery = await call("operon_query_tasks", {
+      search: runId,
+      forceRefresh: true,
+      limit: 100,
+    });
+    assert.equal((restoredQuery?.tasks ?? []).length, 0);
+    await validateZero("afterArtifactRestore");
+    await pendingRecoveriesZero("afterArtifactRestore");
+    const finalSnapshot = await captureMarkdownSnapshot();
+    assert.deepEqual(
+      inventoryDiff(baselineSnapshot, finalSnapshot),
+      [],
+      "Markdown inventory drifted after Operon refreshed the restored artifacts.",
+    );
+    evidence.artifactRestoration.finalVerifiedAfterIndexRefresh = true;
+    evidence.artifactRestoration.finalInventoryDigestHash = shortHash(
+      inventoryDigest(finalSnapshot),
+    );
+    const registryDeadline = Date.now() + 45_000;
+    let periodicRegistryAfter = await optionalFileState(PERIODIC_REGISTRY_PATH);
+    while (
+      !sameOptionalFileState(periodicRegistryBaseline, periodicRegistryAfter) &&
+      Date.now() < registryDeadline
+    ) {
+      await sleep(750);
+      periodicRegistryAfter = await optionalFileState(PERIODIC_REGISTRY_PATH);
+    }
+    assert.equal(
+      sameOptionalFileState(periodicRegistryBaseline, periodicRegistryAfter),
+      true,
+      "Operon periodic container registry drifted after artifact restoration.",
+    );
+    evidence.periodicRegistryRestoration = {
+      restored: true,
+      expectedState: periodicRegistryBaseline.exists ? "present" : "absent",
+      finalDigestHash: periodicRegistryAfter.exists
+        ? shortHash(sha256(periodicRegistryAfter.content))
+        : null,
+    };
+    for (const artifact of evidence.periodicCreates) {
+      artifact.restoredOnPass = true;
+    }
+    evidence.bridgeConcurrency.restoredOnPass = true;
+
+    evidence.ok = true;
+    evidence.completedAt = new Date().toISOString();
+    success = true;
+  } catch (error) {
+    evidence.error = {
+      name: error instanceof Error ? error.name : "Error",
+      message: redactText(
+        error instanceof Error ? error.message : error,
+        apiKey,
+      ),
+    };
+  } finally {
+    const pending = [...activeRequests];
+    if (pending.length > 0) {
+      await withTimeout(
+        Promise.allSettled(pending),
+        "active MCP requests to settle before artifact restoration",
+        MUTATION_TIMEOUT_MS + 10_000,
+      ).catch((error) => {
+        evidence.error ??= {
+          name: "CleanupError",
+          message: redactText(error.message, apiKey),
+        };
+      });
+    }
+    if (!evidence.artifactRestoration.restored || evidence.error) {
+      await restoreAllCanaryArtifacts().catch((error) => {
+        evidence.fixtureRestoration = {
+          restored: false,
+          expectedState: "absent",
+          error: redactText(error.message, apiKey),
+        };
+        evidence.error ??= {
+          name: "CleanupError",
+          message: "Canary artifact restoration failed.",
+        };
+      });
+    }
+    await client?.close().catch(() => undefined);
+    if (startupOrder && openedVaultCli) {
+      try {
+        const closed = await runCli(openedVaultCli, [
+          `vault=${EXPECTED_VAULT_NAME}`,
+          "eval",
+          "code=window.close();'closing...'",
+        ]);
+        evidence.startupOrder.closeCliExitCode = closed.exitCode;
+        await waitForLocalRestClosed();
+        evidence.startupOrder.closedOnExit = true;
+      } catch (error) {
+        evidence.startupOrder.closedOnExit = false;
+        evidence.error ??= {
+          name: "CleanupError",
+          message: redactText(error.message, apiKey),
+        };
+      }
+    }
+    evidence.ok = Boolean(
+      success &&
+        fixtureRestored &&
+        evidence.artifactRestoration.restored &&
+        evidence.periodicRegistryRestoration.restored &&
+        !evidence.error,
+    );
+    evidence.completedAt ??= new Date().toISOString();
+    evidence.fixtureRestoration.restored = fixtureRestored;
+    if (shutdownSignal) evidence.interruptedBy = shutdownSignal;
+    if (backendStderr) {
+      evidence.backendDiagnosticHash = shortHash(
+        redactText(backendStderr, apiKey),
+      );
+    }
+    let backupDeletedOnPass = false;
+    if (evidence.ok) {
+      try {
+        await rm(tempRoot, { recursive: true, force: true });
+        backupDeletedOnPass = true;
+      } catch (error) {
+        evidence.ok = false;
+        evidence.error = {
+          name: "CleanupError",
+          message: "Private canary backup could not be deleted after success.",
+        };
+      }
+    }
+    if (evidence.preMutationInventory) {
+      evidence.preMutationInventory.backupDeletedOnPass = backupDeletedOnPass;
+      evidence.preMutationInventory.backupRetainedOnFailure = !evidence.ok;
+    }
+    await writeFile(evidenceFile, `${JSON.stringify(evidence, null, 2)}\n`, {
+      encoding: "utf8",
+      mode: 0o600,
+    });
+    process.off("SIGINT", onSigint);
+    process.off("SIGTERM", onSigterm);
+  }
+
+  const summary = {
+    ok: evidence.ok,
+    evidenceFile,
+    fixtureRestored,
+    periodicArtifactsRetained: evidence.ok ? 0 : null,
+    ...(evidence.ok ? {} : { backupRetainedAt: tempRoot }),
+  };
+  console.log(JSON.stringify(summary, null, 2));
+  if (!evidence.ok) process.exitCode = 1;
+}
+
+const inspectPendingMode = process.argv.includes("--inspect-pending-live");
+const offlineContractMode = process.argv.includes(
+  "--offline-startup-order-contract",
+);
+assert.equal(
+  inspectPendingMode && offlineContractMode,
+  false,
+  "Select only one canary mode.",
+);
+const selectedMain = inspectPendingMode
+  ? inspectPendingLive
+  : offlineContractMode
+    ? offlineStartupOrderContract
+    : main;
+
+selectedMain().catch((error) => {
+  if (inspectPendingMode) {
+    const apiKey = (process.env.OBSIDIAN_API_KEY ?? "").trim();
+    console.error(
+      JSON.stringify({
+        count: null,
+        recoveries: [],
+        errorHash: shortHash(
+          redactText(
+            error instanceof Error ? error.message : String(error),
+            apiKey,
+          ),
+        ),
+      }),
+    );
+    process.exitCode = 1;
+    return;
+  }
+  console.error(
+    JSON.stringify({
+      ok: false,
+      error: error instanceof Error ? error.message : String(error),
+      note: offlineContractMode
+        ? "The deterministic offline startup-order contract failed."
+        : "The canary refused before its guarded live workflow started.",
+    }),
+  );
+  process.exitCode = 1;
+});

--- a/scripts/test-doc-contract.mjs
+++ b/scripts/test-doc-contract.mjs
@@ -57,6 +57,28 @@ assert.match(httpAdr, /remote HTTP remains pilot-only/i);
 
 const matrix = await text("docs/runtime-capability-matrix.md");
 const matrixFr = await text("docs/runtime-capability-matrix.fr.md");
+const operonLocalValidation = await text("docs/operon-local-validation.md");
+const taskRuntimeReference = await text(
+  "profiles/elysia-tasks/skills/elysia-task-gouverneur/references/runtime-et-mutations.md",
+);
+for (const content of [
+  matrix,
+  matrixFr,
+  operonLocalValidation,
+  taskRuntimeReference,
+]) {
+  assert.match(content, /3\.5\.240438/u);
+  assert.match(content, /3\.5\.2/u);
+  assert.match(content, /read-only|lecture seule/iu);
+}
+assert.doesNotMatch(
+  matrix,
+  /official Operon `3\.5\.2` exposes saved-filter evaluation,[\s\S]{0,80}official adoption/iu,
+);
+assert.doesNotMatch(
+  matrixFr,
+  /Operon officiel `3\.5\.2` expose les[\s\S]{0,80}l’adoption officielle/iu,
+);
 const commonTools = [
   "external_runtime_status",
   "external_roots_list",
@@ -79,6 +101,8 @@ const commonTools = [
   "operon_get_timer_state",
   "operon_adopt_task",
   "operon_create_task",
+  "operon_create_periodic_task",
+  "operon_update_periodic_scheduling",
   "operon_update_task",
   "operon_transition_task",
   "operon_set_relationships",
@@ -106,8 +130,8 @@ assert.match(matrixFr, /\| Admin filesystem\s+\| Non\s+\| Non/);
 const packageJson = JSON.parse(await text("package.json"));
 assert.equal(
   packageJson.version,
-  "3.0.1",
-  "package metadata must match the 3.0.1 stdio reliability release",
+  "3.1.0",
+  "package metadata must match the 3.1.0 Operon 3.5 candidate release",
 );
 assert.equal(packageJson.scripts["start:http"], "node scripts/run-http.mjs");
 assert.equal(packageJson.scripts["start:daemon"], "node scripts/run-http.mjs");
@@ -168,6 +192,17 @@ assert.match(envExample, /MCP_OBSIDIAN_NOTE_REPLACE_JOURNAL_PATH=\//u);
 
 const operonContract = await text("docs/operon-mcp-contract.md");
 const operonContractFr = await text("docs/operon-mcp-contract.fr.md");
+const operonRestContract = await text("docs/operon-rest-contract.md");
+assert.match(
+  operonRestContract,
+  /POST \/tasks\/:operonId\/periodic-update/u,
+  "Operon REST documentation must use the mounted periodic-update route",
+);
+assert.doesNotMatch(
+  operonRestContract,
+  /POST \/tasks\/:operonId\/periodic-scheduling/u,
+  "Operon REST documentation must not revive the obsolete periodic-scheduling route",
+);
 const operonAudit = await text("docs/operon-cli-audit.md");
 const operonAuditFr = await text("docs/operon-cli-audit.fr.md");
 for (const content of [operonContract, operonContractFr]) {
@@ -183,6 +218,104 @@ assert.match(operonContract, /generic CLI passthrough/i);
 assert.match(operonContractFr, /passthrough CLI générique/i);
 assert.match(operonContract, /structured unavailable result/i);
 assert.match(operonContractFr, /indisponibilité structurée/i);
+for (const content of [operonContract, operonAudit]) {
+  assert.match(content, /Operon `3\.5\.2`/u);
+  assert.match(content, /Operon CLI `1\.2\.0`/u);
+  assert.match(content, /Bridge\s+`0\.8\.0`/u);
+  assert.match(content, /compatible-provisional/u);
+  assert.match(content, /opaque sealed\s+plan/iu);
+  assert.match(content, /(?:same-plan|même\s+plan)/iu);
+  assert.match(content, /taskGallery/u);
+  assert.match(content, /__taskDataType/u);
+}
+for (const content of [operonContractFr, operonAuditFr]) {
+  assert.match(content, /Operon `3\.5\.2`/u);
+  assert.match(content, /Operon CLI `1\.2\.0`/u);
+  assert.match(content, /Bridge\s+`0\.8\.0`/u);
+  assert.match(content, /compatible-provisional/u);
+  assert.match(content, /plan opaque\s+scellé/iu);
+  assert.match(content, /(?:same-plan|même\s+plan)/iu);
+  assert.match(content, /taskGallery/u);
+  assert.match(content, /__taskDataType/u);
+}
+assert.match(operonContract, /tasks\.adopt\.preview/u);
+assert.match(operonContract, /Daily\/Weekly/u);
+assert.match(operonContract, /scalar strings/u);
+assert.match(operonContract, /ordered string array/u);
+assert.match(operonContractFr, /tasks\.adopt\.preview/u);
+assert.match(operonContractFr, /Daily\/Weekly/u);
+assert.match(operonContractFr, /chaînes scalaires/u);
+assert.match(operonContractFr, /tableau ordonné/u);
+for (const content of [operonContract, operonRestContract]) {
+  assert.match(content, /reserv(?:e|es).*atomically/isu);
+  assert.match(content, /version[- ]1 journal/iu);
+  assert.match(content, /500 entries/iu);
+  assert.match(content, /30 days/iu);
+  assert.match(content, /in-progress.*outcome-unknown/isu);
+  assert.match(content, /recoveryRequired: true/u);
+  assert.match(content, /(?:no promise|promises nothing)/iu);
+  assert.match(
+    content,
+    /Task Workflow results?.*(?:strictly validated|validated as a strict)/isu,
+  );
+  assert.match(content, /nativeProof/u);
+  assert.match(content, /bounded proof projection/iu);
+  assert.match(content, /pendingRecoveries/u);
+  assert.match(content, /optional.*planDigest/iu);
+  assert.match(content, /priorityId.*postflight/isu);
+  assert.match(content, /ambiguous creation/iu);
+  assert.match(content, /compatible-provisional/u);
+}
+assert.match(operonContractFr, /réserve.*atomiquement/isu);
+assert.match(operonContractFr, /journal version 1/iu);
+assert.match(operonContractFr, /500 entrées/iu);
+assert.match(operonContractFr, /30 jours/iu);
+assert.match(operonContractFr, /in-progress.*outcome-unknown/isu);
+assert.match(operonContractFr, /recoveryRequired: true/u);
+assert.match(operonContractFr, /aucune promesse/iu);
+assert.match(
+  operonContractFr,
+  /résultats Task Workflow.*validés strictement/isu,
+);
+assert.match(operonContractFr, /nativeProof/u);
+assert.match(operonContractFr, /projection de preuve bornée/iu);
+assert.match(operonContractFr, /pendingRecoveries/u);
+assert.match(operonContractFr, /planDigest.*optionnel/isu);
+assert.match(operonContractFr, /priorityId.*postflight/isu);
+assert.match(operonContractFr, /création ambiguë/iu);
+assert.match(
+  operonContract,
+  /3\.5\.240438[\s\S]*stock `3\.5\.2` remains read-only/iu,
+);
+assert.match(
+  operonContractFr,
+  /3\.5\.240438[\s\S]*3\.5\.2` stock reste en lecture seule/iu,
+);
+assert.doesNotMatch(
+  operonContract,
+  /Adoption is available only on Operon 3\.5\.2/iu,
+);
+assert.match(
+  operonContract,
+  /Adoption[\s\S]*mutation-admitted `3\.5\.240438`[\s\S]*stock `3\.5\.2` remains read-only/iu,
+);
+assert.match(
+  operonContractFr,
+  /adoption[\s\S]*admis en mutation `3\.5\.240438`[\s\S]*3\.5\.2`[\s\S]*lecture seule/iu,
+);
+
+const profilesEn = await text("docs/tool-surface-profiles.md");
+const profilesFr = await text("docs/tool-surface-profiles.fr.md");
+assert.match(readme, /\| `tasks`\s+\|\s+33\s+\|/u);
+assert.match(readme, /\| `full`\s+\|\s+72\s+\|/u);
+assert.match(readmeFr, /\| `tasks`\s+\|\s+33\s+\|/u);
+assert.match(readmeFr, /\| `full`\s+\|\s+72\s+\|/u);
+assert.match(profilesEn, /\| `tasks`\s+\|[^\n]+33 tools/u);
+assert.match(profilesEn, /\| `full`\s+\|[^\n]+72 tools/u);
+assert.match(profilesEn, /76 unique names/u);
+assert.match(profilesFr, /\| `tasks`\s+\|[^\n]+33 outils/u);
+assert.match(profilesFr, /\| `full`\s+\|[^\n]+72 outils/u);
+assert.match(profilesFr, /76 noms uniques/u);
 
 const backpressureContract = await text(
   "docs/http-concurrency-backpressure.md",

--- a/scripts/test-doc-contract.mjs
+++ b/scripts/test-doc-contract.mjs
@@ -203,6 +203,16 @@ assert.doesNotMatch(
   /POST \/tasks\/:operonId\/periodic-scheduling/u,
   "Operon REST documentation must not revive the obsolete periodic-scheduling route",
 );
+assert.match(operonRestContract, /POST \/mutations\/recover/u);
+assert.match(operonRestContract, /POST \/task-workflows\/recover/u);
+assert.match(
+  operonRestContract,
+  /"recoveryRef": "twr1_[\s\S]*"kind": "adopt"[\s\S]*"planDigest"/u,
+);
+assert.doesNotMatch(
+  operonRestContract,
+  /"recoveryRef": "twr1_[\s\S]{0,120}"recovery":/u,
+);
 const operonAudit = await text("docs/operon-cli-audit.md");
 const operonAuditFr = await text("docs/operon-cli-audit.fr.md");
 for (const content of [operonContract, operonContractFr]) {

--- a/scripts/test-doc-contract.mjs
+++ b/scripts/test-doc-contract.mjs
@@ -207,11 +207,11 @@ assert.match(operonRestContract, /POST \/mutations\/recover/u);
 assert.match(operonRestContract, /POST \/task-workflows\/recover/u);
 assert.match(
   operonRestContract,
-  /"recoveryRef": "twr1_[\s\S]*"kind": "adopt"[\s\S]*"planDigest"/u,
+  /"recoveryRef": "dvr1_[\s\S]*"kind": "adopt"[\s\S]*"planDigest"/u,
 );
 assert.doesNotMatch(
   operonRestContract,
-  /"recoveryRef": "twr1_[\s\S]{0,120}"recovery":/u,
+  /"recoveryRef": "dvr1_[\s\S]{0,120}"recovery":/u,
 );
 const operonAudit = await text("docs/operon-cli-audit.md");
 const operonAuditFr = await text("docs/operon-cli-audit.fr.md");

--- a/scripts/test-http-backpressure.mjs
+++ b/scripts/test-http-backpressure.mjs
@@ -45,6 +45,8 @@ function testGovernedStateChangesUseMutationBackpressureByDefault() {
     "obsidian_canvas_patch_plan",
     "obsidian_canvas_patch_apply",
     "obsidian_canvas_patch_recover",
+    "operon_create_periodic_task",
+    "operon_update_periodic_scheduling",
   ];
   for (const toolName of governedStateChanges) {
     assert.equal(
@@ -415,6 +417,67 @@ async function testRealMiddlewareResponses() {
     "mutation",
   );
   await admittedSecond.arrayBuffer();
+}
+
+async function testOperonPeriodicToolsUseMutationSaturation() {
+  for (const [index, toolName] of [
+    "operon_create_periodic_task",
+    "operon_update_periodic_scheduling",
+  ].entries()) {
+    const admission = controller({
+      maxInFlight: 2,
+      maxInFlightPerIdentity: 2,
+      mutationMaxInFlight: 1,
+      mutationMaxInFlightPerIdentity: 1,
+      maxQueued: 0,
+      maxQueuedPerIdentity: 0,
+    });
+    const app = new Hono();
+    app.use("*", async (c, next) => {
+      attachTestIdentity(c, c.req.header("x-test-identity") ?? "anonymous");
+      await next();
+    });
+    app.use("/mcp", createHttpBackpressureMiddleware(admission));
+    app.post("/mcp", async (c) => {
+      await sleep(Number(c.req.header("x-test-delay-ms") ?? "0"));
+      return c.json({ ok: true });
+    });
+    const body = JSON.stringify({
+      jsonrpc: "2.0",
+      id: 100 + index,
+      method: "tools/call",
+      params: { name: toolName, arguments: {} },
+    });
+    const request = (identity, delay) =>
+      app.request("http://test/mcp", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-test-identity": identity,
+          "x-test-delay-ms": String(delay),
+        },
+        body,
+      });
+
+    const held = request("periodic-a", 60);
+    await sleep(5);
+    assert.equal(admission.getSnapshot().mutationInFlight, 1);
+    const rejected = await request("periodic-b", 0);
+    assert.equal(rejected.status, 503);
+    assert.equal(
+      rejected.headers.get("x-optimike-operation-class"),
+      "mutation",
+      `${toolName} must be classified from its JSON-RPC envelope as a mutation`,
+    );
+    const completed = await held;
+    assert.equal(completed.status, 200);
+    assert.equal(
+      completed.headers.get("x-optimike-operation-class"),
+      "mutation",
+    );
+    await completed.arrayBuffer();
+    assert.equal(admission.getSnapshot().mutationInFlight, 0);
+  }
 }
 
 async function testDownstreamAdmissionErrorIsNotReclassified() {
@@ -901,6 +964,7 @@ await testRoundRobinFairness();
 await testReleaseAfterError();
 await testDeterministicLoad();
 await testRealMiddlewareResponses();
+await testOperonPeriodicToolsUseMutationSaturation();
 await testDownstreamAdmissionErrorIsNotReclassified();
 await testRequestBodyParsingIsBoundedAndAdmitted();
 await testBodyGuardHasBoundedGlobalAdmission();

--- a/scripts/test-operon-contract.mjs
+++ b/scripts/test-operon-contract.mjs
@@ -61,6 +61,29 @@ assert.deepEqual(
   validNativeProof,
   "a bounded native Operon mutation proof must survive MCP validation intact",
 );
+for (const mutationKind of [
+  "task.adopt",
+  "task.create",
+  "task.update",
+  "task.transition",
+  "task.relationship",
+  "task.recurrence",
+  "task.convert",
+  "task.inline-relocate",
+]) {
+  assert.equal(
+    OperonNativeMutationProofSchema.safeParse({
+      ...validNativeProof,
+      receipt: { ...validNativeProof.receipt, mutationKind },
+      postflight: {
+        status: "receipt-replay",
+        observedAt: "2026-08-24T08:00:02.000Z",
+      },
+    }).success,
+    true,
+    `native receipt proof must admit ${mutationKind}`,
+  );
+}
 assert.equal(
   OperonNativeMutationProofSchema.safeParse({
     ...validNativeProof,

--- a/scripts/test-operon-contract.mjs
+++ b/scripts/test-operon-contract.mjs
@@ -1,4 +1,7 @@
 import assert from "node:assert/strict";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import {
   OPERON_CONTRACT_VERSION,
   OperonAdoptTaskSchema,
@@ -12,19 +15,255 @@ import {
   OperonRelocateTaskSchema,
   OperonConfigurationSchema,
   OperonCreateTaskSchema,
+  OperonCreatePeriodicTaskSchema,
   OperonQuerySchema,
   OperonStatusSchema,
   OperonTaskSchema,
   OperonTransitionTaskSchema,
   OperonUpdateTaskSchema,
+  OperonUpdatePeriodicSchedulingSchema,
   OperonSetRelationshipsSchema,
   OperonUpdateRecurrenceSchema,
+  OperonRecoverMutationInputSchema,
+  OperonRecoverMutationSchema,
+  OperonPendingRecoveriesSchema,
+  OperonMutationResultSchema,
+  OperonNativeMutationProofSchema,
   OperonVaultMarkdownPathSchema,
   OperonVaultRelativePathSchema,
   queryOperonSnapshot,
   resolveOperonPriorityStableId,
   resolveOperonWorkflowStatus,
 } from "../dist/services/operon/contract.js";
+
+const planDigestA = "a".repeat(64);
+const validNativeProof = {
+  contractVersion: 1,
+  kind: "mutation-result",
+  status: "already-applied",
+  mutationMayHaveApplied: true,
+  retryAllowed: false,
+  groupResults: [],
+  receipt: {
+    contractVersion: 1,
+    planDigest: planDigestA,
+    mutationKind: "task.update",
+    targetDigest: "b".repeat(64),
+    terminalOutcome: "already-applied",
+    effectiveAt: "2026-08-24T08:00:00.000Z",
+    completedAt: "2026-08-24T08:00:01.000Z",
+    expiresAt: "2026-08-24T09:00:01.000Z",
+  },
+  postflight: { status: "receipt-replay" },
+};
+assert.deepEqual(
+  OperonNativeMutationProofSchema.parse(validNativeProof),
+  validNativeProof,
+  "a bounded native Operon mutation proof must survive MCP validation intact",
+);
+assert.equal(
+  OperonNativeMutationProofSchema.safeParse({
+    ...validNativeProof,
+    status: "committed",
+  }).success,
+  false,
+  "unknown native proof statuses must be rejected",
+);
+assert.equal(
+  OperonNativeMutationProofSchema.safeParse({
+    ...validNativeProof,
+    groupResults: Array.from({ length: 513 }, (_, index) => ({
+      groupId: `group-${index}`,
+      status: "committed",
+    })),
+  }).success,
+  false,
+  "native proof group results must remain bounded",
+);
+assert.equal(
+  OperonNativeMutationProofSchema.safeParse({
+    ...validNativeProof,
+    receipt: {
+      ...validNativeProof.receipt,
+      planDigest: planDigestA.toUpperCase(),
+    },
+  }).success,
+  false,
+  "native receipt proofs must reject non-lowercase SHA-256 digests",
+);
+assert.equal(
+  OperonNativeMutationProofSchema.safeParse({
+    ...validNativeProof,
+    groupResults: [
+      {
+        groupId: "group-no-leak",
+        status: "failed",
+        error: { reason: "private task content" },
+      },
+    ],
+  }).success,
+  false,
+  "native group proofs must reject uncontracted error payloads",
+);
+assert.equal(
+  OperonNativeMutationProofSchema.safeParse({
+    ...validNativeProof,
+    postflight: {
+      status: "verified",
+      observedAt: "2026-08-24T08:00:01.000Z",
+      contextRevision: { private: "not projected by the Bridge" },
+    },
+  }).success,
+  false,
+  "native postflight proofs must reject unprojected context state",
+);
+assert.equal(
+  OperonRecoverMutationSchema.safeParse({
+    idempotencyKey: "recovery-contract-key",
+    recoveryRef: "dvr1_contract-recovery",
+    recovery: { kind: "periodic-update", planDigest: planDigestA },
+  }).success,
+  true,
+);
+assert.equal(
+  OperonRecoverMutationSchema.safeParse({
+    idempotencyKey: "recovery-contract-key",
+    recoveryRef: "dvr1_contract-recovery",
+    recovery: {
+      kind: "periodic-update",
+      planDigest: `sha256:${planDigestA}`,
+    },
+  }).success,
+  false,
+  "recovery planDigest must use Operon's exact lowercase 64-hex format",
+);
+assert.equal(
+  OperonRecoverMutationSchema.safeParse({
+    idempotencyKey: "recovery-contract-key",
+    recoveryRef: "dvr1_contract-recovery",
+  }).success,
+  false,
+  "every recovery must declare a typed recovery binding",
+);
+assert.equal(
+  OperonRecoverMutationSchema.safeParse({
+    idempotencyKey: "recovery-contract-key",
+    recoveryRef: "dvr1_contract-recovery",
+    recovery: { kind: "developer-api" },
+  }).success,
+  true,
+  "legacy official Developer API recovery remains available through an explicit kind",
+);
+assert.equal(
+  OperonRecoverMutationSchema.safeParse({
+    idempotencyKey: "recovery-contract-key",
+    recoveryRef: "dvr1_contract-recovery",
+    recovery: { kind: "developer-api", planDigest: planDigestA },
+  }).success,
+  false,
+  "developer-api recovery must structurally reject task-workflow plan digests",
+);
+assert.equal(
+  OperonPendingRecoveriesSchema.safeParse({
+    ok: true,
+    contractVersion: "1",
+    source: "operon-live",
+    stale: false,
+    recoveries: [{ planDigest: planDigestA }],
+  }).success,
+  true,
+);
+assert.equal(
+  OperonPendingRecoveriesSchema.safeParse({
+    ok: true,
+    contractVersion: "1",
+    source: "operon-live",
+    stale: false,
+    recoveries: [{ planDigest: planDigestA.toUpperCase() }],
+  }).success,
+  false,
+  "pending recovery results must reject non-lowercase SHA-256 digests",
+);
+assert.equal(
+  OperonMutationResultSchema.safeParse({
+    ok: true,
+    contractVersion: "1",
+    operationId: "operation-uppercase-digest",
+    idempotencyKey: "uppercase-digest-key",
+    status: "planned",
+    requested: {},
+    planDigest: planDigestA.toUpperCase(),
+    source: "operon-live",
+    stale: false,
+  }).success,
+  false,
+  "mutation results must reject non-lowercase SHA-256 digests",
+);
+assert.equal(
+  OperonMutationResultSchema.safeParse({
+    ok: true,
+    contractVersion: "1",
+    operationId: "operation-native-proof",
+    idempotencyKey: "native-proof-key",
+    status: "already-applied",
+    requested: {},
+    nativeProof: { ...validNativeProof, retryAllowed: "false" },
+    source: "operon-live",
+    stale: false,
+  }).success,
+  false,
+  "a malformed native proof must reject the complete mutation response",
+);
+
+const schemaServer = new McpServer({
+  name: "operon-recovery-schema-test",
+  version: "0",
+});
+schemaServer.tool(
+  "operon_recover_mutation",
+  OperonRecoverMutationInputSchema.shape,
+  async () => ({ content: [{ type: "text", text: "ok" }] }),
+);
+const [schemaClientTransport, schemaServerTransport] =
+  InMemoryTransport.createLinkedPair();
+const schemaClient = new Client({
+  name: "operon-recovery-schema-client",
+  version: "0",
+});
+await schemaServer.connect(schemaServerTransport);
+await schemaClient.connect(schemaClientTransport);
+const publishedRecoveryTool = (await schemaClient.listTools()).tools.find(
+  (tool) => tool.name === "operon_recover_mutation",
+);
+assert.ok(publishedRecoveryTool);
+assert.ok(
+  publishedRecoveryTool.inputSchema.required?.includes("recovery"),
+  "tools/list must publish the typed recovery binding as required",
+);
+const publishedRecoveryBinding =
+  publishedRecoveryTool.inputSchema.properties?.recovery;
+assert.ok(
+  Array.isArray(publishedRecoveryBinding?.anyOf),
+  "tools/list must publish the nested recovery discriminated union",
+);
+const publishedTaskWorkflowBranch = publishedRecoveryBinding.anyOf.find(
+  (branch) => branch.properties?.planDigest,
+);
+const publishedDeveloperApiBranch = publishedRecoveryBinding.anyOf.find(
+  (branch) => branch.properties?.kind?.const === "developer-api",
+);
+assert.equal(
+  publishedTaskWorkflowBranch?.properties?.planDigest?.pattern,
+  "^[a-f0-9]{64}$",
+  "tools/list must publish the exact lowercase SHA-256 planDigest pattern only in the task-workflow branch",
+);
+assert.equal(
+  Object.hasOwn(publishedDeveloperApiBranch?.properties ?? {}, "planDigest"),
+  false,
+  "tools/list must not publish planDigest in the developer-api branch",
+);
+await schemaClient.close();
+await schemaServer.close();
 
 assert.equal(
   resolveOperonPriorityStableId("F", [
@@ -177,6 +416,10 @@ const task = OperonTaskSchema.parse({
     status: "Project.InProgress",
     priority: "A",
     custom: "signal",
+    taskGallery: [
+      "attachments/one,comma.png",
+      "attachments\\two;semicolon.png",
+    ],
   },
   properties: { rang: 4, north_star: true },
   revision: "fnv1a32:deadbeef",
@@ -283,6 +526,7 @@ const page = queryOperonSnapshot(
     operonVersion: "2.4.0",
     bridgeVersion: "0.1.0",
     contractVersion: OPERON_CONTRACT_VERSION,
+    snapshotSchemaVersion: 2,
     settingsSignature: "fnv1a32:01234567",
     generation: 42,
     capabilities,
@@ -304,6 +548,7 @@ const stripped = queryOperonSnapshot(
     operonVersion: "2.4.0",
     bridgeVersion: "0.1.0",
     contractVersion: OPERON_CONTRACT_VERSION,
+    snapshotSchemaVersion: 2,
     settingsSignature: "fnv1a32:01234567",
     generation: 42,
     capabilities,
@@ -316,6 +561,56 @@ assert.equal(stripped.source, "operon-cache");
 assert.equal(stripped.stale, true);
 assert.equal("properties" in stripped.tasks[0], false);
 
+const galleryMatch = queryOperonSnapshot(
+  {
+    source: "operon-live",
+    stale: false,
+    snapshotAt: "2026-07-20T12:00:00.000Z",
+    snapshotAgeMs: 0,
+    operonVersion: "3.5.2",
+    bridgeVersion: "0.8.0",
+    contractVersion: OPERON_CONTRACT_VERSION,
+    snapshotSchemaVersion: 2,
+    settingsSignature: "fnv1a32:01234567",
+    generation: 42,
+    capabilities,
+    limitations: [],
+    tasks: [task],
+  },
+  {
+    fieldEquals: {
+      taskGallery: [
+        "attachments/one,comma.png",
+        "attachments\\two;semicolon.png",
+      ],
+    },
+    limit: 10,
+  },
+);
+assert.equal(galleryMatch.total, 1);
+const galleryReordered = queryOperonSnapshot(
+  {
+    ...galleryMatch,
+    tasks: [task],
+    settingsSignature: "fnv1a32:01234567",
+    generation: 42,
+  },
+  {
+    fieldEquals: {
+      taskGallery: [
+        "attachments\\two;semicolon.png",
+        "attachments/one,comma.png",
+      ],
+    },
+    limit: 10,
+  },
+);
+assert.equal(
+  galleryReordered.total,
+  0,
+  "ordered list equality must detect reordering",
+);
+
 const create = OperonCreateTaskSchema.parse({
   idempotencyKey: "contract-create-1",
   task: {
@@ -325,6 +620,109 @@ const create = OperonCreateTaskSchema.parse({
   },
 });
 assert.equal(create.dryRun, true);
+
+const createWithGallery = OperonCreateTaskSchema.parse({
+  idempotencyKey: "contract-create-gallery",
+  task: {
+    source: "inline",
+    description: "Create ordered gallery",
+    targetPath: "Efforts/Projets/Test.md",
+    fields: {
+      taskGallery: ["media/a,b.png", "media\\c;d.png", "media/a,b.png"],
+    },
+  },
+});
+assert.deepEqual(createWithGallery.task.fields.taskGallery, [
+  "media/a,b.png",
+  "media\\c;d.png",
+]);
+assert.equal(
+  OperonCreateTaskSchema.safeParse({
+    ...createWithGallery,
+    task: {
+      ...createWithGallery.task,
+      fields: { taskGallery: "media/a.png;media/b.png" },
+    },
+  }).success,
+  false,
+  "taskGallery must never be reconstructed from a delimiter string",
+);
+
+const createGallery256 = Array.from(
+  { length: 256 },
+  (_, index) => `media/create-${index}.png`,
+);
+assert.equal(
+  OperonCreateTaskSchema.safeParse({
+    idempotencyKey: "contract-create-gallery-256",
+    task: {
+      source: "inline",
+      description: "Create maximum gallery",
+      targetPath: "Efforts/Projets/Test.md",
+      fields: { taskGallery: createGallery256 },
+    },
+  }).success,
+  true,
+);
+assert.equal(
+  OperonCreateTaskSchema.safeParse({
+    idempotencyKey: "contract-create-gallery-257",
+    task: {
+      source: "inline",
+      description: "Reject oversized gallery",
+      targetPath: "Efforts/Projets/Test.md",
+      fields: { taskGallery: [...createGallery256, "media/create-256.png"] },
+    },
+  }).success,
+  false,
+  "create must reject item 257 before normalization",
+);
+
+const updateGallery512 = Array.from(
+  { length: 512 },
+  (_, index) => `media/update-${index}.png`,
+);
+assert.equal(
+  OperonUpdateTaskSchema.safeParse({
+    operonId: "abc1234",
+    expectedRevision: task.revision,
+    idempotencyKey: "contract-update-gallery-512",
+    patch: { fields: { taskGallery: updateGallery512 } },
+  }).success,
+  true,
+);
+assert.equal(
+  OperonUpdateTaskSchema.safeParse({
+    operonId: "abc1234",
+    expectedRevision: task.revision,
+    idempotencyKey: "contract-update-gallery-513",
+    patch: {
+      fields: { taskGallery: [...updateGallery512, "media/update-512.png"] },
+    },
+  }).success,
+  false,
+  "update must reject item 513 before normalization",
+);
+
+const createPeriodic = OperonCreatePeriodicTaskSchema.parse({
+  idempotencyKey: "contract-periodic-create",
+  periodic: {
+    description: "Daily review",
+    periodicKind: "daily",
+    routeDate: "2026-08-23",
+    fields: { taskGallery: ["media/daily,one.png"] },
+  },
+});
+assert.equal(createPeriodic.dryRun, true);
+assert.equal(createPeriodic.periodic.periodicKind, "daily");
+
+const updatePeriodic = OperonUpdatePeriodicSchedulingSchema.parse({
+  operonId: "abc1234",
+  expectedRevision: task.revision,
+  idempotencyKey: "contract-periodic-update",
+  patch: { fields: { dateScheduled: null } },
+});
+assert.equal(updatePeriodic.patch.fields.dateScheduled, null);
 
 const adopt = OperonAdoptTaskSchema.parse({
   idempotencyKey: "contract-adopt-1",

--- a/scripts/test-operon-contract.mjs
+++ b/scripts/test-operon-contract.mjs
@@ -814,6 +814,24 @@ const createPeriodic = OperonCreatePeriodicTaskSchema.parse({
 assert.equal(createPeriodic.dryRun, true);
 assert.equal(createPeriodic.periodic.periodicKind, "daily");
 assert.deepEqual(createPeriodic.periodic.tags, ["work", "focus"]);
+for (const periodic of [
+  { fields: { parentTask: "abc1234" } },
+  { statusId: "planned", fields: { status: "other" } },
+  { priorityId: "priority-a", fields: { priority: "priority-b" } },
+]) {
+  assert.equal(
+    OperonCreatePeriodicTaskSchema.safeParse({
+      idempotencyKey: `contract-periodic-exclusive-${JSON.stringify(periodic)}`,
+      periodic: {
+        description: "Daily review",
+        periodicKind: "daily",
+        ...periodic,
+      },
+    }).success,
+    false,
+    "periodic creation must preserve Operon-owned parentage and unambiguous selectors",
+  );
+}
 assert.equal(
   OperonCreatePeriodicTaskSchema.safeParse({
     idempotencyKey: "contract-periodic-invalid-route-date",

--- a/scripts/test-operon-contract.mjs
+++ b/scripts/test-operon-contract.mjs
@@ -733,11 +733,25 @@ const createPeriodic = OperonCreatePeriodicTaskSchema.parse({
     description: "Daily review",
     periodicKind: "daily",
     routeDate: "2026-08-23",
+    tags: ["work", "#work", " #focus ", "", "#"],
     fields: { taskGallery: ["media/daily,one.png"] },
   },
 });
 assert.equal(createPeriodic.dryRun, true);
 assert.equal(createPeriodic.periodic.periodicKind, "daily");
+assert.deepEqual(createPeriodic.periodic.tags, ["work", "focus"]);
+assert.equal(
+  OperonCreatePeriodicTaskSchema.safeParse({
+    idempotencyKey: "contract-periodic-invalid-route-date",
+    periodic: {
+      description: "Daily review",
+      periodicKind: "daily",
+      routeDate: "tomorrow",
+    },
+  }).success,
+  false,
+  "periodic routeDate must be rejected at the MCP boundary",
+);
 
 const updatePeriodic = OperonUpdatePeriodicSchedulingSchema.parse({
   operonId: "abc1234",

--- a/scripts/test-operon-contract.mjs
+++ b/scripts/test-operon-contract.mjs
@@ -671,6 +671,80 @@ assert.equal(
   "taskGallery must never be reconstructed from a delimiter string",
 );
 
+for (const field of [
+  "taskType",
+  "taskImage",
+  "taskIcon",
+  "taskColor",
+  "note",
+  "location",
+  "dateDue",
+  "dateScheduled",
+  "dateStarted",
+  "datetimeStart",
+  "datetimeEnd",
+  "estimate",
+]) {
+  assert.equal(
+    OperonCreateTaskSchema.safeParse({
+      idempotencyKey: `contract-create-scalar-${field}`,
+      task: {
+        description: "Scalar field contract",
+        source: "inline",
+        fields: { [field]: ["must-not-coerce"] },
+      },
+    }).success,
+    false,
+    `${field} must reject arrays before preview/apply`,
+  );
+  assert.equal(
+    OperonUpdateTaskSchema.safeParse({
+      operonId: "abc1234",
+      expectedRevision: task.revision,
+      idempotencyKey: `contract-update-scalar-${field}`,
+      patch: { fields: { [field]: ["must-not-coerce"] } },
+    }).success,
+    false,
+    `update ${field} must reject arrays before preview/apply`,
+  );
+}
+for (const field of ["taskGallery", "assignees", "contexts", "links"]) {
+  assert.equal(
+    OperonCreateTaskSchema.safeParse({
+      idempotencyKey: `contract-create-list-${field}`,
+      task: {
+        description: "List field contract",
+        source: "inline",
+        fields: { [field]: "must-not-split" },
+      },
+    }).success,
+    false,
+    `${field} must reject scalar coercion before preview/apply`,
+  );
+  assert.equal(
+    OperonUpdateTaskSchema.safeParse({
+      operonId: "abc1234",
+      expectedRevision: task.revision,
+      idempotencyKey: `contract-update-list-${field}`,
+      patch: { fields: { [field]: "must-not-split" } },
+    }).success,
+    false,
+    `update ${field} must reject scalar coercion before preview/apply`,
+  );
+}
+assert.equal(
+  OperonCreatePeriodicTaskSchema.safeParse({
+    idempotencyKey: "contract-periodic-scalar-field-array",
+    periodic: {
+      description: "Periodic scalar field contract",
+      periodicKind: "daily",
+      fields: { taskType: ["must-not-coerce"] },
+    },
+  }).success,
+  false,
+  "periodic creation must apply the scalar field contract before dispatch",
+);
+
 const createGallery256 = Array.from(
   { length: 256 },
   (_, index) => `media/create-${index}.png`,

--- a/scripts/test-operon-service.mjs
+++ b/scripts/test-operon-service.mjs
@@ -160,6 +160,8 @@ function makeTask(operonId, overrides = {}) {
 }
 
 const tasks = [makeTask("abc1234"), makeTask("bcd2345")];
+const taskWorkflowPlanDigest = "a".repeat(64);
+const alternateTaskWorkflowPlanDigest = "b".repeat(64);
 const state = {
   mode: "normal",
   generation: 1,
@@ -167,7 +169,9 @@ const state = {
   postCalls: 0,
   validationCalls: 0,
   mutationCalls: 0,
+  pendingRecoveryCalls: 0,
   recoveryCalls: 0,
+  lastTaskWorkflowRecoveryBody: null,
   mutations: false,
 };
 
@@ -211,6 +215,9 @@ function statusPayload() {
       ? {
           ...capabilities,
           adopt: true,
+          periodicCreate: true,
+          periodicUpdate: true,
+          taskWorkflowRecovery: true,
           create: true,
           update: true,
           transition: true,
@@ -416,6 +423,20 @@ const server = http.createServer((request, response) => {
     return;
   }
   if (
+    request.method === "GET" &&
+    url.pathname.endsWith("/mutations/pending-recoveries")
+  ) {
+    state.pendingRecoveryCalls += 1;
+    sendJson(response, 200, {
+      ok: true,
+      contractVersion: "1",
+      source: "operon-live",
+      stale: false,
+      recoveries: [{ recoveryRef: "legacy-recovery" }],
+    });
+    return;
+  }
+  if (
     request.method === "POST" &&
     url.pathname.endsWith("/mutations/recover")
   ) {
@@ -435,8 +456,189 @@ const server = http.createServer((request, response) => {
         before: null,
         requested: { recoveryRef: params.recoveryRef },
         after: null,
-        planDigest: "plan-recovery-test",
+        planDigest: "d".repeat(64),
         recoveryRef: params.recoveryRef,
+        source: "operon-live",
+        stale: false,
+      });
+    });
+    return;
+  }
+  if (
+    request.method === "GET" &&
+    url.pathname.endsWith("/task-workflows/pending-recoveries")
+  ) {
+    state.pendingRecoveryCalls += 1;
+    sendJson(response, 200, {
+      ok: true,
+      contractVersion: "1",
+      source: "operon-live",
+      stale: false,
+      recoveries: [
+        {
+          ...(url.searchParams.get("kind")
+            ? { kind: url.searchParams.get("kind") }
+            : { workflowKind: "periodic-update" }),
+          planDigest: taskWorkflowPlanDigest,
+        },
+      ],
+    });
+    return;
+  }
+  if (
+    request.method === "POST" &&
+    url.pathname.endsWith("/task-workflows/recover")
+  ) {
+    state.recoveryCalls += 1;
+    let body = "";
+    request.on("data", (chunk) => {
+      body += chunk;
+    });
+    request.on("end", () => {
+      const params = body ? JSON.parse(body) : {};
+      state.lastTaskWorkflowRecoveryBody = params;
+      const nativeProof = {
+        contractVersion: 1,
+        kind: "mutation-result",
+        status:
+          params.idempotencyKey === "test-workflow-recovery-malformed"
+            ? "committed"
+            : "already-applied",
+        mutationMayHaveApplied: true,
+        retryAllowed: false,
+        groupResults: [],
+        receipt: {
+          contractVersion: 1,
+          planDigest: params.planDigest,
+          mutationKind: "task.update",
+          targetDigest: "c".repeat(64),
+          terminalOutcome: "already-applied",
+          effectiveAt: "2026-08-24T08:00:00.000Z",
+          completedAt: "2026-08-24T08:00:01.000Z",
+          expiresAt: "2026-08-24T09:00:01.000Z",
+        },
+        postflight: { status: "receipt-replay" },
+      };
+      sendJson(response, 200, {
+        ok: true,
+        contractVersion: "1",
+        operationId: `operation-workflow-recovery-${state.recoveryCalls}`,
+        idempotencyKey: params.idempotencyKey,
+        status: "already-applied",
+        before: null,
+        requested: { recoveryRef: params.recoveryRef, kind: params.kind },
+        after: null,
+        recoveryRef: params.recoveryRef,
+        nativeProof,
+        source: "operon-live",
+        stale: false,
+      });
+    });
+    return;
+  }
+  if (request.method === "POST" && url.pathname.endsWith("/tasks/periodic")) {
+    state.mutationCalls += 1;
+    let body = "";
+    request.on("data", (chunk) => {
+      body += chunk;
+    });
+    request.on("end", () => {
+      const params = body ? JSON.parse(body) : {};
+      sendJson(response, 200, {
+        ok: true,
+        contractVersion: "1",
+        operationId: `operation-periodic-create-${state.mutationCalls}`,
+        idempotencyKey: params.idempotencyKey,
+        status: params.dryRun === false ? "applied" : "planned",
+        before: null,
+        requested: params.periodic,
+        after:
+          params.dryRun === false
+            ? makeTask("per1234", {
+                description: params.periodic.description,
+                fields: params.periodic.fields ?? {},
+                // Operon owns periodic routing. Keep the result outside the
+                // configured-prefix fixture: scoped apply must be rejected
+                // before POST, while unscoped apply still validates the
+                // returned canonical vault-relative path.
+                path: "Periodic/Daily/2026-08-24.md",
+              })
+            : null,
+        source: "operon-live",
+        stale: false,
+      });
+    });
+    return;
+  }
+  if (
+    request.method === "POST" &&
+    /\/tasks\/([^/]+)\/periodic-update$/u.test(url.pathname)
+  ) {
+    state.mutationCalls += 1;
+    let body = "";
+    request.on("data", (chunk) => {
+      body += chunk;
+    });
+    request.on("end", () => {
+      const params = body ? JSON.parse(body) : {};
+      const operonId =
+        /\/tasks\/([^/]+)\/periodic-update$/u.exec(url.pathname)?.[1] ??
+        "abc1234";
+      const before = tasks[0];
+      const scheduled = params.patch.fields.dateScheduled;
+      const after = makeTask(operonId, {
+        dates: { ...before.dates, scheduled },
+        fields: {
+          ...before.fields,
+          ...(scheduled === null ? {} : { dateScheduled: scheduled }),
+        },
+      });
+      if (scheduled === null) delete after.fields.dateScheduled;
+      sendJson(response, 200, {
+        ok: true,
+        contractVersion: "1",
+        operationId: `operation-periodic-update-${state.mutationCalls}`,
+        idempotencyKey: params.idempotencyKey,
+        status: params.dryRun === false ? "applied" : "planned",
+        before,
+        requested: params.patch,
+        after: params.dryRun === false ? after : null,
+        source: "operon-live",
+        stale: false,
+      });
+    });
+    return;
+  }
+  if (
+    request.method === "POST" &&
+    /\/tasks\/([^/]+)\/update$/u.test(url.pathname)
+  ) {
+    state.mutationCalls += 1;
+    let body = "";
+    request.on("data", (chunk) => {
+      body += chunk;
+    });
+    request.on("end", () => {
+      const params = body ? JSON.parse(body) : {};
+      const operonId =
+        /\/tasks\/([^/]+)\/update$/u.exec(url.pathname)?.[1] ?? "abc1234";
+      const requestedFields = params.patch.fields ?? {};
+      const fields = { ...tasks[0].fields, ...requestedFields };
+      if (
+        state.mode === "gallery-reordered" &&
+        Array.isArray(fields.taskGallery)
+      ) {
+        fields.taskGallery = [...fields.taskGallery].reverse();
+      }
+      sendJson(response, 200, {
+        ok: true,
+        contractVersion: "1",
+        operationId: `operation-update-${state.mutationCalls}`,
+        idempotencyKey: params.idempotencyKey,
+        status: params.dryRun === false ? "applied" : "planned",
+        before: tasks[0],
+        requested: params.patch,
+        after: params.dryRun === false ? makeTask(operonId, { fields }) : null,
         source: "operon-live",
         stale: false,
       });
@@ -540,13 +742,16 @@ const server = http.createServer((request, response) => {
         if (value === null) delete fields[field];
         else fields[field] = String(value);
       }
-      const repeating = typeof fields.repeat === "string" && fields.repeat.length > 0;
+      const repeating =
+        typeof fields.repeat === "string" && fields.repeat.length > 0;
       const after = makeTask(operonId, {
         fields,
         recurrence: {
           repeating,
           seriesId: repeating ? "rsabc12" : null,
-          occurrenceDate: repeating ? (fields.dateScheduled ?? "2026-08-10") : null,
+          occurrenceDate: repeating
+            ? (fields.dateScheduled ?? "2026-08-10")
+            : null,
         },
       });
       sendJson(response, 200, {
@@ -726,15 +931,13 @@ try {
   assert.equal(secondFilterPage.hasMore, false);
   assert.equal(secondFilterPage.tasks[0].operonId, "bcd2345");
   await assert.rejects(
-    () =>
-      service.querySavedFilter({ filterSetId: "missing-filter", limit: 1 }),
+    () => service.querySavedFilter({ filterSetId: "missing-filter", limit: 1 }),
     (error) =>
       error?.code === "NOT_FOUND" &&
       error?.message === "Saved filter was not found.",
   );
   await assert.rejects(
-    () =>
-      service.querySavedFilter({ filterSetId: "invalid-filter", limit: 1 }),
+    () => service.querySavedFilter({ filterSetId: "invalid-filter", limit: 1 }),
     (error) =>
       error?.code === "VALIDATION_ERROR" &&
       error?.message === "Saved filter request is invalid.",
@@ -827,6 +1030,18 @@ try {
   });
   assert.equal(adoptionPlanned.status, "planned");
   assert.equal(state.mutationCalls, 2);
+  const periodicPlanned = await service.createPeriodicTask({
+    idempotencyKey: "test-periodic-create-idempotency",
+    dryRun: true,
+    periodic: {
+      description: "Daily task through sealed routing",
+      periodicKind: "daily",
+      routeDate: "2026-08-23",
+      fields: { taskGallery: ["media/a,b.png", "media/c;d.png"] },
+    },
+  });
+  assert.equal(periodicPlanned.status, "planned");
+  assert.equal(state.mutationCalls, 3);
   const replayed = await service.createTask({
     idempotencyKey: "test-create-idempotency",
     dryRun: true,
@@ -840,7 +1055,7 @@ try {
   assert.equal(replayed.operationId, planned.operationId);
   assert.equal(
     state.mutationCalls,
-    2,
+    3,
     "journal replay must not call the Bridge twice",
   );
 
@@ -858,7 +1073,7 @@ try {
   );
   assert.equal(
     state.mutationCalls,
-    2,
+    3,
     "mismatched idempotency reuse must be rejected locally",
   );
 
@@ -922,7 +1137,7 @@ try {
   );
   assert.equal(
     state.mutationCalls,
-    2,
+    3,
     "scope rejection must happen before the Bridge call",
   );
 
@@ -940,7 +1155,7 @@ try {
   );
   assert.equal(
     state.mutationCalls,
-    2,
+    3,
     "non-canonical paths must be rejected before any Bridge request",
   );
 
@@ -956,7 +1171,7 @@ try {
   assert.equal(scopedInline.status, "planned");
   assert.equal(
     state.mutationCalls,
-    3,
+    4,
     "explicit allowed inline target must reach the Bridge",
   );
 
@@ -987,6 +1202,49 @@ try {
     "relationship replay after restart must use the durable MCP journal",
   );
 
+  const configuredMutationPrefixes = [
+    ...config.operonMutationAllowedPathPrefixes,
+  ];
+  const callsBeforeScopedPeriodicApply = state.mutationCalls;
+  await assert.rejects(
+    service.createPeriodicTask({
+      idempotencyKey: "test-periodic-create-guarded-configured-prefixes",
+      dryRun: false,
+      periodic: {
+        description: "Daily task with opaque Operon routing",
+        periodicKind: "daily",
+        routeDate: "2026-08-24",
+      },
+    }),
+    (error) =>
+      error?.code === "FORBIDDEN" &&
+      /requires verifiable route evidence/u.test(error.message),
+    "guarded periodic apply must fail closed when configured prefixes cannot be checked against route evidence",
+  );
+  assert.equal(
+    state.mutationCalls,
+    callsBeforeScopedPeriodicApply,
+    "scoped periodic apply must be rejected before the Bridge POST",
+  );
+
+  config.operonMutationAllowedPathPrefixes = [];
+  const guardedPeriodicWithoutPrefixes = await service.createPeriodicTask({
+    idempotencyKey: "test-periodic-create-guarded-empty-prefixes",
+    dryRun: false,
+    periodic: {
+      description: "Weekly task with Operon-owned routing",
+      periodicKind: "weekly",
+      routeDate: "2026-08-24",
+    },
+  });
+  assert.equal(guardedPeriodicWithoutPrefixes.status, "applied");
+  assert.equal(
+    guardedPeriodicWithoutPrefixes.after.path,
+    "Periodic/Daily/2026-08-24.md",
+    "guarded periodic creation must not require arbitrary path prefixes",
+  );
+  config.operonMutationAllowedPathPrefixes = configuredMutationPrefixes;
+
   await assert.rejects(
     service.updateRecurrence({
       idempotencyKey: "test-recurrence-guarded",
@@ -1001,6 +1259,181 @@ try {
   );
 
   config.mcpWriteMode = "full";
+
+  const orderedGallery = ["media/a,b.png", "media\\c;d.png", "media/a,b.png"];
+  const normalizedOrderedGallery = ["media/a,b.png", "media\\c;d.png"];
+  const galleryApplied = await service.updateTask({
+    idempotencyKey: "test-gallery-ordered-apply",
+    dryRun: false,
+    operonId: "abc1234",
+    expectedRevision: tasks[0].revision,
+    patch: { fields: { taskGallery: orderedGallery } },
+  });
+  assert.deepEqual(
+    galleryApplied.after.fields.taskGallery,
+    normalizedOrderedGallery,
+    "MCP must preserve list punctuation/order and apply Operon's first-occurrence deduplication",
+  );
+
+  state.mode = "gallery-reordered";
+  await assert.rejects(
+    service.updateTask({
+      idempotencyKey: "test-gallery-reordered-conflict",
+      dryRun: false,
+      operonId: "abc1234",
+      expectedRevision: tasks[0].revision,
+      patch: { fields: { taskGallery: orderedGallery } },
+    }),
+    (error) =>
+      error?.code === "CONFLICT" && /value or order/u.test(error.message),
+    "MCP postflight must reject a reordered taskGallery",
+  );
+  state.mode = "normal";
+
+  const periodicUpdated = await service.updatePeriodicScheduling({
+    idempotencyKey: "test-periodic-update-apply",
+    dryRun: false,
+    operonId: "abc1234",
+    expectedRevision: tasks[0].revision,
+    patch: { fields: { dateScheduled: "2026-08-30" } },
+  });
+  assert.equal(periodicUpdated.after.dates.scheduled, "2026-08-30");
+
+  const pendingCallsBeforeScopedRecovery = state.pendingRecoveryCalls;
+  const recoveryCallsBeforeScopedRecovery = state.recoveryCalls;
+  await assert.rejects(
+    service.pendingRecoveries({ kind: "periodic-update" }),
+    (error) =>
+      error?.code === "FORBIDDEN" &&
+      /do not expose canonical route evidence/u.test(error.message),
+    "configured path prefixes must hide recovery references whose route cannot be proven",
+  );
+  await assert.rejects(
+    service.recoverMutation({
+      idempotencyKey: "test-scoped-recovery-bypass",
+      recoveryRef: "dvr1_scoped-recovery-bypass",
+      recovery: {
+        kind: "periodic-update",
+        planDigest: taskWorkflowPlanDigest,
+      },
+    }),
+    (error) =>
+      error?.code === "FORBIDDEN" &&
+      /before listing, replay, or Bridge apply/u.test(error.message),
+    "configured path prefixes must fail closed before recovery can reach the durable replay or Bridge",
+  );
+  assert.equal(state.pendingRecoveryCalls, pendingCallsBeforeScopedRecovery);
+  assert.equal(state.recoveryCalls, recoveryCallsBeforeScopedRecovery);
+
+  config.operonMutationAllowedPathPrefixes = [];
+
+  const workflowRecoveries = await service.pendingRecoveries({
+    kind: "periodic-update",
+  });
+  assert.equal(workflowRecoveries.recoveries[0].kind, "periodic-update");
+  assert.equal(
+    workflowRecoveries.recoveries[0].planDigest,
+    taskWorkflowPlanDigest,
+  );
+  assert.equal(
+    workflowRecoveries.recoveries[0].recoveryFamily,
+    "task-workflow",
+  );
+  const allRecoveries = await service.pendingRecoveries();
+  assert.deepEqual(
+    allRecoveries.recoveries.map((entry) => entry.recoveryFamily),
+    ["developer-api", "task-workflow"],
+    "unfiltered recovery listing must aggregate legacy and task-workflow families",
+  );
+  assert.deepEqual(
+    allRecoveries.recoveries.map((entry) => entry.kind),
+    ["developer-api", "periodic-update"],
+    "every pending recovery must expose the exact required recover kind without caller inference",
+  );
+
+  const workflowRecovered = await service.recoverMutation({
+    idempotencyKey: "test-workflow-recovery",
+    recoveryRef: "dvr1_workflow-recovery",
+    recovery: {
+      kind: "periodic-update",
+      planDigest: taskWorkflowPlanDigest,
+    },
+  });
+  assert.equal(workflowRecovered.status, "already-applied");
+  assert.equal(
+    state.lastTaskWorkflowRecoveryBody.planDigest,
+    taskWorkflowPlanDigest,
+    "task-workflow recovery must forward only the caller-provided pending plan digest",
+  );
+  assert.equal(
+    workflowRecovered.nativeProof.receipt.planDigest,
+    taskWorkflowPlanDigest,
+    "the validated native receipt proof must survive the MCP boundary",
+  );
+  const recoveryCallsAfterBoundWorkflow = state.recoveryCalls;
+  await assert.rejects(
+    service.recoverMutation({
+      idempotencyKey: "test-workflow-recovery",
+      recoveryRef: "dvr1_workflow-recovery",
+      recovery: {
+        kind: "periodic-update",
+        planDigest: alternateTaskWorkflowPlanDigest,
+      },
+    }),
+    (error) => error?.code === "CONFLICT",
+    "the durable idempotency binding must reject a different digest for the same recovery request",
+  );
+  assert.equal(
+    state.recoveryCalls,
+    recoveryCallsAfterBoundWorkflow,
+    "a digest substitution must be rejected before the Bridge POST",
+  );
+  await assert.rejects(
+    service.recoverMutation({
+      idempotencyKey: "test-workflow-recovery-malformed",
+      recoveryRef: "dvr1_workflow-recovery-malformed",
+      recovery: {
+        kind: "periodic-update",
+        planDigest: taskWorkflowPlanDigest,
+      },
+    }),
+    (error) => error?.code === "PARSING_ERROR",
+    "a malformed native mutation proof must reject the Bridge response",
+  );
+  const flatCandidateRecoveryDb = new DatabaseSync(dbPath);
+  try {
+    flatCandidateRecoveryDb
+      .prepare(
+        `UPDATE operon_mutation_journal
+         SET requested_json = ?
+         WHERE idempotency_key = ?`,
+      )
+      .run(
+        JSON.stringify({
+          kind: "periodic-update",
+          planDigest: taskWorkflowPlanDigest,
+          recoveryRef: "dvr1_workflow-recovery",
+        }),
+        "test-workflow-recovery",
+      );
+  } finally {
+    flatCandidateRecoveryDb.close();
+  }
+  const recoveryCallsBeforeFlatCandidateReplay = state.recoveryCalls;
+  const migratedFlatCandidate = await new OperonService().recoverMutation({
+    idempotencyKey: "test-workflow-recovery",
+    recoveryRef: "dvr1_workflow-recovery",
+    recovery: {
+      kind: "periodic-update",
+      planDigest: taskWorkflowPlanDigest,
+    },
+  });
+  assert.equal(migratedFlatCandidate.replayed, true);
+  assert.equal(
+    state.recoveryCalls,
+    recoveryCallsBeforeFlatCandidateReplay,
+    "the unreleased flat 3.1 recovery journal binding must migrate without another Bridge apply",
+  );
 
   const recurrenceApplied = await service.updateRecurrence({
     idempotencyKey: "test-recurrence-apply",
@@ -1037,10 +1470,27 @@ try {
   const recoveryInput = {
     idempotencyKey: "test-recovery-idempotency",
     recoveryRef: "dvr1_test-recovery-ref",
+    recovery: { kind: "developer-api" },
   };
+  const recoveryCallsBeforeLegacy = state.recoveryCalls;
   const recovered = await service.recoverMutation(recoveryInput);
   assert.equal(recovered.status, "already-applied");
-  assert.equal(state.recoveryCalls, 1);
+  assert.equal(state.recoveryCalls, recoveryCallsBeforeLegacy + 1);
+  const legacyRecoveryDb = new DatabaseSync(dbPath);
+  try {
+    legacyRecoveryDb
+      .prepare(
+        `UPDATE operon_mutation_journal
+         SET requested_json = ?
+         WHERE idempotency_key = ?`,
+      )
+      .run(
+        JSON.stringify({ recoveryRef: recoveryInput.recoveryRef }),
+        recoveryInput.idempotencyKey,
+      );
+  } finally {
+    legacyRecoveryDb.close();
+  }
   state.mode = "offline";
   const restartedRecovery = await new OperonService().recoverMutation(
     recoveryInput,
@@ -1048,10 +1498,24 @@ try {
   assert.equal(restartedRecovery.replayed, true);
   assert.equal(
     state.recoveryCalls,
-    1,
+    recoveryCallsBeforeLegacy + 1,
     "completed recovery must replay from the MCP journal after restart",
   );
   state.mode = "normal";
+  config.operonMutationAllowedPathPrefixes = configuredMutationPrefixes;
+  const recoveryCallsBeforePolicyReplay = state.recoveryCalls;
+  await assert.rejects(
+    new OperonService().recoverMutation(recoveryInput),
+    (error) =>
+      error?.code === "FORBIDDEN" &&
+      /before listing, replay, or Bridge apply/u.test(error.message),
+    "a stricter path policy must fence a durable recovery replay sealed under an earlier unscoped policy",
+  );
+  assert.equal(
+    state.recoveryCalls,
+    recoveryCallsBeforePolicyReplay,
+    "the path-policy replay fence must not contact the Bridge",
+  );
 
   const concurrentInput = {
     idempotencyKey: "test-concurrent-idempotency",
@@ -1119,8 +1583,115 @@ try {
     "restart-safe reservation must block a blind Bridge retry",
   );
 
+  const legacyDbPath = path.join(tempRoot, "legacy-v1-cache.sqlite");
+  const legacySnapshotDb = new DatabaseSync(legacyDbPath);
+  try {
+    legacySnapshotDb.exec(`
+      CREATE TABLE operon_task_snapshot (
+        operon_id TEXT PRIMARY KEY,
+        revision TEXT NOT NULL,
+        source_path TEXT NOT NULL,
+        source_mtime INTEGER,
+        payload_json TEXT NOT NULL,
+        operon_version TEXT NOT NULL,
+        bridge_version TEXT NOT NULL,
+        snapshot_at INTEGER NOT NULL
+      );
+      CREATE TABLE operon_snapshot_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT NOT NULL
+      );
+    `);
+    const snapshotAt = Date.now() - 60_000;
+    const insertTask = legacySnapshotDb.prepare(
+      `INSERT INTO operon_task_snapshot (
+        operon_id, revision, source_path, source_mtime, payload_json,
+        operon_version, bridge_version, snapshot_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    );
+    for (const current of tasks) {
+      const legacyTask = {
+        ...current,
+        fields: {
+          status: String(current.fields.status),
+          priority: String(current.fields.priority),
+          taskGallery: "media/a,b.png; media\\c;d.png",
+        },
+      };
+      insertTask.run(
+        legacyTask.operonId,
+        legacyTask.revision,
+        legacyTask.path,
+        legacyTask.sourceMtime,
+        JSON.stringify(legacyTask),
+        "2.4.0",
+        "0.1.0",
+        snapshotAt,
+      );
+    }
+    const legacyStatus = statusPayload();
+    delete legacyStatus.capabilities.periodicCreate;
+    delete legacyStatus.capabilities.periodicUpdate;
+    delete legacyStatus.capabilities.taskWorkflowRecovery;
+    const writeLegacyMeta = legacySnapshotDb.prepare(
+      "INSERT INTO operon_snapshot_meta (key, value) VALUES (?, ?)",
+    );
+    for (const [key, value] of [
+      // Real v1 snapshots predate the explicit schema marker. Its absence is
+      // the durable signal the reader must safely interpret as schema v1.
+      ["snapshot_at", String(snapshotAt)],
+      ["generation", String(state.generation)],
+      ["settings_signature", "fnv1a32:settings"],
+      ["operon_version", "2.4.0"],
+      ["bridge_version", "0.1.0"],
+      ["contract_version", "1"],
+      ["status_json", JSON.stringify(legacyStatus)],
+    ]) {
+      writeLegacyMeta.run(key, value);
+    }
+  } finally {
+    legacySnapshotDb.close();
+  }
+  const originalDbPath = config.obsidianSharedCacheDbPath;
+  config.obsidianSharedCacheDbPath = legacyDbPath;
+  state.mode = "offline";
+  const legacyService = new OperonService();
+  const migratedLegacySnapshot = await legacyService.ensureSnapshot();
+  assert.equal(migratedLegacySnapshot.snapshotSchemaVersion, 1);
+  assert.equal(
+    typeof migratedLegacySnapshot.tasks[0].fields.taskGallery,
+    "string",
+    "v1 compatibility must not invent list boundaries from a lossy delimiter string",
+  );
+  assert.ok(
+    migratedLegacySnapshot.limitations.some((entry) =>
+      entry.includes("Legacy Operon snapshot schema v1"),
+    ),
+    "v1 compatibility must disclose the flattened-list limitation",
+  );
+  tasks[0].fields.taskGallery = ["media/a,b.png", "media\\c;d.png"];
+  state.mode = "normal";
+  const postCallsBeforeV2Refresh = state.postCalls;
+  const refreshedV2Snapshot = await legacyService.ensureSnapshot();
+  assert.equal(refreshedV2Snapshot.snapshotSchemaVersion, 2);
+  assert.ok(
+    state.postCalls > postCallsBeforeV2Refresh,
+    "a matching-generation v1 snapshot must still be replaced by a live v2 refresh",
+  );
+  assert.deepEqual(refreshedV2Snapshot.tasks[0].fields.taskGallery, [
+    "media/a,b.png",
+    "media\\c;d.png",
+  ]);
+  assert.ok(
+    refreshedV2Snapshot.limitations.every(
+      (entry) => !entry.includes("Legacy Operon snapshot schema v1"),
+    ),
+    "the v1 compatibility limitation must disappear after a proven live v2 refresh",
+  );
+  config.obsidianSharedCacheDbPath = originalDbPath;
+
   console.log(
-    "PASS: Operon snapshot refresh, readiness gating, generation reuse, stale fallback, property gating, duplicate/P0 refusal, pagination/validation drift preservation, short-status postflight, durable recovery replay, scoped mutations, and durable/concurrent mutation idempotency",
+    "PASS: Operon snapshot v2/v1 compatibility, typed ordered fields, periodic workflows, task-workflow recovery, readiness gating, postflight, scoped mutations, and durable/concurrent mutation idempotency",
   );
 } finally {
   await new Promise((resolve, reject) =>

--- a/scripts/test-tool-profiles.mjs
+++ b/scripts/test-tool-profiles.mjs
@@ -12,12 +12,12 @@ import { TOOL_REGISTRATION_MODES } from "../dist/mcp-server/toolSurfaceRegistry.
 const WITH_CACHE = ["vault-cache"];
 
 const EXPECTED_COUNTS = {
-  live: { standard: 19, authoring: 30, tasks: 31, full: 70 },
-  "hybrid-live": { standard: 19, authoring: 30, tasks: 31, full: 70 },
-  "hybrid-degraded": { standard: 6, authoring: 6, tasks: 14, full: 43 },
-  "headless-readonly": { standard: 9, authoring: 9, tasks: 14, full: 46 },
-  "headless-guarded": { standard: 12, authoring: 12, tasks: 14, full: 49 },
-  "headless-filesystem": { standard: 12, authoring: 16, tasks: 14, full: 58 },
+  live: { standard: 19, authoring: 30, tasks: 33, full: 72 },
+  "hybrid-live": { standard: 19, authoring: 30, tasks: 33, full: 72 },
+  "hybrid-degraded": { standard: 6, authoring: 6, tasks: 14, full: 45 },
+  "headless-readonly": { standard: 9, authoring: 9, tasks: 14, full: 48 },
+  "headless-guarded": { standard: 12, authoring: 12, tasks: 14, full: 51 },
+  "headless-filesystem": { standard: 12, authoring: 16, tasks: 14, full: 60 },
 };
 
 assert.deepEqual(TOOL_PROFILE_IDS, ["standard", "authoring", "tasks", "full"]);
@@ -177,6 +177,8 @@ for (const required of [
   "operon_list_tasks",
   "operon_query_tasks",
   "operon_create_task",
+  "operon_create_periodic_task",
+  "operon_update_periodic_scheduling",
   "operon_update_task",
   "operon_transition_task",
   "operon_list_pending_recoveries",
@@ -220,6 +222,8 @@ for (const liveOnly of [
   "operon_build_context",
   "operon_get_timer_state",
   "operon_create_task",
+  "operon_create_periodic_task",
+  "operon_update_periodic_scheduling",
   "operon_update_task",
   "operon_transition_task",
   "operon_list_pending_recoveries",

--- a/scripts/test-tool-surface-registry.mjs
+++ b/scripts/test-tool-surface-registry.mjs
@@ -16,14 +16,14 @@ const repoRoot = path.resolve(
   "..",
 );
 
-const EXPECTED_UNION_COUNT = 74;
+const EXPECTED_UNION_COUNT = 76;
 const EXPECTED_COUNTS_BY_MODE = {
-  live: 70,
-  "hybrid-live": 70,
-  "hybrid-degraded": 43,
-  "headless-readonly": 46,
-  "headless-guarded": 49,
-  "headless-filesystem": 58,
+  live: 72,
+  "hybrid-live": 72,
+  "hybrid-degraded": 45,
+  "headless-readonly": 48,
+  "headless-guarded": 51,
+  "headless-filesystem": 60,
 };
 
 assert.equal(
@@ -56,8 +56,8 @@ for (const mode of TOOL_REGISTRATION_MODES) {
 
 assert.equal(
   compileToolNames({ registrationMode: "live" }).length,
-  70,
-  "70 is the current full live/hybrid surface, not the cross-runtime registry size",
+  72,
+  "72 is the current full live/hybrid surface, not the cross-runtime registry size",
 );
 
 for (const entry of TOOL_SURFACE_REGISTRY) {

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -139,7 +139,10 @@ const EnvSchema = z
     OBSIDIAN_STARTUP_BLOCKING: z
       .string()
       .transform((val) => val.toLowerCase() === "true")
-      .default("true"),
+      // A desktop MCP client can legitimately start before Obsidian. Keep the
+      // transport alive by default and let live tools report a temporary
+      // unavailable/degraded state until Local REST becomes reachable.
+      .default("false"),
     MCP_EXTERNAL_ROOTS_FILE: z.string().optional(),
     MCP_EXTERNAL_MOVE_ENABLED: z
       .string()

--- a/src/mcp-server/toolSurfaceRegistry.ts
+++ b/src/mcp-server/toolSurfaceRegistry.ts
@@ -180,6 +180,8 @@ const OPERON_READ_TOOLS = [
 
 const OPERON_MUTATION_TOOLS = [
   "operon_adopt_task",
+  "operon_create_periodic_task",
+  "operon_update_periodic_scheduling",
   "operon_create_task",
   "operon_update_task",
   "operon_transition_task",

--- a/src/mcp-server/tools/operonTools/registration.ts
+++ b/src/mcp-server/tools/operonTools/registration.ts
@@ -2,12 +2,16 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import {
   OperonAdoptTaskSchema,
+  OperonCreatePeriodicTaskSchema,
+  OperonUpdatePeriodicSchedulingSchema,
   OperonConvertTaskSchema,
   OperonConvertTaskInputSchema,
   OperonCreateTaskSchema,
   OperonFilterQuerySchema,
   OperonRelocateTaskSchema,
+  OperonRecoverMutationInputSchema,
   OperonRecoverMutationSchema,
+  OperonPendingRecoveriesInputSchema,
   OperonTaskFinderSchema,
   OperonResolveTaskSchema,
   OperonRelationshipsSchema,
@@ -206,11 +210,29 @@ export async function registerOperonTools(server: McpServer): Promise<void> {
 
   server.tool(
     "operon_adopt_task",
-    "Adopt one existing plain Markdown or Obsidian Tasks checkbox in place only when the live engine advertises adoption. Requires an exact one-based line and expectedLine precondition, plus idempotencyKey; dryRun defaults to true. Official Operon 3.2 does not currently expose this capability, and no raw Markdown fallback exists.",
+    "Adopt one existing plain Markdown or Obsidian Tasks checkbox in place through Operon's official sealed task-workflow preview/apply contract. Requires an exact one-based line and expectedLine precondition, plus idempotencyKey; dryRun defaults to true. No raw Markdown or CLI fallback exists.",
     OperonAdoptTaskSchema.shape,
     MUTATION_ANNOTATIONS,
     async (params: z.infer<typeof OperonAdoptTaskSchema>) =>
       runTool(() => service.adoptTask(params)),
+  );
+
+  server.tool(
+    "operon_create_periodic_task",
+    "Create exactly one inline Operon task in the configured Daily or Weekly Note through Operon's sealed periodic-note workflow. Operon owns routing, templates, container identity and receipts; routeDate is optional and dryRun defaults to true. Apply requires the live Bridge, idempotency and the periodicCreate capability.",
+    OperonCreatePeriodicTaskSchema.shape,
+    MUTATION_ANNOTATIONS,
+    async (params: z.infer<typeof OperonCreatePeriodicTaskSchema>) =>
+      runTool(() => service.createPeriodicTask(params)),
+  );
+
+  server.tool(
+    "operon_update_periodic_scheduling",
+    "Set or clear dateScheduled for one exact Operon task through the sealed periodic-update workflow. Operon decides retain, detach or realign without moving the source Markdown. expectedRevision and idempotencyKey are mandatory; dryRun defaults to true.",
+    OperonUpdatePeriodicSchedulingSchema.shape,
+    MUTATION_ANNOTATIONS,
+    async (params: z.infer<typeof OperonUpdatePeriodicSchedulingSchema>) =>
+      runTool(() => service.updatePeriodicScheduling(params)),
   );
 
   server.tool(
@@ -279,15 +301,16 @@ export async function registerOperonTools(server: McpServer): Promise<void> {
   server.tool(
     "operon_list_pending_recoveries",
     "List durable official Operon Developer API mutation recoveries. Read-only: it does not retry or apply anything; use the returned recoveryRef only with operon_recover_mutation after inspecting the uncertain outcome.",
-    {},
+    OperonPendingRecoveriesInputSchema.shape,
     READ_ONLY_ANNOTATIONS,
-    async () => runTool(() => service.pendingRecoveries()),
+    async (params: z.infer<typeof OperonPendingRecoveriesInputSchema>) =>
+      runTool(() => service.pendingRecoveries(params)),
   );
 
   server.tool(
     "operon_recover_mutation",
-    "Recover exactly one uncertain official Operon mutation by recoveryRef. This replays the same durable plan only; it never constructs a new mutation. Requires idempotencyKey, OPERON_MUTATIONS_ENABLED=true, and MCP_WRITE_MODE=full.",
-    OperonRecoverMutationSchema.shape,
+    "Recover exactly one uncertain official Operon mutation by recoveryRef. Set recovery.kind=developer-api for legacy official recovery, or use the exact task-workflow kind returned by pending state and optionally echo its planDigest. This replays the same durable plan only; it never constructs a new mutation. Requires idempotencyKey, OPERON_MUTATIONS_ENABLED=true, MCP_WRITE_MODE=full, and an empty OPERON_MUTATION_ALLOWED_PATH_PREFIXES because current recovery records do not prove their route.",
+    OperonRecoverMutationInputSchema.shape,
     MUTATION_ANNOTATIONS,
     async (params: z.infer<typeof OperonRecoverMutationSchema>) =>
       runTool(() => service.recoverMutation(params)),

--- a/src/mcp-server/transports/httpBackpressure.ts
+++ b/src/mcp-server/transports/httpBackpressure.ts
@@ -37,6 +37,8 @@ const DEFAULT_MUTATION_TOOLS = [
   "bases_upsert_config",
   "bases_upsert_rows",
   "operon_adopt_task",
+  "operon_create_periodic_task",
+  "operon_update_periodic_scheduling",
   "operon_create_task",
   "operon_update_task",
   "operon_transition_task",
@@ -199,7 +201,10 @@ export const httpBackpressureConfig = {
 };
 
 export type AdmissionRejectReason =
-  "queue-full" | "identity-queue-full" | "timeout" | "cancelled";
+  | "queue-full"
+  | "identity-queue-full"
+  | "timeout"
+  | "cancelled";
 
 export class AdmissionRejectedError extends Error {
   public readonly name = "AdmissionRejectedError";
@@ -789,7 +794,8 @@ export async function classifyHttpOperation(
 
   try {
     const payload = (await readBoundedJsonBody(c.req.raw, bodyLimits)) as
-      JsonRpcEnvelope | JsonRpcEnvelope[];
+      | JsonRpcEnvelope
+      | JsonRpcEnvelope[];
     if (Array.isArray(payload)) {
       throw new JsonRpcBatchUnsupportedError();
     }

--- a/src/services/operon/contract.ts
+++ b/src/services/operon/contract.ts
@@ -1133,7 +1133,16 @@ const OperonNativeReceiptSchema = z
   .object({
     contractVersion: z.literal(1),
     planDigest: OperonPlanDigestSchema,
-    mutationKind: z.enum(["task.adopt", "task.create", "task.update"]),
+    mutationKind: z.enum([
+      "task.adopt",
+      "task.create",
+      "task.update",
+      "task.transition",
+      "task.relationship",
+      "task.recurrence",
+      "task.convert",
+      "task.inline-relocate",
+    ]),
     targetDigest: OperonPlanDigestSchema,
     terminalOutcome: z.enum(["applied", "already-applied"]),
     effectiveAt: z.string().datetime({ offset: true }),
@@ -1149,7 +1158,12 @@ const OperonNativePostflightSchema = z.discriminatedUnion("status", [
       observedAt: z.string().datetime({ offset: true }).optional(),
     })
     .strict(),
-  z.object({ status: z.literal("receipt-replay") }).strict(),
+  z
+    .object({
+      status: z.literal("receipt-replay"),
+      observedAt: z.string().datetime({ offset: true }).optional(),
+    })
+    .strict(),
 ]);
 
 export const OperonNativeMutationProofSchema = z

--- a/src/services/operon/contract.ts
+++ b/src/services/operon/contract.ts
@@ -606,6 +606,58 @@ const OperonMutationFieldValueSchema = z.union([
 
 const OperonMutationFieldsSchema = z.record(OperonMutationFieldValueSchema);
 
+const OPERON_SCALAR_MUTATION_FIELDS = new Set([
+  "status",
+  "priority",
+  "parentTask",
+  "taskType",
+  "taskImage",
+  "taskIcon",
+  "taskColor",
+  "note",
+  "location",
+  "dateDue",
+  "dateScheduled",
+  "dateStarted",
+  "datetimeStart",
+  "datetimeEnd",
+  "estimate",
+]);
+
+const OPERON_LIST_MUTATION_FIELDS = new Set([
+  "taskGallery",
+  "assignees",
+  "contexts",
+  "links",
+  "related",
+  "blocking",
+  "blockedBy",
+]);
+
+function validateKnownMutationFieldTypes(
+  fields:
+    | Record<string, z.infer<typeof OperonMutationFieldValueSchema>>
+    | undefined,
+  context: z.RefinementCtx,
+): void {
+  for (const [field, value] of Object.entries(fields ?? {})) {
+    if (OPERON_SCALAR_MUTATION_FIELDS.has(field) && Array.isArray(value)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["fields", field],
+        message: `Managed field '${field}' requires one scalar string value.`,
+      });
+    }
+    if (OPERON_LIST_MUTATION_FIELDS.has(field) && !Array.isArray(value)) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["fields", field],
+        message: `Managed field '${field}' requires an ordered string array.`,
+      });
+    }
+  }
+}
+
 function validateTaskGallery(
   fields:
     | Record<string, z.infer<typeof OperonMutationFieldValueSchema>>
@@ -770,6 +822,7 @@ export const OperonCreatePeriodicTaskSchema = MutationControlSchema.extend({
       fields: OperonMutationFieldsSchema.optional(),
     })
     .superRefine((value, context) => {
+      validateKnownMutationFieldTypes(value.fields, context);
       validateTaskGallery(value.fields, 256, context);
     })
     .transform((value) => {
@@ -808,6 +861,7 @@ export const OperonCreateTaskSchema = MutationControlSchema.extend({
       targetPath: OperonVaultMarkdownPathSchema.optional(),
     })
     .superRefine((value, context) => {
+      validateKnownMutationFieldTypes(value.fields, context);
       validateTaskGallery(value.fields, 256, context);
       if (value.source === "file" && value.targetPath) {
         context.addIssue({
@@ -849,6 +903,7 @@ export const OperonUpdatePatchSchema = z
     properties: z.record(OperonRawPropertyValueSchema).optional(),
   })
   .superRefine((value, context) => {
+    validateKnownMutationFieldTypes(value.fields, context);
     validateTaskGallery(value.fields, 512, context);
     const dedicatedFields = new Set([
       "parentTask",

--- a/src/services/operon/contract.ts
+++ b/src/services/operon/contract.ts
@@ -729,6 +729,18 @@ const OperonIdSchema = z.string().regex(/^[a-z0-9]{7}$/u, {
   message: "Operon ids must contain exactly seven lowercase letters or digits.",
 });
 
+const OperonDateKeySchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/u, {
+  message: "Date keys must use the YYYY-MM-DD format.",
+});
+
+const OperonNormalizedTagsSchema = z.array(z.string()).transform((tags) => [
+  ...new Set(
+    tags
+      .map((tag) => tag.trim().replace(/^#/u, "").trim())
+      .filter(Boolean),
+  ),
+]);
+
 export const OperonAdoptTaskSchema = MutationControlSchema.extend({
   adoption: z.object({
     targetPath: OperonVaultMarkdownPathSchema,
@@ -751,10 +763,10 @@ export const OperonCreatePeriodicTaskSchema = MutationControlSchema.extend({
     .object({
       description: z.string().trim().min(1).max(20_000),
       periodicKind: z.enum(["daily", "weekly"]),
-      routeDate: z.string().trim().min(1).optional(),
+      routeDate: OperonDateKeySchema.optional(),
       statusId: z.string().trim().min(1).optional(),
       priorityId: z.string().trim().min(1).optional(),
-      tags: z.array(z.string()).optional(),
+      tags: OperonNormalizedTagsSchema.optional(),
       fields: OperonMutationFieldsSchema.optional(),
     })
     .superRefine((value, context) => {

--- a/src/services/operon/contract.ts
+++ b/src/services/operon/contract.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 
 export const OPERON_CONTRACT_VERSION = "1" as const;
-export const OPERON_SNAPSHOT_SCHEMA_VERSION = 1;
+export const OPERON_SNAPSHOT_SCHEMA_VERSION = 2;
+export const OPERON_LEGACY_SNAPSHOT_SCHEMA_VERSION = 1;
 
 export const OperonTaskSourceSchema = z.enum(["inline", "file"]);
 export const OperonCheckboxSchema = z.enum(["open", "done", "cancelled"]);
@@ -18,6 +19,13 @@ export const OperonTaskDatesSchema = z.object({
   created: z.string().nullable(),
   modified: z.string().nullable(),
 });
+
+export const OperonFieldValueSchema = z.union([
+  z.string(),
+  z.array(z.string()),
+]);
+
+export type OperonFieldValue = z.infer<typeof OperonFieldValueSchema>;
 
 export const OperonTaskSchema = z.object({
   operonId: z.string().min(1),
@@ -39,7 +47,7 @@ export const OperonTaskSchema = z.object({
   blocking: z.array(z.string()),
   blockedBy: z.array(z.string()),
   dates: OperonTaskDatesSchema,
-  fields: z.record(z.string()),
+  fields: z.record(OperonFieldValueSchema),
   properties: z.record(z.unknown()).optional(),
   plainCheckboxProgress: z
     .object({
@@ -85,6 +93,9 @@ export const OperonCapabilitiesSchema = z.object({
   filterQuery: z.boolean().optional().default(false),
   relocate: z.boolean().optional().default(false),
   recovery: z.boolean().optional().default(false),
+  periodicCreate: z.boolean().optional().default(false),
+  periodicUpdate: z.boolean().optional().default(false),
+  taskWorkflowRecovery: z.boolean().optional().default(false),
 });
 
 export const OperonWorkflowTaxonomySchema = z.object({
@@ -270,16 +281,12 @@ export const OperonStatusSchema = z.object({
     pluginName: z.string().nullable().optional(),
     version: z.string().nullable(),
     compatible: z.boolean(),
-    compatibilityState: z.enum([
-      "certified",
-      "compatible-provisional",
-      "incompatible",
-    ]).optional(),
-    compatibilityAdmission: z.enum([
-      "developer-api-v1",
-      "legacy-version",
-      "none",
-    ]).optional(),
+    compatibilityState: z
+      .enum(["certified", "compatible-provisional", "incompatible"])
+      .optional(),
+    compatibilityAdmission: z
+      .enum(["developer-api-v1", "legacy-version", "none"])
+      .optional(),
     compatibilityReason: z.string().min(1).optional(),
     testedAgainst: z.string(),
     supportedRange: z.string(),
@@ -391,7 +398,7 @@ export const OperonQuerySchema = z.object({
   tagsAll: z.array(z.string()).optional(),
   parentTask: z.string().nullable().optional(),
   dates: z.array(OperonDateFilterSchema).optional(),
-  fieldEquals: z.record(z.string()).optional(),
+  fieldEquals: z.record(OperonFieldValueSchema).optional(),
   propertyEquals: z.record(z.unknown()).optional(),
   sort: z.array(OperonSortSchema).optional(),
   includeProperties: z.boolean().optional().default(false),
@@ -570,6 +577,78 @@ export const OperonRawPropertyValueSchema = z.union([
   z.array(z.union([z.string(), z.number(), z.boolean(), z.null()])),
 ]);
 
+const OPERON_TEXT_MAX_LENGTH = 65_536;
+
+function utf8Length(value: string): number {
+  return new TextEncoder().encode(value).byteLength;
+}
+
+const OperonMutationTextSchema = z
+  .string()
+  .max(OPERON_TEXT_MAX_LENGTH)
+  .refine((value) => utf8Length(value) <= OPERON_TEXT_MAX_LENGTH, {
+    message: `Value must not exceed ${OPERON_TEXT_MAX_LENGTH} UTF-8 bytes.`,
+  });
+
+const OperonMutationListItemSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(OPERON_TEXT_MAX_LENGTH)
+  .refine((value) => utf8Length(value) <= OPERON_TEXT_MAX_LENGTH, {
+    message: `Value must not exceed ${OPERON_TEXT_MAX_LENGTH} UTF-8 bytes.`,
+  });
+
+const OperonMutationFieldValueSchema = z.union([
+  OperonMutationTextSchema,
+  z.array(OperonMutationListItemSchema).max(512),
+]);
+
+const OperonMutationFieldsSchema = z.record(OperonMutationFieldValueSchema);
+
+function validateTaskGallery(
+  fields:
+    | Record<string, z.infer<typeof OperonMutationFieldValueSchema>>
+    | undefined,
+  maximumItems: number,
+  context: z.RefinementCtx,
+): void {
+  if (!fields || !("taskGallery" in fields)) return;
+  const gallery = fields.taskGallery;
+  if (!Array.isArray(gallery)) {
+    context.addIssue({
+      code: z.ZodIssueCode.custom,
+      path: ["fields", "taskGallery"],
+      message:
+        "taskGallery must be an ordered string array; delimiter-based strings are not accepted.",
+    });
+    return;
+  }
+  if (gallery.length > maximumItems) {
+    context.addIssue({
+      code: z.ZodIssueCode.too_big,
+      maximum: maximumItems,
+      inclusive: true,
+      type: "array",
+      path: ["fields", "taskGallery"],
+      message: `taskGallery must contain at most ${maximumItems} items.`,
+    });
+  }
+}
+
+function normalizeTaskGalleryFields<
+  T extends Record<string, z.infer<typeof OperonMutationFieldValueSchema>>,
+>(fields: T | undefined): T | undefined {
+  if (!fields || !Array.isArray(fields.taskGallery)) return fields;
+  const seen = new Set<string>();
+  const taskGallery = fields.taskGallery.filter((item) => {
+    if (seen.has(item)) return false;
+    seen.add(item);
+    return true;
+  });
+  return { ...fields, taskGallery } as T;
+}
+
 const MutationControlSchema = z.object({
   idempotencyKey: z.string().min(8).max(200),
   dryRun: z.boolean().optional().default(true),
@@ -646,6 +725,10 @@ export const OperonFilterQuerySchema = z.object({
   limit: z.number().int().positive().max(500).optional().default(100),
 });
 
+const OperonIdSchema = z.string().regex(/^[a-z0-9]{7}$/u, {
+  message: "Operon ids must contain exactly seven lowercase letters or digits.",
+});
+
 export const OperonAdoptTaskSchema = MutationControlSchema.extend({
   adoption: z.object({
     targetPath: OperonVaultMarkdownPathSchema,
@@ -659,8 +742,44 @@ export const OperonAdoptTaskSchema = MutationControlSchema.extend({
         "expectedLine must contain exactly one source line.",
       ),
     statusId: z.string().trim().min(1).optional(),
+    terminalSourcePolicy: z.literal("reopen").optional(),
   }),
 });
+
+export const OperonCreatePeriodicTaskSchema = MutationControlSchema.extend({
+  periodic: z
+    .object({
+      description: z.string().trim().min(1).max(20_000),
+      periodicKind: z.enum(["daily", "weekly"]),
+      routeDate: z.string().trim().min(1).optional(),
+      statusId: z.string().trim().min(1).optional(),
+      priorityId: z.string().trim().min(1).optional(),
+      tags: z.array(z.string()).optional(),
+      fields: OperonMutationFieldsSchema.optional(),
+    })
+    .superRefine((value, context) => {
+      validateTaskGallery(value.fields, 256, context);
+    })
+    .transform((value) => {
+      const fields = normalizeTaskGalleryFields(value.fields);
+      return fields === undefined ? value : { ...value, fields };
+    }),
+});
+
+export const OperonUpdatePeriodicSchedulingSchema =
+  MutationControlSchema.extend({
+    operonId: OperonIdSchema,
+    expectedRevision: z.string().min(1),
+    patch: z
+      .object({
+        fields: z
+          .object({
+            dateScheduled: z.string().trim().min(1).nullable(),
+          })
+          .strict(),
+      })
+      .strict(),
+  });
 
 export const OperonCreateTaskSchema = MutationControlSchema.extend({
   task: z
@@ -669,7 +788,7 @@ export const OperonCreateTaskSchema = MutationControlSchema.extend({
       description: z.string().trim().min(1),
       statusId: z.string().trim().min(1).optional(),
       tags: z.array(z.string()).optional(),
-      fields: z.record(z.string()).optional(),
+      fields: OperonMutationFieldsSchema.optional(),
       properties: z.record(OperonRawPropertyValueSchema).optional(),
       fileTemplateId: z.string().optional(),
       targetDateKey: z.string().optional(),
@@ -677,6 +796,7 @@ export const OperonCreateTaskSchema = MutationControlSchema.extend({
       targetPath: OperonVaultMarkdownPathSchema.optional(),
     })
     .superRefine((value, context) => {
+      validateTaskGallery(value.fields, 256, context);
       if (value.source === "file" && value.targetPath) {
         context.addIssue({
           code: z.ZodIssueCode.custom,
@@ -691,13 +811,21 @@ export const OperonCreateTaskSchema = MutationControlSchema.extend({
           message: "targetFolder is supported only for file tasks.",
         });
       }
-      if (value.statusId && value.fields?.status?.trim()) {
+      if (
+        value.statusId &&
+        typeof value.fields?.status === "string" &&
+        value.fields.status.trim()
+      ) {
         context.addIssue({
           code: z.ZodIssueCode.custom,
           path: ["statusId"],
           message: "Provide at most one of fields.status or statusId.",
         });
       }
+    })
+    .transform((value) => {
+      const fields = normalizeTaskGalleryFields(value.fields);
+      return fields === undefined ? value : { ...value, fields };
     }),
 });
 
@@ -705,10 +833,11 @@ export const OperonUpdatePatchSchema = z
   .object({
     description: z.string().trim().min(1).optional(),
     tags: z.array(z.string()).optional(),
-    fields: z.record(z.string()).optional(),
+    fields: OperonMutationFieldsSchema.optional(),
     properties: z.record(OperonRawPropertyValueSchema).optional(),
   })
   .superRefine((value, context) => {
+    validateTaskGallery(value.fields, 512, context);
     const dedicatedFields = new Set([
       "parentTask",
       "blocking",
@@ -743,6 +872,10 @@ export const OperonUpdatePatchSchema = z
         message: "Update exactly one unmanaged property per operation.",
       });
     }
+  })
+  .transform((value) => {
+    const fields = normalizeTaskGalleryFields(value.fields);
+    return fields === undefined ? value : { ...value, fields };
   });
 
 export const OperonUpdateTaskSchema = MutationControlSchema.extend({
@@ -808,10 +941,6 @@ export const OperonRelocateTaskSchema = MutationControlSchema.extend({
   operonId: z.string().min(1),
   expectedRevision: z.string().min(1),
   targetPath: OperonVaultMarkdownPathSchema,
-});
-
-const OperonIdSchema = z.string().regex(/^[a-z0-9]{7}$/u, {
-  message: "Operon ids must contain exactly seven lowercase letters or digits.",
 });
 
 const UniqueOperonIdsSchema = z
@@ -902,18 +1031,145 @@ export const OperonUpdateRecurrenceSchema = MutationControlSchema.extend({
   changes: OperonRecurrenceChangesSchema,
 });
 
-export const OperonRecoverMutationSchema = z.object({
-  idempotencyKey: z.string().min(8).max(200),
-  recoveryRef: z.string().trim().min(1).max(512),
+export const OperonTaskWorkflowRecoveryKindSchema = z.enum([
+  "adopt",
+  "periodic-create",
+  "periodic-update",
+]);
+
+export const OperonPlanDigestSchema = z
+  .string()
+  .regex(/^[a-f0-9]{64}$/u, "Expected a lowercase SHA-256 hex digest.")
+  .describe(
+    "Exact lowercase 64-hex planDigest returned by Operon pending recovery state; never synthesize or alter it.",
+  );
+
+export const OperonPendingRecoveriesInputSchema = z.object({
+  kind: OperonTaskWorkflowRecoveryKindSchema.optional(),
 });
+
+const OperonDeveloperApiRecoverySchema = z
+  .object({
+    kind: z.literal("developer-api"),
+  })
+  .strict();
+
+const OperonTaskWorkflowRecoverySchema = z
+  .object({
+    kind: OperonTaskWorkflowRecoveryKindSchema,
+    planDigest: OperonPlanDigestSchema.optional(),
+  })
+  .strict();
+
+export const OperonRecoveryBindingSchema = z.discriminatedUnion("kind", [
+  OperonDeveloperApiRecoverySchema,
+  OperonTaskWorkflowRecoverySchema,
+]);
+
+export const OperonRecoverMutationInputSchema = z
+  .object({
+    idempotencyKey: z.string().min(8).max(200),
+    recoveryRef: z.string().trim().min(1).max(512),
+    // The nested discriminated union keeps the MCP root an object while
+    // publishing the planDigest => task-workflow-kind implication in
+    // tools/list. The developer-api branch has no planDigest property.
+    recovery: OperonRecoveryBindingSchema,
+  })
+  .strict();
+
+export const OperonRecoverMutationSchema = OperonRecoverMutationInputSchema;
+
+const OperonPendingRecoverySchema = z
+  .object({
+    recoveryRef: z.string().trim().min(1).max(512).optional(),
+    planDigest: OperonPlanDigestSchema.optional(),
+    mutationKind: z.string().trim().min(1).max(256).optional(),
+    capability: z.string().trim().min(1).max(256).optional(),
+    riskLevel: z.string().trim().min(1).max(128).optional(),
+    createdAt: z.string().datetime({ offset: true }).optional(),
+    expiresAt: z.string().datetime({ offset: true }).optional(),
+    workflowKind: OperonTaskWorkflowRecoveryKindSchema.optional(),
+    // Accepted for the bounded MCP test fixture and older additive Bridge
+    // projections. The current Bridge uses workflowKind.
+    kind: OperonTaskWorkflowRecoveryKindSchema.optional(),
+  })
+  .strip();
 
 export const OperonPendingRecoveriesSchema = z.object({
   ok: z.literal(true),
   contractVersion: z.literal(OPERON_CONTRACT_VERSION),
   source: z.literal("operon-live"),
   stale: z.literal(false),
-  recoveries: z.array(z.record(z.unknown())),
+  recoveries: z.array(OperonPendingRecoverySchema).max(512),
 });
+
+const OperonNativeResourceRevisionSchema = z
+  .object({
+    resourceKind: z.enum([
+      "timer",
+      "repeat-series",
+      "active-tracker",
+      "pinned",
+      "project-serial",
+      "task-source",
+    ]),
+    resourceKey: z.string().min(1).max(4096),
+    revision: z.string().min(1).max(4096),
+  })
+  .strict();
+
+const OperonNativeAtomicGroupResultSchema = z
+  .object({
+    groupId: z.string().min(1).max(4096),
+    status: z.enum(["committed", "failed", "outcome-unknown"]),
+    resourceRevisions: z
+      .array(OperonNativeResourceRevisionSchema)
+      .max(1024)
+      .optional(),
+  })
+  .strict();
+
+const OperonNativeReceiptSchema = z
+  .object({
+    contractVersion: z.literal(1),
+    planDigest: OperonPlanDigestSchema,
+    mutationKind: z.enum(["task.adopt", "task.create", "task.update"]),
+    targetDigest: OperonPlanDigestSchema,
+    terminalOutcome: z.enum(["applied", "already-applied"]),
+    effectiveAt: z.string().datetime({ offset: true }),
+    completedAt: z.string().datetime({ offset: true }),
+    expiresAt: z.string().datetime({ offset: true }),
+  })
+  .strict();
+
+const OperonNativePostflightSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      status: z.literal("verified"),
+      observedAt: z.string().datetime({ offset: true }).optional(),
+    })
+    .strict(),
+  z.object({ status: z.literal("receipt-replay") }).strict(),
+]);
+
+export const OperonNativeMutationProofSchema = z
+  .object({
+    contractVersion: z.literal(1),
+    kind: z.literal("mutation-result"),
+    status: z.enum([
+      "applied",
+      "already-applied",
+      "partial",
+      "failed",
+      "outcome-unknown",
+    ]),
+    mutationMayHaveApplied: z.boolean(),
+    retryAllowed: z.boolean(),
+    groupResults: z.array(OperonNativeAtomicGroupResultSchema).max(512),
+    receipt: OperonNativeReceiptSchema.optional(),
+    postflight: OperonNativePostflightSchema.optional(),
+  })
+  .strict();
 
 export const OperonMutationResultSchema = z.object({
   ok: z.boolean(),
@@ -937,11 +1193,12 @@ export const OperonMutationResultSchema = z.object({
   after: OperonTaskSchema.nullable().optional(),
   error: z.object({ code: z.string(), message: z.string() }).optional(),
   retryable: z.boolean().optional(),
-  planDigest: z.string().optional(),
+  planDigest: OperonPlanDigestSchema.optional(),
   plan: z.record(z.unknown()).optional(),
   recoveryRef: z.string().optional(),
   mutationMayHaveApplied: z.boolean().optional(),
   nativeStatus: z.string().optional(),
+  nativeProof: OperonNativeMutationProofSchema.optional(),
   source: z.literal("operon-live"),
   stale: z.literal(false),
   replayed: z.boolean().optional(),
@@ -953,6 +1210,12 @@ export type OperonResolveTask = z.infer<typeof OperonResolveTaskSchema>;
 export type OperonRelationships = z.infer<typeof OperonRelationshipsSchema>;
 export type OperonContext = z.infer<typeof OperonContextSchema>;
 export type OperonAdoptTask = z.infer<typeof OperonAdoptTaskSchema>;
+export type OperonCreatePeriodicTask = z.infer<
+  typeof OperonCreatePeriodicTaskSchema
+>;
+export type OperonUpdatePeriodicScheduling = z.infer<
+  typeof OperonUpdatePeriodicSchedulingSchema
+>;
 export type OperonUpdateTask = z.infer<typeof OperonUpdateTaskSchema>;
 export type OperonSetRelationships = z.infer<
   typeof OperonSetRelationshipsSchema
@@ -964,6 +1227,9 @@ export type OperonTransitionTask = z.infer<typeof OperonTransitionTaskSchema>;
 export type OperonConvertTask = z.infer<typeof OperonConvertTaskSchema>;
 export type OperonFilterQuery = z.infer<typeof OperonFilterQuerySchema>;
 export type OperonRelocateTask = z.infer<typeof OperonRelocateTaskSchema>;
+export type OperonPendingRecoveriesInput = z.infer<
+  typeof OperonPendingRecoveriesInputSchema
+>;
 export type OperonRecoverMutation = z.infer<typeof OperonRecoverMutationSchema>;
 export type OperonMutationResult = z.infer<typeof OperonMutationResultSchema>;
 
@@ -975,6 +1241,7 @@ export interface OperonSnapshotEnvelope {
   operonVersion: string;
   bridgeVersion: string;
   contractVersion: typeof OPERON_CONTRACT_VERSION;
+  snapshotSchemaVersion: 1 | typeof OPERON_SNAPSHOT_SCHEMA_VERSION;
   settingsSignature: string | null;
   generation: number | null;
   capabilities: z.infer<typeof OperonCapabilitiesSchema>;
@@ -990,6 +1257,7 @@ export interface OperonTaskPage {
   operonVersion: string;
   bridgeVersion: string;
   contractVersion: typeof OPERON_CONTRACT_VERSION;
+  snapshotSchemaVersion: OperonSnapshotEnvelope["snapshotSchemaVersion"];
   capabilities: OperonSnapshotEnvelope["capabilities"];
   limitations: string[];
   total: number;
@@ -1004,6 +1272,31 @@ function normalizeNeedle(value: unknown): string {
   return String(value ?? "")
     .trim()
     .toLocaleLowerCase();
+}
+
+function fieldValueEquals(
+  actual: OperonFieldValue | undefined,
+  expected: OperonFieldValue,
+): boolean {
+  if (Array.isArray(actual) || Array.isArray(expected)) {
+    if (!Array.isArray(actual) || !Array.isArray(expected)) return false;
+    return (
+      actual.length === expected.length &&
+      actual.every(
+        (value, index) =>
+          normalizeNeedle(value) === normalizeNeedle(expected[index]),
+      )
+    );
+  }
+  return normalizeNeedle(actual) === normalizeNeedle(expected);
+}
+
+function searchableFieldValues(
+  fields: Record<string, OperonFieldValue>,
+): string[] {
+  return Object.values(fields).flatMap((value) =>
+    Array.isArray(value) ? value : [value],
+  );
 }
 
 function stableValue(value: unknown): unknown {
@@ -1117,8 +1410,7 @@ export function filterOperonTasks(
     )
       return false;
     for (const [key, expected] of Object.entries(query.fieldEquals ?? {})) {
-      if (normalizeNeedle(task.fields[key]) !== normalizeNeedle(expected))
-        return false;
+      if (!fieldValueEquals(task.fields[key], expected)) return false;
     }
     for (const [key, expected] of Object.entries(query.propertyEquals ?? {})) {
       if (stableStringify(task.properties?.[key]) !== stableStringify(expected))
@@ -1137,7 +1429,7 @@ export function filterOperonTasks(
         task.priority,
         task.parentTask,
         ...task.tags,
-        ...Object.values(task.fields),
+        ...searchableFieldValues(task.fields),
         ...(task.properties ? [stableStringify(task.properties)] : []),
       ]
         .map(normalizeNeedle)
@@ -1238,6 +1530,7 @@ export function queryOperonSnapshot(
     operonVersion: snapshot.operonVersion,
     bridgeVersion: snapshot.bridgeVersion,
     contractVersion: snapshot.contractVersion,
+    snapshotSchemaVersion: snapshot.snapshotSchemaVersion,
     capabilities: snapshot.capabilities,
     limitations: snapshot.limitations,
     total: filtered.length,

--- a/src/services/operon/contract.ts
+++ b/src/services/operon/contract.ts
@@ -824,6 +824,28 @@ export const OperonCreatePeriodicTaskSchema = MutationControlSchema.extend({
     .superRefine((value, context) => {
       validateKnownMutationFieldTypes(value.fields, context);
       validateTaskGallery(value.fields, 256, context);
+      if (value.fields?.parentTask !== undefined) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["fields", "parentTask"],
+          message:
+            "Periodic-note creation owns parentage; parentTask is not accepted.",
+        });
+      }
+      if (value.statusId && value.fields?.status !== undefined) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["statusId"],
+          message: "Provide at most one of fields.status or statusId.",
+        });
+      }
+      if (value.priorityId && value.fields?.priority !== undefined) {
+        context.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["priorityId"],
+          message: "Provide at most one of fields.priority or priorityId.",
+        });
+      }
     })
     .transform((value) => {
       const fields = normalizeTaskGalleryFields(value.fields);

--- a/src/services/operon/service.ts
+++ b/src/services/operon/service.ts
@@ -9,6 +9,7 @@ import { logger, requestContextService } from "../../utils/index.js";
 import { assertWriteAllowed } from "../writePolicy.js";
 import {
   OPERON_CONTRACT_VERSION,
+  OPERON_LEGACY_SNAPSHOT_SCHEMA_VERSION,
   OPERON_SNAPSHOT_SCHEMA_VERSION,
   OperonBridgePageSchema,
   OperonConfigurationSchema,
@@ -19,6 +20,8 @@ import {
   queryOperonSnapshot,
   OperonCapabilitiesSchema,
   OperonAdoptTaskSchema,
+  OperonCreatePeriodicTaskSchema,
+  OperonUpdatePeriodicSchedulingSchema,
   OperonConvertTaskSchema,
   OperonCreateTaskSchema,
   OperonFilterQuerySchema,
@@ -30,6 +33,7 @@ import {
   OperonRelocateTaskSchema,
   OperonRecoverMutationSchema,
   OperonPendingRecoveriesSchema,
+  OperonPendingRecoveriesInputSchema,
   OperonMutationResultSchema,
   OperonTransitionTaskSchema,
   OperonUpdateTaskSchema,
@@ -47,6 +51,8 @@ import {
   type OperonTaskPage,
   type OperonValidation,
   type OperonAdoptTask,
+  type OperonCreatePeriodicTask,
+  type OperonUpdatePeriodicScheduling,
   type OperonSetRelationships,
   type OperonUpdateRecurrence,
   type OperonConvertTask,
@@ -57,6 +63,7 @@ import {
   type OperonRelationships,
   type OperonContext,
   type OperonRelocateTask,
+  type OperonPendingRecoveriesInput,
   type OperonRecoverMutation,
   type OperonMutationResult,
   type OperonTransitionTask,
@@ -116,6 +123,7 @@ interface SnapshotRow {
 }
 
 interface SnapshotMeta {
+  snapshotSchemaVersion: number;
   snapshotAt: number;
   generation: number | null;
   settingsSignature: string | null;
@@ -130,6 +138,8 @@ interface SnapshotMeta {
 type OperonCapabilities = z.infer<typeof OperonCapabilitiesSchema>;
 type OperonMutationAction =
   | "adopt"
+  | "periodic-create"
+  | "periodic-update"
   | "create"
   | "update"
   | "transition"
@@ -175,6 +185,9 @@ function readOnlyCapabilities(): OperonCapabilities {
     filterQuery: false,
     relocate: false,
     recovery: false,
+    periodicCreate: false,
+    periodicUpdate: false,
+    taskWorkflowRecovery: false,
   };
 }
 
@@ -523,11 +536,15 @@ export class OperonService {
     const requested =
       action === "adopt"
         ? payload.adoption
-        : action === "create"
-          ? payload.task
-          : action === "update"
+        : action === "periodic-create"
+          ? payload.periodic
+          : action === "periodic-update"
             ? payload.patch
-            : payload;
+            : action === "create"
+              ? payload.task
+              : action === "update"
+                ? payload.patch
+                : payload;
     const request =
       requested && typeof requested === "object" && !Array.isArray(requested)
         ? (requested as Record<string, unknown>)
@@ -541,19 +558,24 @@ export class OperonService {
       if (typeof request.line !== "number" || after.line !== request.line)
         return "Adopted task line does not match the requested line.";
     }
-    if (action === "create") {
+    if (action === "create" || action === "periodic-create") {
       if (
         typeof request.description === "string" &&
         after.description !== request.description.trim()
       )
         return "Created task description does not match the request.";
       if (
+        action === "create" &&
         (request.source === "inline" || request.source === "file") &&
         after.source !== request.source
       )
         return "Created task source does not match the request.";
     }
-    if (action === "update" || action === "create") {
+    if (
+      action === "update" ||
+      action === "create" ||
+      action === "periodic-create"
+    ) {
       if (
         typeof request.description === "string" &&
         after.description !== request.description.trim()
@@ -576,6 +598,15 @@ export class OperonService {
           : {};
       for (const [key, value] of Object.entries(fields)) {
         if (key === "status") continue;
+        if (Array.isArray(value)) {
+          if (
+            !Array.isArray(after.fields[key]) ||
+            stableJson(after.fields[key]) !== stableJson(value)
+          ) {
+            return `Managed list field '${key}' does not match the request in value or order.`;
+          }
+          continue;
+        }
         const expectedValue =
           key === "priority"
             ? (resolveOperonPriorityStableId(value, priorities) ??
@@ -595,7 +626,11 @@ export class OperonService {
           return `Unmanaged property '${key}' does not match the request.`;
       }
     }
-    if (action === "transition" || action === "create") {
+    if (
+      action === "transition" ||
+      action === "create" ||
+      action === "periodic-create"
+    ) {
       if (typeof request.status === "string") {
         const requestedStatus = resolveOperonWorkflowStatus(
           request.status,
@@ -615,6 +650,21 @@ export class OperonService {
         after.statusId !== request.statusId.trim()
       )
         return "Task status id does not match the request.";
+    }
+    if (action === "periodic-update") {
+      const requestedFields =
+        request.fields &&
+        typeof request.fields === "object" &&
+        !Array.isArray(request.fields)
+          ? (request.fields as Record<string, unknown>)
+          : {};
+      const scheduled = requestedFields.dateScheduled;
+      if (
+        (scheduled === null || typeof scheduled === "string") &&
+        after.dates.scheduled !== scheduled
+      ) {
+        return "Periodic task scheduled date does not match the request.";
+      }
     }
     if (action === "relationships") {
       const relationships = payload.relationships;
@@ -728,7 +778,11 @@ export class OperonService {
         ? "relationshipMutation"
         : action === "recurrence"
           ? "recurrenceMutation"
-          : action;
+          : action === "periodic-create"
+            ? "periodicCreate"
+            : action === "periodic-update"
+              ? "periodicUpdate"
+              : action;
     if (!status.capabilities[capability]) {
       throw new McpError(
         BaseErrorCode.SERVICE_UNAVAILABLE,
@@ -745,13 +799,21 @@ export class OperonService {
         ? "operon_set_relationships"
         : action === "recurrence"
           ? "operon_update_recurrence"
-          : (`operon_${action}_task` as const);
+          : action === "periodic-create"
+            ? "operon_create_periodic_task"
+            : action === "periodic-update"
+              ? "operon_update_periodic_scheduling"
+              : (`operon_${action}_task` as const);
     const mutationData =
       action === "create"
         ? payload.task
-        : action === "update"
-          ? payload.patch
-          : null;
+        : action === "periodic-create"
+          ? payload.periodic
+          : action === "periodic-update"
+            ? payload.patch
+            : action === "update"
+              ? payload.patch
+              : null;
     const mutationRecord =
       mutationData &&
       typeof mutationData === "object" &&
@@ -780,6 +842,8 @@ export class OperonService {
       allowInGuarded:
         dryRun ||
         (action !== "recurrence" &&
+          (action !== "periodic-create" ||
+            config.operonMutationAllowedPathPrefixes.length === 0) &&
           (action !== "convert" ||
             config.operonMutationAllowedPathPrefixes.length > 0)),
       frontmatterKeys,
@@ -893,6 +957,18 @@ export class OperonService {
     }
   }
 
+  private assertRecoveryPathScope(operation: string): void {
+    if (config.operonMutationAllowedPathPrefixes.length === 0) return;
+    throw new McpError(
+      BaseErrorCode.FORBIDDEN,
+      "Operon recovery is blocked while OPERON_MUTATION_ALLOWED_PATH_PREFIXES is configured because pending recovery records do not expose canonical route evidence. Recovery therefore fails closed before listing, replay, or Bridge apply.",
+      this.requestContext(operation, {
+        allowedPathPrefixes: config.operonMutationAllowedPathPrefixes,
+        routeEvidence: "unavailable",
+      }),
+    );
+  }
+
   private async isConfiguredFileTaskFolderAllowed(): Promise<boolean> {
     try {
       const configuration = await this.fetchLiveConfiguration();
@@ -910,6 +986,22 @@ export class OperonService {
     payload: Record<string, unknown>,
     dryRun: boolean,
   ): Promise<void> {
+    // Daily/Weekly routing is sealed by Operon and the opaque preview does not
+    // provide route evidence MCP can check against configured path prefixes.
+    // Preview remains safe, but apply must fail closed before the Bridge POST.
+    if (action === "periodic-create") {
+      if (dryRun || config.operonMutationAllowedPathPrefixes.length === 0) {
+        return;
+      }
+      throw new McpError(
+        BaseErrorCode.FORBIDDEN,
+        "Scoped periodic creation requires verifiable route evidence, which the Operon preview does not expose. Clear OPERON_MUTATION_ALLOWED_PATH_PREFIXES or keep this request in dry-run mode.",
+        this.requestContext("assertOperonMutationPathScope", {
+          action,
+          allowedPathPrefixes: config.operonMutationAllowedPathPrefixes,
+        }),
+      );
+    }
     if (config.operonMutationAllowedPathPrefixes.length === 0) return;
 
     if (action === "adopt") {
@@ -1049,6 +1141,10 @@ export class OperonService {
     const values = new Map(rows.map((row) => [row.key, row.value]));
     const snapshotAt = Number(values.get("snapshot_at"));
     if (!Number.isFinite(snapshotAt) || snapshotAt <= 0) return null;
+    const snapshotSchemaVersion = Number(
+      values.get("snapshot_schema_version") ??
+        OPERON_LEGACY_SNAPSHOT_SCHEMA_VERSION,
+    );
     const generationRaw = values.get("generation");
     const generation =
       generationRaw === undefined || generationRaw === "null"
@@ -1067,6 +1163,7 @@ export class OperonService {
       ? OperonConfigurationSchema.safeParse(parsedConfiguration)
       : { success: false as const };
     return {
+      snapshotSchemaVersion,
       snapshotAt,
       generation: Number.isFinite(generation) ? generation : null,
       settingsSignature: values.get("settings_signature") ?? null,
@@ -1092,6 +1189,16 @@ export class OperonService {
         throw new McpError(
           BaseErrorCode.PARSING_ERROR,
           `Operon snapshot contract ${meta.contractVersion} is incompatible with MCP contract ${OPERON_CONTRACT_VERSION}.`,
+          this.requestContext("loadOperonSnapshot", { dbPath: this.dbPath }),
+        );
+      }
+      if (
+        meta.snapshotSchemaVersion !== OPERON_LEGACY_SNAPSHOT_SCHEMA_VERSION &&
+        meta.snapshotSchemaVersion !== OPERON_SNAPSHOT_SCHEMA_VERSION
+      ) {
+        throw new McpError(
+          BaseErrorCode.PARSING_ERROR,
+          `Operon snapshot schema ${meta.snapshotSchemaVersion} is incompatible with supported schemas ${OPERON_LEGACY_SNAPSHOT_SCHEMA_VERSION} and ${OPERON_SNAPSHOT_SCHEMA_VERSION}.`,
           this.requestContext("loadOperonSnapshot", { dbPath: this.dbPath }),
         );
       }
@@ -1138,6 +1245,7 @@ export class OperonService {
         operonVersion: meta.operonVersion,
         bridgeVersion: meta.bridgeVersion,
         contractVersion: OPERON_CONTRACT_VERSION,
+        snapshotSchemaVersion: meta.snapshotSchemaVersion as 1 | 2,
         settingsSignature: meta.settingsSignature,
         generation: meta.generation,
         capabilities: stale
@@ -1147,6 +1255,12 @@ export class OperonService {
           ? [
               ...new Set([
                 ...(meta.status?.limitations ?? []),
+                ...(meta.snapshotSchemaVersion ===
+                OPERON_LEGACY_SNAPSHOT_SCHEMA_VERSION
+                  ? [
+                      "Legacy Operon snapshot schema v1 was read through the safe v2 compatibility path; list-valued fields may remain flattened strings until a live refresh replaces the snapshot.",
+                    ]
+                  : []),
                 ...CACHE_LIMITATIONS,
               ]),
             ]
@@ -1456,6 +1570,7 @@ export class OperonService {
   ): boolean {
     return Boolean(
       snapshot &&
+        snapshot.snapshotSchemaVersion === OPERON_SNAPSHOT_SCHEMA_VERSION &&
         snapshot.generation === status.index.generation &&
         snapshot.settingsSignature === status.settingsSignature &&
         snapshot.operonVersion === status.operon.version &&
@@ -1738,10 +1853,7 @@ export class OperonService {
       );
     }
     const response = await this.getClient()
-      .post(
-        `${BRIDGE_PREFIX}/tasks/filter`,
-        params,
-      )
+      .post(`${BRIDGE_PREFIX}/tasks/filter`, params)
       .catch((error: unknown) =>
         this.bridgeHttpError(error, "operonQuerySavedFilter"),
       );
@@ -1892,6 +2004,34 @@ export class OperonService {
     );
   }
 
+  async createPeriodicTask(input: unknown): Promise<OperonMutationResult> {
+    const params: OperonCreatePeriodicTask =
+      OperonCreatePeriodicTaskSchema.parse(input);
+    return this.executeMutation(
+      "periodic-create",
+      null,
+      params.idempotencyKey,
+      params.dryRun,
+      `${BRIDGE_PREFIX}/tasks/periodic`,
+      params,
+    );
+  }
+
+  async updatePeriodicScheduling(
+    input: unknown,
+  ): Promise<OperonMutationResult> {
+    const params: OperonUpdatePeriodicScheduling =
+      OperonUpdatePeriodicSchedulingSchema.parse(input);
+    return this.executeMutation(
+      "periodic-update",
+      params.operonId,
+      params.idempotencyKey,
+      params.dryRun,
+      `${BRIDGE_PREFIX}/tasks/${encodeURIComponent(params.operonId)}/periodic-update`,
+      params,
+    );
+  }
+
   async updateTask(input: unknown): Promise<OperonMutationResult> {
     const params: OperonUpdateTask = OperonUpdateTaskSchema.parse(input);
     return this.executeMutation(
@@ -1967,7 +2107,12 @@ export class OperonService {
     );
   }
 
-  async pendingRecoveries(): Promise<Record<string, unknown>> {
+  async pendingRecoveries(
+    input: unknown = {},
+  ): Promise<Record<string, unknown>> {
+    const params: OperonPendingRecoveriesInput =
+      OperonPendingRecoveriesInputSchema.parse(input);
+    this.assertRecoveryPathScope("operon_list_pending_recoveries");
     if (!liveModeConfigured()) {
       throw new McpError(
         BaseErrorCode.SERVICE_UNAVAILABLE,
@@ -1976,34 +2121,112 @@ export class OperonService {
       );
     }
     const status = await this.fetchLiveStatus();
-    if (!status.capabilities.recovery) {
+    if (params.kind && !status.capabilities.taskWorkflowRecovery) {
+      throw new McpError(
+        BaseErrorCode.SERVICE_UNAVAILABLE,
+        "Operon Bridge does not expose task-workflow recovery.",
+        this.requestContext("operonPendingRecoveries"),
+      );
+    }
+    const requests: Array<{
+      family: "developer-api" | "task-workflow";
+      path: string;
+      query?: Record<string, string>;
+    }> = [];
+    if (!params.kind && status.capabilities.recovery) {
+      requests.push({
+        family: "developer-api",
+        path: `${BRIDGE_PREFIX}/mutations/pending-recoveries`,
+      });
+    }
+    if (status.capabilities.taskWorkflowRecovery) {
+      requests.push({
+        family: "task-workflow",
+        path: `${BRIDGE_PREFIX}/task-workflows/pending-recoveries`,
+        ...(params.kind ? { query: { kind: params.kind } } : {}),
+      });
+    }
+    if (requests.length === 0) {
       throw new McpError(
         BaseErrorCode.SERVICE_UNAVAILABLE,
         "Operon Bridge does not expose official Developer API recovery.",
         this.requestContext("operonPendingRecoveries"),
       );
     }
-    const response = await this.getClient().get(
-      `${BRIDGE_PREFIX}/mutations/pending-recoveries`,
-    );
-    const parsed = OperonPendingRecoveriesSchema.safeParse(response.data);
-    if (!parsed.success) {
-      throw new McpError(
-        BaseErrorCode.PARSING_ERROR,
-        "Operon Bridge pending-recoveries returned an incompatible payload.",
-        this.requestContext("operonPendingRecoveries", {
-          issues: parsed.error.issues,
-        }),
+    const recoveries: Record<string, unknown>[] = [];
+    for (const request of requests) {
+      const response = await this.getClient().get(
+        request.path,
+        request.query ? { params: request.query } : undefined,
       );
+      const parsed = OperonPendingRecoveriesSchema.safeParse(response.data);
+      if (!parsed.success) {
+        throw new McpError(
+          BaseErrorCode.PARSING_ERROR,
+          `Operon Bridge ${request.family} pending-recoveries returned an incompatible payload.`,
+          this.requestContext("operonPendingRecoveries", {
+            family: request.family,
+            issues: parsed.error.issues,
+          }),
+        );
+      }
+      for (const recovery of parsed.data.recoveries) {
+        const kind =
+          request.family === "developer-api"
+            ? "developer-api"
+            : (recovery.workflowKind ?? recovery.kind);
+        if (!kind) {
+          throw new McpError(
+            BaseErrorCode.PARSING_ERROR,
+            "Operon Bridge task-workflow pending recovery omitted its workflow kind.",
+            this.requestContext("operonPendingRecoveries", {
+              family: request.family,
+            }),
+          );
+        }
+        recoveries.push({
+          ...recovery,
+          kind,
+          recoveryFamily: request.family,
+        });
+      }
     }
-    return parsed.data;
+    return {
+      ok: true,
+      contractVersion: OPERON_CONTRACT_VERSION,
+      source: "operon-live",
+      stale: false,
+      recoveries,
+    };
   }
 
   async recoverMutation(input: unknown): Promise<OperonMutationResult> {
     const params: OperonRecoverMutation =
       OperonRecoverMutationSchema.parse(input);
-    const requested = { recoveryRef: params.recoveryRef };
+    // Enforce the current path policy before consulting the durable replay
+    // journal. Otherwise a result sealed while the allowlist was empty could
+    // bypass a later, stricter configuration after restart.
+    this.assertRecoveryPathScope("operon_recover_mutation");
+    const requested = {
+      recoveryRef: params.recoveryRef,
+      recovery: params.recovery,
+    };
     const requestedJson = stableJson(requested);
+    // 3.1 candidates briefly used the same fields flat. Accept their durable
+    // journal binding internally so an upgrade does not strand a terminal
+    // replay, while the public MCP input remains nested and unambiguous.
+    const flatCandidateRequestedJson = stableJson({
+      recoveryRef: params.recoveryRef,
+      kind: params.recovery.kind,
+      ...(params.recovery.kind !== "developer-api" &&
+      params.recovery.planDigest
+        ? { planDigest: params.recovery.planDigest }
+        : {}),
+    });
+    const legacyDeveloperApiRequestedJson =
+      params.recovery.kind === "developer-api"
+        ? stableJson({ recoveryRef: params.recoveryRef })
+        : null;
     // Recovery is itself idempotent at the MCP boundary. A completed
     // recovery must replay from the durable journal after an MCP restart,
     // without requiring the Bridge to be reachable a second time.
@@ -2011,7 +2234,9 @@ export class OperonService {
     if (existing) {
       if (
         existing.action !== "recover" ||
-        existing.requestedJson !== requestedJson
+        (existing.requestedJson !== requestedJson &&
+          existing.requestedJson !== flatCandidateRequestedJson &&
+          existing.requestedJson !== legacyDeveloperApiRequestedJson)
       ) {
         throw new McpError(
           BaseErrorCode.CONFLICT,
@@ -2043,10 +2268,17 @@ export class OperonService {
       );
     }
     const status = await this.fetchLiveStatus();
-    if (!status.capabilities.recovery) {
+    const taskWorkflow = params.recovery.kind !== "developer-api";
+    if (
+      taskWorkflow
+        ? !status.capabilities.taskWorkflowRecovery
+        : !status.capabilities.recovery
+    ) {
       throw new McpError(
         BaseErrorCode.SERVICE_UNAVAILABLE,
-        "Operon Bridge does not expose official Developer API recovery.",
+        taskWorkflow
+          ? "Operon Bridge does not expose task-workflow recovery."
+          : "Operon Bridge does not expose official Developer API recovery.",
         this.requestContext("operon_recover_mutation", {
           recoveryRef: params.recoveryRef,
         }),
@@ -2071,8 +2303,23 @@ export class OperonService {
     );
     if (reservedResult) return reservedResult.result;
     const response = await this.getClient().post(
-      `${BRIDGE_PREFIX}/mutations/recover`,
-      params,
+      taskWorkflow
+        ? `${BRIDGE_PREFIX}/task-workflows/recover`
+        : `${BRIDGE_PREFIX}/mutations/recover`,
+      taskWorkflow
+        ? {
+            idempotencyKey: params.idempotencyKey,
+            recoveryRef: params.recoveryRef,
+            kind: params.recovery.kind,
+            ...(params.recovery.kind !== "developer-api" &&
+            params.recovery.planDigest
+              ? { planDigest: params.recovery.planDigest }
+              : {}),
+          }
+        : {
+            idempotencyKey: params.idempotencyKey,
+            recoveryRef: params.recoveryRef,
+          },
       { validateStatus: () => true },
     );
     const parsed = OperonMutationResultSchema.safeParse(response.data);

--- a/src/services/writePolicy.ts
+++ b/src/services/writePolicy.ts
@@ -28,6 +28,8 @@ export type WriteOperation =
   | "bases_upsert_config"
   | "bases_upsert_rows"
   | "operon_adopt_task"
+  | "operon_create_periodic_task"
+  | "operon_update_periodic_scheduling"
   | "operon_create_task"
   | "operon_update_task"
   | "operon_transition_task"


### PR DESCRIPTION
## Outcome

Prepares Optimike MCP 3.1.0 and Operon Bridge 0.8.0 for Operon 3.5 workflows without treating an unknown product version as mutation-safe.

## Contract

- keeps stock Operon 3.5.2 readable but fails every Bridge mutation/recovery route closed;
- admits mutations only for certified versions or the explicit local acceptance identity `3.5.240438`;
- adds strict saved-filter, adoption, Daily/Weekly, periodic scheduling and typed task-media projections;
- keeps opaque host plans, bounded idempotence and same-plan recovery; no Markdown/private-API fallback;
- keeps MCP startup non-blocking when Obsidian starts later and preserves the chosen tool profile.

## Evidence

- `npm run check:operon`
- `npm run test:runtime`
- `npm run test:operation-runtime`
- `npm run test:stdio-proxy-reliability`
- `npm run test:docs`
- `npm run test:profiles`
- `npm run test:tool-annotations`
- `npm run test:package`
- hostile full-diff review: CLEAN
- live Pilot 2 canary on combined Operon acceptance head `4412a20`: `ok=true`, exact fixture restoration, zero retained periodic artifacts

## Upstream gates

- hasanyilmaz/operon#182
- hasanyilmaz/operon#183
- hasanyilmaz/operon#184

Stock certification remains blocked until those fixes ship in an official Operon release and that stock artifact passes the same live canary.