### PR TITLE
docs: record Operon 3.5.3 release evidence

### DIFF
--- a/docs/adr/ADR-Operon-Bridge.md
+++ b/docs/adr/ADR-Operon-Bridge.md
@@ -2,9 +2,9 @@
 
 - Status: accepted and implemented on `main`
 - Date: 2026-07-21
-- Amended: 2026-08-24
-- MCP baseline: `optimikelabs/optimike-obsidian-mcp@8cea94610a526e50a017d334be6008b8dab79500`
-- Operon baselines: upstream `2.4.0@76d251973b149afc69192ef565d626740aa7b7cf`, `2.5.0@31099cc3d5231b320cd8520424fc29449b003778`, certified official `3.2.1`, historical live `3.3.2`, and provisional candidate `3.5.3` / CLI `1.2.0`
+- Amended: 2026-08-25
+- MCP baseline: `optimikelabs/optimike-obsidian-mcp@77322f84903fddfdc1bb056981b997a96bdeebca`
+- Operon baselines: upstream `2.4.0@76d251973b149afc69192ef565d626740aa7b7cf`, `2.5.0@31099cc3d5231b320cd8520424fc29449b003778`, certified official `3.2.1`, historical live `3.3.2`, and released provisional `3.5.3` / CLI `1.2.0`
 
 ## Problem
 
@@ -77,8 +77,9 @@ non-blocking startup before Obsidian, exact-grant auth, Daily/Weekly creation,
 periodic scheduling with a configured modified-time plugin, same-source graph
 ordering, durable concurrent replay, zero validation violations, zero pending
 recoveries and exact restoration. This remains historical evidence for the
-pre-release candidate; Operon `3.5.3` ships superseding implementations and is
-the current official validation target.
+unpublished patched candidate; Operon `3.5.3` ships superseding implementations,
+passed the same complete gate with Bridge `0.8.1`, and is the current released
+official validation target.
 
 Still outside this local acceptance proof:
 

--- a/docs/obsidian_mcp_tools_spec.md
+++ b/docs/obsidian_mcp_tools_spec.md
@@ -217,7 +217,7 @@ Operon responses always declare `source`, `stale`, `snapshotAt`, `snapshotAgeMs`
 Operon/Bridge versions, capabilities, and limitations.
 
 Mutations require a live Bridge and the loaded engine's official contract.
-Operon 3.5.3 plus CLI 1.2.0 is the 3.1.1 candidate target through Bridge 0.8.1
+Operon 3.5.3 plus CLI 1.2.0 is the 3.1.1 released target through Bridge 0.8.1
 and remains `compatible-provisional` as certification metadata. Valid mutations
 are admitted by the negotiated contract and exact live gates rather than a
 product-version allowlist.

--- a/docs/operon-cli-audit.fr.md
+++ b/docs/operon-cli-audit.fr.md
@@ -4,7 +4,7 @@ English version: [operon-cli-audit.md](operon-cli-audit.md)
 
 Mise à jour : 2026-08-25
 
-Candidate courante : Operon officiel `3.5.3`, Operon CLI `1.2.0`, Bridge
+Release courante : Operon officiel `3.5.3`, Operon CLI `1.2.0`, Bridge
 `0.8.1`, Developer API V1 et API task-workflow additive. Operon 3.5.3 embarque
 des implémentations qui remplacent les PR upstream `#182`, `#183` et `#184`.
 `compatible-provisional` décrit le niveau de certification, pas une allowlist de

--- a/docs/operon-cli-audit.md
+++ b/docs/operon-cli-audit.md
@@ -3,7 +3,7 @@
 French version: [operon-cli-audit.fr.md](operon-cli-audit.fr.md)
 
 Updated: 2026-08-25
-Current candidate: official Operon `3.5.3`, Operon CLI `1.2.0`, Bridge `0.8.1`, Developer API V1 and the additive task-workflow API. Operon 3.5.3 ships superseding implementations of upstream PRs `#182`, `#183` and `#184`. `compatible-provisional` describes certification evidence only; mutation admission follows the negotiated contract and exact live capabilities rather than a product-version allowlist.
+Current release: official Operon `3.5.3`, Operon CLI `1.2.0`, Bridge `0.8.1`, Developer API V1 and the additive task-workflow API. Operon 3.5.3 ships superseding implementations of upstream PRs `#182`, `#183` and `#184`. `compatible-provisional` describes certification evidence only; mutation admission follows the negotiated contract and exact live capabilities rather than a product-version allowlist.
 
 Operon CLI `1.2.0` adds operator access to Daily/Weekly routing and the typed
 Task Type, Task Image and ordered Task Gallery fields. The MCP does not relay

--- a/docs/operon-decision-report.md
+++ b/docs/operon-decision-report.md
@@ -1,16 +1,16 @@
 # Operon integration decision report
 
-## Current candidate — 2026-08-25
+## Current release — 2026-08-25
 
 Optimike MCP `3.1.1` and Bridge `0.8.1` target official Operon `3.5.3` with
-Operon CLI `1.2.0`. The candidate preserves ordered `taskGallery` values,
+Operon CLI `1.2.0`. The release preserves ordered `taskGallery` values,
 keeps `taskType` and `taskImage` scalar, rejects writes to `__taskDataType`, and
 adds two bounded Daily/Weekly operations. Official adoption and periodic
 workflows require their exact additive grants; missing grants fail closed and
 never activate a Markdown fallback. Operon remains the owner of every opaque
 sealed plan and same-plan recovery.
 
-The deterministic contract candidate is `compatible-provisional`: this label
+The deterministic contract remains `compatible-provisional`: this label
 describes certification evidence, not mutation admission. A non-denied future
 Operon release remains writable when the exact Developer API V1 contract,
 capabilities, schemas, live health, settled index and recovery support validate.
@@ -22,9 +22,10 @@ degraded status and became live after Pilot 2 opened. The final patched
 candidate (`#182` + `#183` + `#184`, combined code head `4412a20`, local
 attested manifest version `3.5.240438`) also passed the
 complete canary with exact restoration, zero retained periodic artifacts and
-zero pending recoveries. Operon `3.5.3` now ships superseding implementations of
-those fixes. The stock 3.5.3 artifact and Bridge 0.8.1 are rerun through the same
-gate before release. The detailed execution journal lives in
+zero pending recoveries. Operon `3.5.3` ships superseding implementations of
+those fixes. The stock 3.5.3 artifact and Bridge 0.8.1 subsequently passed the
+same complete Pilot 2 gate, including exact restoration and zero retained
+periodic artifacts. The detailed execution journal lives in
 [the local validation recipe](operon-local-validation.md).
 
 ## Historical status — 2026-08-17
@@ -64,7 +65,7 @@ commands when a capability is missing or an outcome is uncertain.
 - double mutation opt-in and mode-based write policy;
 - no generic CLI passthrough.
 
-The 3.1 candidate extends that list to twenty-five tools with
+The 3.1 release extends that list to twenty-five tools with
 `operon_create_periodic_task` and `operon_update_periodic_scheduling`; adoption
 is now official but still grant-gated.
 
@@ -146,7 +147,7 @@ CLI `1.2.0` is the paired operator-reference target.
 - deletion: CLI operator action until a reversible `operon_trash_task` contract
   exists;
 - reminders, pinned state and timer control/session: retained in the CLI;
-- official adoption in the 3.5.3 candidate remains capability- and grant-gated;
+- official adoption in the 3.5.3 release remains capability- and grant-gated;
   it was unavailable in the historical 3.3.2 Developer API generation;
 - saved-filter execution is available with an exact ID and grant, while catalog
   discovery and filter creation/editing remain unavailable;
@@ -159,7 +160,8 @@ Keep the current Operon integration active. Use MCP/Bridge for governed agent
 workflows and CLI for broad operator work. Keep Kairélys disabled but available
 for rollback until a separate non-dependency proof authorizes removal.
 
-The 3.1.1 implementation and deterministic checks are complete. Publication
-depends on the stock Operon 3.5.3 / Bridge 0.8.1 Pilot 2 canary, exact CI and
-review gates. The separate real Sync/non-dependency decision remains outside
-this integration scope.
+The 3.1.1 implementation is released. Stock Operon 3.5.3 / Bridge 0.8.1 passed
+the Pilot 2 canary, exact Codex Review and the complete Linux/Windows PR and
+post-merge CI gates. The release is tagged from merge commit
+`77322f84903fddfdc1bb056981b997a96bdeebca`. The separate real
+Sync/non-dependency decision remains outside this integration scope.

--- a/docs/operon-local-validation.md
+++ b/docs/operon-local-validation.md
@@ -7,7 +7,7 @@ This recipe is the Desktop proof. Run destructive fixtures only in a disposable 
 - Node.js `>=22.7.5`
 - Obsidian Desktop
 - Local REST API enabled
-- Operon `3.5.3` with Operon CLI `1.2.0` for the current candidate; `3.2.1` remains in the explicit certified set, `3.3.2` / CLI `1.1.2` remains completed historical evidence, and `2.4.0` / `2.5.0` remain legacy-read fixtures
+- Operon `3.5.3` with Operon CLI `1.2.0` for the current release; `3.2.1` remains in the explicit certified set, `3.3.2` / CLI `1.1.2` remains completed historical evidence, and `2.4.0` / `2.5.0` remain legacy-read fixtures
 - Optimike Operon Bridge `0.8.1`
 - Optimike Operon Bridge built from this branch
 - Optimike Obsidian MCP built from this branch
@@ -21,7 +21,7 @@ contract-first policy. Settings grant controls, implicit File Task rename
 refusal, and unscoped transition settlement are fixed in `3.3.2`. Adoption was
 unavailable through that Developer API generation. Operon `3.5.3` exposes
 adoption plus Daily/Weekly workflows through exact additive grants. The 3.1
-candidate preserves `taskGallery` as an ordered array, keeps `taskType` and
+release preserves `taskGallery` as an ordered array, keeps `taskType` and
 `taskImage` scalar, and treats `__taskDataType` as read-only. It remains
 `compatible-provisional` as certification metadata, while mutation admission
 depends on the negotiated contract and exact live gates rather than a product
@@ -257,7 +257,7 @@ PASS when:
 
 ## 8a. Exact Operon 3.5 live canary
 
-Run only after the exact candidate Bridge is installed and the Pilot 2 status,
+Run only after the exact release Bridge is installed and the Pilot 2 status,
 grants, index and validation gates above are green. The recommended mode proves
 the real startup order: MCP connects first while Pilot 2 is closed, the same MCP
 connection survives a degraded status, then the CLI opens only Pilot 2 and that
@@ -304,7 +304,7 @@ The script refuses to start unless all of these gates hold:
 The command writes its JSON evidence under the OS temporary root and prints the
 exact `evidenceFile`. Certification is forbidden unless the command exits `0`,
 the printed summary has `ok=true`, `fixtureRestored=true` and
-`periodicArtifactsRetained=0`, and the evidence confirms the exact candidate
+`periodicArtifactsRetained=0`, and the evidence confirms the exact release
 versions, zero validation violations, zero pending recoveries, byte-exact
 artifact restoration, and—when startup-order mode is selected—
 `degradedObserved=true`, `connectionAliveAfterDegraded=true`,
@@ -342,9 +342,10 @@ summary reported `ok=true`, `fixtureRestored=true` and
 `periodicArtifactsRetained=0`. It also proved Daily/Weekly creation, periodic
 scheduling set/clear with Frontmatter Date Manager active, concurrent Bridge
 replay, zero validation violations and zero pending recoveries. This is
-historical acceptance evidence for the patched candidate. Operon `3.5.3` ships
-superseding implementations of the three fixes and must pass this same recipe
-with Bridge `0.8.1`. The synthetic `3.5.240438` identity remains historical and
+historical acceptance evidence for the patched candidate. Stock Operon `3.5.3`
+with Bridge `0.8.1` passed this same complete recipe on 2026-08-25, with
+`ok=true`, exact fixture restoration and zero retained periodic artifacts. The
+synthetic `3.5.240438` identity remains historical and
 must never be published as an upstream Operon release.
 
 ## 9. Restart and reindex

--- a/docs/operon-mcp-contract.fr.md
+++ b/docs/operon-mcp-contract.fr.md
@@ -300,10 +300,10 @@ La suppression reste une action opérateur dans la CLI. Un futur
 le même `operonId`, relations réconciliées, journal durable et confirmation
 humaine explicite. Il n’est pas implémenté.
 
-## Admission de la candidate 3.1.1
+## Admission de la release 3.1.1
 
 Optimike MCP `3.1.1`, Bridge `0.8.1`, Operon `3.5.3` et Operon CLI `1.2.0`
-forment l’ensemble candidat courant. Operon `3.5.3` reste
+forment l’ensemble publié courant. Operon `3.5.3` reste
 `compatible-provisional` jusqu’à son entrée dans l’ensemble explicite de preuves
 certifiées, mais ce libellé ne masque plus les mutations valides. La version
 produit reste une métadonnée diagnostique pouvant sélectionner un refus ou une

--- a/docs/operon-mcp-contract.md
+++ b/docs/operon-mcp-contract.md
@@ -190,10 +190,10 @@ operator CLI action. A future `operon_trash_task` may be considered only with
 guaranteed restoration under the same `operonId`, reconciled relations, durable
 journal evidence, and an explicit human confirmation; it is not implemented.
 
-## 3.1.1 candidate admission
+## 3.1.1 release admission
 
 Optimike MCP `3.1.1`, Bridge `0.8.1`, Operon `3.5.3` and Operon CLI `1.2.0`
-form the current candidate set. Operon `3.5.3` remains
+form the current released set. Operon `3.5.3` remains
 `compatible-provisional` until it joins the explicit certified evidence set,
 but that label no longer masks valid mutation capabilities. Product version is
 diagnostic metadata and may select an explicit deny or narrowly blocked path;

--- a/docs/operon-rest-contract.md
+++ b/docs/operon-rest-contract.md
@@ -15,7 +15,7 @@ All routes inherit Local REST API authentication and TLS behavior.
 ## Compatibility and capabilities
 
 - Bridge contract: `1`
-- Certified compatibility through official Operon `3.2.1`; completed provisional live pilot: `3.3.2` with CLI `1.1.2`; current provisional candidate: `3.5.3` with CLI `1.2.0` and Bridge `0.8.1`
+- Certified compatibility through official Operon `3.2.1`; completed provisional live pilot: `3.3.2` with CLI `1.1.2`; current provisional release: `3.5.3` with CLI `1.2.0` and Bridge `0.8.1`
 - Official Operon legacy read allowlist: `2.4.0`, `2.5.0`
 - Official Operon Developer API V1 allowlist: `3.0.1`, `3.1.0`, `3.1.1`, `3.2.0`, `3.2.1`
 - Kairélys read allowlist: `2.5.1`, `2.5.2`, `2.5.3`, `2.6.1`, `2.6.2`, `2.6.3`
@@ -26,7 +26,7 @@ All routes inherit Local REST API authentication and TLS behavior.
 
 `GET /status` reports `bridge.mode` as `read-only` or `read-write` and exposes each capability independently. A future non-denied Operon version is admitted provisionally when its Developer API V1 accessor is present; Markdown similarity is irrelevant. Reads and new writes remain independently gated by successful negotiation, `developerApi`, top-level `ok`, `index.ready`, and the exact advertised capability. Recovery is the deliberate exception: `GET /recovery-status` negotiates only exact core and task-workflow recovery sessions without awaiting health, catalog or task-index reads, allowing same-plan recovery when those surfaces are degraded or hung.
 
-The adapter certifies official `3.2.1` and provisionally admits later non-denied V1 releases. The complete `3.3.2` live acceptance remains historical green evidence with Bridge `0.7.0` and CLI `1.1.2`. The `3.5.3` / CLI `1.2.0` / Bridge `0.8.1` candidate adds official adoption, periodic-note routing and typed task media fields. Product-version certification remains explicit, but valid mutations are admitted by negotiated contract, exact capabilities, schemas, live health, settled index and recovery support rather than a second version allowlist. Task Type and Task Image are scalar, Task Gallery is an ordered array and `__taskDataType` is read-only. No Markdown or private-API fallback is introduced.
+The adapter certifies official `3.2.1` and provisionally admits later non-denied V1 releases. The complete `3.3.2` live acceptance remains historical green evidence with Bridge `0.7.0` and CLI `1.1.2`. The released `3.5.3` / CLI `1.2.0` / Bridge `0.8.1` integration adds official adoption, periodic-note routing and typed task media fields and passed the complete Pilot 2 gate. Product-version certification remains explicit, but valid mutations are admitted by negotiated contract, exact capabilities, schemas, live health, settled index and recovery support rather than a second version allowlist. Task Type and Task Image are scalar, Task Gallery is an ordered array and `__taskDataType` is read-only. No Markdown or private-API fallback is introduced.
 
 A future non-denied product version remains `compatible-provisional` until it
 joins the certified evidence set, but it may advertise mutations when every


### PR DESCRIPTION
## Summary
- replace stale 3.1.1 candidate language with the released state
- record the stock Operon 3.5.3 / Bridge 0.8.1 Pilot 2 canary
- record exact post-merge CI and release commit evidence

## Verification
- npm run test:docs
- git diff --check